### PR TITLE
feat: pPr cascade + chart data labels + more fidelity

### DIFF
--- a/.changeset/chart-data-labels.md
+++ b/.changeset/chart-data-labels.md
@@ -1,0 +1,11 @@
+---
+'pptx-kit': minor
+---
+
+feat: `ChartSpec.dataLabels` carries the chart-level `<c:dLbls>` toggles
+— `showValue`, `showCategory`, `showSeriesName`, `showPercent` — read
+from each plotted-kind element. Playground projects them onto bar /
+column tops (numeric value above each bar) and pie / doughnut slices
+(value, percent, and / or category text painted at the slice mid-arc).
+
+Adds the `ChartDataLabels` interface to the public type surface.

--- a/.changeset/pPr-cascade.md
+++ b/.changeset/pPr-cascade.md
@@ -1,0 +1,15 @@
+---
+'pptx-kit': minor
+---
+
+feat: `getParagraphPropertiesEffective(pres, shape, p)` — paragraph-property
+cascade mirroring the rPr one. Resolves alignment, left / right / first-line
+indents, line spacing, paragraph spacing (before / after), and rtl through
+the paragraph → text-body lstStyle → layout placeholder lstStyle →
+master placeholder lstStyle → master txStyles chain.
+
+The playground uses it as the primary source of paragraph properties so
+placeholders inherit their default alignment / line-spacing / indent from
+the layout / master, with any per-slide override winning on top.
+
+Adds the `ParagraphProperties` type to the public surface.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -2386,6 +2386,7 @@ const renderColumnChart = (
   const groupW = f.plotW / N;
   const barW = (groupW * 0.8) / spec.series.length;
   const baseY = f.plotY + f.plotH - ((0 - min) / range) * f.plotH;
+  const showLabel = spec.dataLabels?.showValue ?? false;
   const out: string[] = [];
   for (let c = 0; c < N; c++) {
     for (let s = 0; s < spec.series.length; s++) {
@@ -2397,6 +2398,14 @@ const renderColumnChart = (
       out.push(
         `<rect x="${px(x0)}" y="${px(y0)}" width="${px(barW)}" height="${px(h)}" fill="${colors[s % colors.length]}"/>`,
       );
+      if (showLabel) {
+        // Label centered above the bar (below if the bar is below the
+        // baseline for negative values).
+        const labelY = v >= 0 ? y0 - 2 : y0 + h + 9;
+        out.push(
+          `<text x="${px(x0 + barW / 2)}" y="${px(labelY)}" text-anchor="middle" font-family="sans-serif" font-size="9" fill="#374151">${formatChartValue(v)}</text>`,
+        );
+      }
     }
   }
   // Zero baseline for visual reference.
@@ -2404,6 +2413,16 @@ const renderColumnChart = (
     `<line x1="${px(f.plotX)}" y1="${px(baseY)}" x2="${px(f.plotX + f.plotW)}" y2="${px(baseY)}" stroke="#9CA3AF" stroke-width="0.5"/>`,
   );
   return out.join('');
+};
+
+// Trim long decimals; large numbers keep their integer form.
+const formatChartValue = (v: number): string => {
+  if (!Number.isFinite(v)) return '';
+  if (Number.isInteger(v)) return String(v);
+  const abs = Math.abs(v);
+  if (abs >= 1000) return Math.round(v).toString();
+  if (abs >= 10) return v.toFixed(1);
+  return v.toFixed(2).replace(/\.?0+$/, '');
 };
 
 const renderBarChart = (f: ChartFrame, spec: ChartSpec, colors: ReadonlyArray<string>): string => {
@@ -2515,6 +2534,23 @@ const renderPieChart = (
     } else {
       const d = `M${px(cx)},${px(cy)} L${px(ox1)},${px(oy1)} A${px(radius)},${px(radius)} 0 ${largeArc} 1 ${px(ox2)},${px(oy2)} Z`;
       out.push(`<path d="${d}" fill="${color}" stroke="#FFFFFF" stroke-width="0.6"/>`);
+    }
+    // Pie / doughnut data labels — value or percent at the slice midpoint.
+    const labelMid = (start + end) / 2;
+    const labelR = doughnut ? (radius + innerR) / 2 : radius * 0.6;
+    const labelX = cx + labelR * Math.cos(labelMid);
+    const labelY = cy + labelR * Math.sin(labelMid);
+    const labels: string[] = [];
+    if (spec.dataLabels?.showValue) labels.push(formatChartValue(v));
+    if (spec.dataLabels?.showPercent) labels.push(`${((v / total) * 100).toFixed(0)}%`);
+    if (spec.dataLabels?.showCategory) {
+      const catLabel = spec.categories[i];
+      if (catLabel) labels.push(catLabel);
+    }
+    if (labels.length > 0) {
+      out.push(
+        `<text x="${px(labelX)}" y="${px(labelY)}" text-anchor="middle" dominant-baseline="middle" font-family="sans-serif" font-size="10" fill="#FFFFFF" font-weight="600">${escapeXml(labels.join(' '))}</text>`,
+      );
     }
   }
   return out.join('');

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -27,6 +27,7 @@ import {
   getParagraphIndent,
   getParagraphLevel,
   getParagraphLineSpacing,
+  getParagraphPropertiesEffective,
   getParagraphSpacing,
   getPresentationTheme,
   getShapeBoundsResolved,
@@ -1841,8 +1842,28 @@ const renderTextBody = (
   const paraData: ParaData[] = [];
   let hasAnyText = false;
   for (let p = 0; p < paragraphCount; p++) {
-    const align = getParagraphAlignment(shape, p) ?? 'left';
-    const level = getParagraphLevel(shape, p);
+    // Resolve paragraph properties through the layout/master cascade so
+    // placeholders inherit their default alignment / line-spacing / indent
+    // without each slide having to repeat them. Fall back to the literal
+    // readers if the cascade throws (very defensive — should never happen).
+    let effective: ReturnType<typeof getParagraphPropertiesEffective>;
+    try {
+      effective = getParagraphPropertiesEffective(pres, shape, p);
+    } catch {
+      effective = {
+        align: getParagraphAlignment(shape, p),
+        level: getParagraphLevel(shape, p),
+        marL: null,
+        marR: null,
+        indent: null,
+        lineSpacing: null,
+        spcBefPts: null,
+        spcAftPts: null,
+        rtl: null,
+      };
+    }
+    const align = effective.align ?? 'left';
+    const level = effective.level;
     const bulletStyle = getParagraphBullet(shape, p);
     let bulletDetail: ReturnType<typeof getParagraphBulletStyle> = {
       color: null,
@@ -1853,24 +1874,26 @@ const renderTextBody = (
     try {
       bulletDetail = getParagraphBulletStyle(pres, shape, p);
     } catch {}
-    let lineSpacing: ReturnType<typeof getParagraphLineSpacing> = null;
-    let spcBefPts: number | null = null;
-    let spcAftPts: number | null = null;
-    let indent: ReturnType<typeof getParagraphIndent> = {
-      leftEmu: null,
-      rightEmu: null,
-      firstLineEmu: null,
+    const lineSpacing: ReturnType<typeof getParagraphLineSpacing> = effective.lineSpacing;
+    let spcBefPts: number | null = effective.spcBefPts;
+    let spcAftPts: number | null = effective.spcAftPts;
+    const indent: ReturnType<typeof getParagraphIndent> = {
+      leftEmu: effective.marL,
+      rightEmu: effective.marR,
+      firstLineEmu: effective.indent,
     };
-    try {
-      lineSpacing = getParagraphLineSpacing(shape, p);
-    } catch {}
+    // Literal pPr values override the cascade so any per-slide override
+    // wins on this paragraph.
     try {
       const spacing = getParagraphSpacing(shape, p);
-      spcBefPts = spacing.beforePts;
-      spcAftPts = spacing.afterPts;
+      if (spacing.beforePts !== null) spcBefPts = spacing.beforePts;
+      if (spacing.afterPts !== null) spcAftPts = spacing.afterPts;
     } catch {}
     try {
-      indent = getParagraphIndent(shape, p);
+      const lit = getParagraphIndent(shape, p);
+      if (lit.leftEmu !== null) indent.leftEmu = lit.leftEmu;
+      if (lit.rightEmu !== null) indent.rightEmu = lit.rightEmu;
+      if (lit.firstLineEmu !== null) indent.firstLineEmu = lit.firstLineEmu;
     } catch {}
     const runs: RunData[] = [];
     // Walk the paragraph's inline elements — runs, field placeholders,

--- a/src/api/fn.ts
+++ b/src/api/fn.ts
@@ -5698,6 +5698,18 @@ const lstStyleLevelDefRPr = (lstStyle: XmlElement | null, level: number): XmlEle
   return firstChildElement(lvlPPr, NAME_A_DEF_RPR);
 };
 
+// Companion to `lstStyleLevelDefRPr` but returns the `<a:lvlNpPr>` (or
+// `<a:defPPr>` for level 0) element itself — i.e. the paragraph-property
+// container, not the run-default child. Used by the pPr cascade.
+const lstStyleLevelPPr = (lstStyle: XmlElement | null, level: number): XmlElement | null => {
+  if (!lstStyle) return null;
+  const localName = `lvl${Math.max(0, Math.min(8, level)) + 1}pPr`;
+  const lvlPPr = firstChildElement(lstStyle, qname('a', localName, NS.dml));
+  if (lvlPPr) return lvlPPr;
+  if (level !== 0) return null;
+  return firstChildElement(lstStyle, qname('a', 'defPPr', NS.dml));
+};
+
 const findShapeLstStyleElement = (shape: SlideShapeData): XmlElement | null => {
   const txBody = firstChildElement(shape[SHAPE_ELEMENT], NAME_P_TX_BODY_PML);
   if (!txBody) return null;
@@ -5893,6 +5905,231 @@ export const getShapeRunFormatEffective = (
   }
 
   return result as TextFormat;
+};
+
+// -- Effective pPr cascade --------------------------------------------------
+//
+// Mirror of the rPr cascade for paragraph-level properties: alignment,
+// indents, line spacing, paragraph spacing, rtl. Walks the same layers:
+//
+//   1. The paragraph's own `<a:pPr>`
+//   2. The text body's `<a:lstStyle><a:lvl{N+1}pPr>` (paragraph defaults)
+//   3. The matching layout placeholder's lstStyle
+//   4. The matching master placeholder's lstStyle, then
+//      `<p:txStyles>/{title|body|other}Style/<a:lvl{N+1}pPr>`
+//
+// Each property merges independently — innermost layer that supplies a
+// value wins for that one property.
+
+/** Effective paragraph properties returned by `getParagraphPropertiesEffective`. */
+export interface ParagraphProperties {
+  /** Horizontal alignment per `ParagraphAlignment`. */
+  align: ParagraphAlignment | null;
+  /** Outline level (0..8). 0 = top-level paragraph. */
+  level: number;
+  /** Left indent in EMU. */
+  marL: number | null;
+  /** Right indent in EMU. */
+  marR: number | null;
+  /** First-line indent in EMU; negative for hanging indents. */
+  indent: number | null;
+  /** Line spacing — either a percent multiplier or a fixed point value. */
+  lineSpacing:
+    | { readonly kind: 'pct'; readonly value: number }
+    | { readonly kind: 'pts'; readonly value: number }
+    | null;
+  /** Space before the paragraph in points. */
+  spcBefPts: number | null;
+  /** Space after the paragraph in points. */
+  spcAftPts: number | null;
+  /** Right-to-left paragraph (`<a:pPr rtl="1"/>`). */
+  rtl: boolean | null;
+}
+
+const ALIGN_TOKEN_MAP: Record<string, ParagraphProperties['align']> = {
+  l: 'left',
+  ctr: 'center',
+  r: 'right',
+  just: 'justify',
+  justLow: 'justify',
+  dist: 'distribute',
+  thaiDist: 'distribute',
+};
+
+const parsePPrLikeElement = (pPr: XmlElement): Partial<ParagraphProperties> => {
+  const out: Partial<ParagraphProperties> = {};
+  const algn = getAttrValue(pPr, qname('', 'algn', ''));
+  if (algn !== null && ALIGN_TOKEN_MAP[algn] !== undefined) out.align = ALIGN_TOKEN_MAP[algn];
+  const marL = getAttrValue(pPr, qname('', 'marL', ''));
+  if (marL !== null) {
+    const n = Number.parseInt(marL, 10);
+    if (Number.isFinite(n)) out.marL = n;
+  }
+  const marR = getAttrValue(pPr, qname('', 'marR', ''));
+  if (marR !== null) {
+    const n = Number.parseInt(marR, 10);
+    if (Number.isFinite(n)) out.marR = n;
+  }
+  const indent = getAttrValue(pPr, qname('', 'indent', ''));
+  if (indent !== null) {
+    const n = Number.parseInt(indent, 10);
+    if (Number.isFinite(n)) out.indent = n;
+  }
+  const rtl = getAttrValue(pPr, qname('', 'rtl', ''));
+  if (rtl !== null) out.rtl = rtl === '1' || rtl === 'true';
+  const lnSpc = firstChildElement(pPr, qname('a', 'lnSpc', NS.dml));
+  if (lnSpc) {
+    const pct = firstChildElement(lnSpc, qname('a', 'spcPct', NS.dml));
+    if (pct) {
+      const v = getAttrValue(pct, qname('', 'val', ''));
+      if (v !== null) {
+        let n = Number.parseFloat(v);
+        if (Number.isFinite(n)) {
+          if (Math.abs(n) > 1) n = n / 100000;
+          out.lineSpacing = { kind: 'pct', value: n };
+        }
+      }
+    } else {
+      const pts = firstChildElement(lnSpc, qname('a', 'spcPts', NS.dml));
+      if (pts) {
+        const v = getAttrValue(pts, qname('', 'val', ''));
+        if (v !== null) {
+          const n = Number.parseInt(v, 10);
+          if (Number.isFinite(n)) out.lineSpacing = { kind: 'pts', value: n / 100 };
+        }
+      }
+    }
+  }
+  const readSpcSide = (local: 'spcBef' | 'spcAft'): number | null => {
+    const side = firstChildElement(pPr, qname('a', local, NS.dml));
+    if (!side) return null;
+    const pts = firstChildElement(side, qname('a', 'spcPts', NS.dml));
+    if (!pts) return null;
+    const v = getAttrValue(pts, qname('', 'val', ''));
+    if (v === null) return null;
+    const n = Number.parseInt(v, 10);
+    return Number.isFinite(n) ? n / 100 : null;
+  };
+  const before = readSpcSide('spcBef');
+  if (before !== null) out.spcBefPts = before;
+  const after = readSpcSide('spcAft');
+  if (after !== null) out.spcAftPts = after;
+  return out;
+};
+
+const mergePPrLayer = (
+  base: Partial<ParagraphProperties>,
+  layer: Partial<ParagraphProperties>,
+): void => {
+  if (base.align === undefined && layer.align !== undefined) base.align = layer.align;
+  if (base.marL === undefined && layer.marL !== undefined) base.marL = layer.marL;
+  if (base.marR === undefined && layer.marR !== undefined) base.marR = layer.marR;
+  if (base.indent === undefined && layer.indent !== undefined) base.indent = layer.indent;
+  if (base.rtl === undefined && layer.rtl !== undefined) base.rtl = layer.rtl;
+  if (base.lineSpacing === undefined && layer.lineSpacing !== undefined) {
+    base.lineSpacing = layer.lineSpacing;
+  }
+  if (base.spcBefPts === undefined && layer.spcBefPts !== undefined) {
+    base.spcBefPts = layer.spcBefPts;
+  }
+  if (base.spcAftPts === undefined && layer.spcAftPts !== undefined) {
+    base.spcAftPts = layer.spcAftPts;
+  }
+};
+
+/**
+ * Resolves a paragraph's effective properties by walking the same
+ * inheritance chain `getShapeRunFormatEffective` uses, but for the
+ * paragraph-level surface:
+ *
+ *   - alignment, indent (left / right / first-line), line spacing,
+ *     paragraph spacing (before / after), rtl.
+ *
+ * Each property is resolved independently; the innermost layer that
+ * sets it wins. Fields the cascade can't resolve come through as `null`
+ * so renderers know to fall back to their own defaults.
+ *
+ * Companion to `getParagraphAlignment` / `getParagraphLineSpacing` /
+ * `getParagraphIndent` / `getParagraphSpacing`, which only surface the
+ * literal `<a:pPr>` and skip the layout / master cascade.
+ */
+export const getParagraphPropertiesEffective = (
+  pres: PresentationData,
+  shape: SlideShapeData,
+  paragraphIndex: number,
+): ParagraphProperties => {
+  const paragraph = requireParagraph(shape, paragraphIndex);
+  const pPr = firstChildElement(paragraph, NAME_A_PPR);
+
+  let level = 0;
+  if (pPr) {
+    const lvlAttr = getAttrValue(pPr, ATTR_LVL);
+    if (lvlAttr !== null) {
+      const parsed = Number.parseInt(lvlAttr, 10);
+      if (Number.isFinite(parsed)) level = parsed;
+    }
+  }
+
+  const result: Partial<ParagraphProperties> = {};
+
+  // 1. Paragraph's own pPr.
+  if (pPr) mergePPrLayer(result, parsePPrLikeElement(pPr));
+
+  // 2. Text-body lstStyle at the paragraph's level.
+  const shapeLstStyle = findShapeLstStyleElement(shape);
+  const shapeLvlPPr = lstStyleLevelPPr(shapeLstStyle, level);
+  if (shapeLvlPPr) mergePPrLayer(result, parsePPrLikeElement(shapeLvlPPr));
+
+  const phIdx = getShapePlaceholderIdx(shape);
+  const phType = getShapePlaceholderType(shape);
+  const slide = shape[SHAPE_SLIDE];
+  const layout = getSlideLayout(slide);
+
+  if (layout) {
+    // 3. Layout placeholder lstStyle.
+    const layoutPh = findPlaceholderShapeIn(layout[LAYOUT_PART].shapes, phIdx, phType);
+    if (layoutPh) {
+      const layoutLst = extractPlaceholderLstStyle(layoutPh.element);
+      const layoutLvlPPr = lstStyleLevelPPr(layoutLst, level);
+      if (layoutLvlPPr) mergePPrLayer(result, parsePPrLikeElement(layoutLvlPPr));
+    }
+
+    // 4. Master placeholder lstStyle + master txStyles.
+    const pkg = pres[INTERNAL_PACKAGE];
+    const layoutPartName = partName(layout[LAYOUT_PART_NAME]);
+    const layoutRels = pkg.getRels(layoutPartName);
+    if (layoutRels) {
+      const masterRel = layoutRels.items.find((r) => r.type === REL_TYPES.slideMaster);
+      if (masterRel) {
+        const masterPart = pkg.getPart(resolveTarget(layoutPartName, masterRel.target));
+        if (masterPart) {
+          const masterRoot = parseXml(decode(masterPart.data)).root;
+          const { shapes: masterShapes } = readShapeTreeFromCsldRoot(masterRoot, 'sldMaster');
+          const masterPh = findPlaceholderShapeIn(masterShapes, phIdx, phType);
+          if (masterPh) {
+            const masterLst = extractPlaceholderLstStyle(masterPh.element);
+            const masterLvlPPr = lstStyleLevelPPr(masterLst, level);
+            if (masterLvlPPr) mergePPrLayer(result, parsePPrLikeElement(masterLvlPPr));
+          }
+          const txStyle = masterTxStyleFor(masterRoot, phType);
+          const txLvlPPr = lstStyleLevelPPr(txStyle, level);
+          if (txLvlPPr) mergePPrLayer(result, parsePPrLikeElement(txLvlPPr));
+        }
+      }
+    }
+  }
+
+  return {
+    align: result.align ?? null,
+    level,
+    marL: result.marL ?? null,
+    marR: result.marR ?? null,
+    indent: result.indent ?? null,
+    lineSpacing: result.lineSpacing ?? null,
+    spcBefPts: result.spcBefPts ?? null,
+    spcAftPts: result.spcAftPts ?? null,
+    rtl: result.rtl ?? null,
+  };
 };
 
 /**

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -24,7 +24,12 @@ export type {
 export type { PresentationInput, SlideSize } from './fn.ts';
 export { SLIDE_SIZE_4_3, SLIDE_SIZE_16_9, SLIDE_SIZE_16_10 } from './fn.ts';
 export type { ImageFormat } from '../internal/opc/index.ts';
-export type { ChartKind, ChartSeries, ChartSpec } from '../internal/chartml/index.ts';
+export type {
+  ChartDataLabels,
+  ChartKind,
+  ChartSeries,
+  ChartSpec,
+} from '../internal/chartml/index.ts';
 export type { SlideChartData } from './fn.ts';
 export type { ShapeClickAction } from './fn.ts';
 export type { IssueSeverity, ValidationIssue } from './fn.ts';

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -173,6 +173,7 @@ export {
   getParagraphIndent,
   getParagraphLevel,
   getParagraphLineSpacing,
+  getParagraphPropertiesEffective,
   getParagraphSpacing,
   getShapeAdjustValues,
   getShapeAltTitle,
@@ -434,7 +435,7 @@ export {
 } from './fn.ts';
 
 export type { BulletStyle, ParagraphAlignment, TextFormat } from '../internal/drawingml/index.ts';
-export type { ShapeParagraphElement } from './fn.ts';
+export type { ParagraphProperties, ShapeParagraphElement } from './fn.ts';
 export type {
   PresetShape,
   TransitionEffect,

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -14,7 +14,7 @@ import {
   getAttrValue,
   qname,
 } from '../xml/index.ts';
-import type { ChartKind, ChartSeries, ChartSpec } from './types.ts';
+import type { ChartDataLabels, ChartKind, ChartSeries, ChartSpec } from './types.ts';
 
 const NS_C = NS.chart;
 const NS_A = NS.dml;
@@ -258,10 +258,33 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
   const categories = categoriesFromFirst ?? [];
   const title = readTitle(chart);
 
+  // <c:dLbls> can sit either on the plotted-kind element (`barChart`,
+  // `lineChart`, …) for chart-level defaults or on each `<c:ser>` for
+  // per-series overrides. Surface the plotted-kind defaults; per-series
+  // toggles are deferred until renderers care.
+  const dLbls = firstChildElement(plotted, qname('c', 'dLbls', NS_C));
+  let dataLabels: ChartDataLabels | undefined;
+  if (dLbls) {
+    const readToggle = (local: string): boolean => {
+      const el = firstChildElement(dLbls, qname('c', local, NS_C));
+      if (!el) return false;
+      const v = getAttrValue(el, ATTR_VAL);
+      // Absent val attribute defaults to true per the schema's CT_Boolean.
+      return v === null || v === '1' || v === 'true';
+    };
+    dataLabels = {
+      showValue: readToggle('showVal'),
+      showCategory: readToggle('showCatName'),
+      showSeriesName: readToggle('showSerName'),
+      showPercent: readToggle('showPercent'),
+    };
+  }
+
   return {
     kind,
     categories,
     series,
     ...(title !== undefined ? { title } : {}),
+    ...(dataLabels !== undefined ? { dataLabels } : {}),
   };
 };

--- a/src/internal/chartml/index.ts
+++ b/src/internal/chartml/index.ts
@@ -1,7 +1,7 @@
 // internal/chartml — c: namespace: charts + minimal xlsx writer for embedded data.
 // Allowed imports: internal/drawingml, internal/parts, internal/xml.
 
-export type { ChartKind, ChartSeries, ChartSpec } from './types.ts';
+export type { ChartDataLabels, ChartKind, ChartSeries, ChartSpec } from './types.ts';
 export { buildChartSpaceDoc } from './chart-builder.ts';
 export { readChartSpec } from './chart-reader.ts';
 export type { DataRow } from './embedded-xlsx.ts';

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -23,6 +23,22 @@ export interface ChartSeries {
   readonly color?: string;
 }
 
+/**
+ * Per-series data-label toggles read from `<c:dLbls>` (ECMA-376
+ * §21.2.2.55). All four toggles default to `false` — renderers paint
+ * labels only when the corresponding flag is `true`.
+ */
+export interface ChartDataLabels {
+  /** Numeric value of each data point. */
+  readonly showValue: boolean;
+  /** Category label of each data point. */
+  readonly showCategory: boolean;
+  /** Series name on each data point. */
+  readonly showSeriesName: boolean;
+  /** Percentage of total (for pie / doughnut). */
+  readonly showPercent: boolean;
+}
+
 /** Full chart specification. */
 export interface ChartSpec {
   readonly kind: ChartKind;
@@ -31,4 +47,6 @@ export interface ChartSpec {
   readonly series: ReadonlyArray<ChartSeries>;
   /** Optional chart title rendered above the plot area. */
   readonly title?: string;
+  /** Optional chart-level data-label toggles. */
+  readonly dataLabels?: ChartDataLabels;
 }


### PR DESCRIPTION
## Summary

Second batch of fidelity improvements building on PR #1.

- **pPr cascade** — `getParagraphPropertiesEffective(pres, shape, p)` walks paragraph → text-body lstStyle → layout placeholder lstStyle → master placeholder lstStyle → master txStyles for alignment, indent (left/right/first-line), line spacing, paragraph spacing, rtl. Playground uses it so placeholders inherit defaults from the layout / master without per-slide overrides.
- **Chart data labels** — `ChartSpec.dataLabels` reads `<c:dLbls>` (showValue, showCategory, showSeriesName, showPercent). Playground renders numeric values above bar/column tops and value/percent/category text at pie/doughnut slice midpoints.

## Test plan

- [x] `pnpm vitest run` — 785 tests pass
- [x] `pnpm svelte-check` — 0 errors
- [x] `pnpm format:check` + `pnpm lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)