### PR TITLE
feat: chart axis scaling + auto-numbered bullets

### DIFF
--- a/.changeset/auto-numbered-bullets.md
+++ b/.changeset/auto-numbered-bullets.md
@@ -1,0 +1,13 @@
+---
+'pptx-kit': minor
+---
+
+feat(site/playground): render auto-numbered bullets. Paragraphs with
+`bulletStyle === 'number'` or `{ autoNum: '…' }` now emit the next
+number in sequence (1., 2., 3., …; A., B., C., …; i., ii., iii., …)
+rather than a generic dot. Counter resets on a non-numbered paragraph
+or a level change, matching PowerPoint's behaviour.
+
+Covers the common `ST_TextAutoNumberScheme` tokens — arabicPeriod /
+ParenR / ParenBoth, romanUc / Lc with Period / ParenR / ParenBoth,
+alphaUc / Lc with Period / ParenR / ParenBoth.

--- a/.changeset/chart-axis-scaling.md
+++ b/.changeset/chart-axis-scaling.md
@@ -1,0 +1,11 @@
+---
+'pptx-kit': minor
+---
+
+feat: `ChartSpec.valueAxis` reports the authored
+`<c:valAx><c:scaling>` min / max. Playground respects them when
+computing axis ranges, so charts with a fixed authored scale (e.g.
+percentage charts pinned to 0..100) render with the same scale the
+deck author saw instead of auto-fitting to the data.
+
+Adds the `ChartAxisScaling` interface to the public type surface.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -1721,6 +1721,101 @@ const placeholderDefaultPt = (phType: string | null): number => {
 
 const bulletChar = (level: number): string => (level <= 0 ? '•' : level === 1 ? '◦' : '▪');
 
+// Maps a `BulletStyle` value to the underlying `ST_TextAutoNumberScheme`
+// token (or `null` when the paragraph isn't auto-numbered). `'number'`
+// is the shorthand for arabicPeriod that setShapeBullets uses.
+const bulletAutoNumType = (style: ReturnType<typeof getParagraphBullet>): string | null => {
+  if (style === 'number') return 'arabicPeriod';
+  if (style !== null && typeof style === 'object' && 'autoNum' in style) {
+    return style.autoNum ?? null;
+  }
+  return null;
+};
+
+const toRoman = (n: number): string => {
+  if (n <= 0) return String(n);
+  const map: ReadonlyArray<[number, string]> = [
+    [1000, 'M'],
+    [900, 'CM'],
+    [500, 'D'],
+    [400, 'CD'],
+    [100, 'C'],
+    [90, 'XC'],
+    [50, 'L'],
+    [40, 'XL'],
+    [10, 'X'],
+    [9, 'IX'],
+    [5, 'V'],
+    [4, 'IV'],
+    [1, 'I'],
+  ];
+  let out = '';
+  let r = n;
+  for (const [v, s] of map) {
+    while (r >= v) {
+      out += s;
+      r -= v;
+    }
+  }
+  return out;
+};
+
+const toAlpha = (n: number): string => {
+  // 1 -> A, 26 -> Z, 27 -> AA, etc.
+  if (n <= 0) return String(n);
+  let r = n;
+  let out = '';
+  while (r > 0) {
+    r -= 1;
+    out = String.fromCharCode(65 + (r % 26)) + out;
+    r = Math.floor(r / 26);
+  }
+  return out;
+};
+
+// Format an auto-number per ECMA-376 §17.18.96 `ST_TextAutoNumberScheme`.
+// Only the most common variants are implemented; unknown tokens fall back
+// to arabicPeriod-style formatting.
+const formatAutoNum = (token: string, n: number): string => {
+  const arabic = String(n);
+  switch (token) {
+    case 'arabicPlain':
+      return arabic;
+    case 'arabicPeriod':
+      return `${arabic}.`;
+    case 'arabicParenR':
+      return `${arabic})`;
+    case 'arabicParenBoth':
+      return `(${arabic})`;
+    case 'romanUcPeriod':
+      return `${toRoman(n)}.`;
+    case 'romanLcPeriod':
+      return `${toRoman(n).toLowerCase()}.`;
+    case 'romanUcParenR':
+      return `${toRoman(n)})`;
+    case 'romanLcParenR':
+      return `${toRoman(n).toLowerCase()})`;
+    case 'romanUcParenBoth':
+      return `(${toRoman(n)})`;
+    case 'romanLcParenBoth':
+      return `(${toRoman(n).toLowerCase()})`;
+    case 'alphaUcPeriod':
+      return `${toAlpha(n)}.`;
+    case 'alphaLcPeriod':
+      return `${toAlpha(n).toLowerCase()}.`;
+    case 'alphaUcParenR':
+      return `${toAlpha(n)})`;
+    case 'alphaLcParenR':
+      return `${toAlpha(n).toLowerCase()})`;
+    case 'alphaUcParenBoth':
+      return `(${toAlpha(n)})`;
+    case 'alphaLcParenBoth':
+      return `(${toAlpha(n).toLowerCase()})`;
+    default:
+      return `${arabic}.`;
+  }
+};
+
 // `effectivePt` is the post-autofit font size in points. Callers pass
 // `format.size` (the authored size, if any) scaled by the body's
 // autofit factor, or the placeholder default scaled the same way.
@@ -1997,9 +2092,38 @@ const renderTextBody = (
   const effectiveLineHeight = LINE_HEIGHT * lineHeightScale;
   void effectiveLineHeight; // currently unused — kept for forward compat
 
+  // Numbering pre-pass — assign an autonum index per paragraph for
+  // consecutive numbered paragraphs at the same level. Resets on a
+  // non-numbered paragraph or a level change.
+  const numberLabels: Array<string | null> = new Array(paraData.length).fill(null);
+  {
+    let counter = 0;
+    let activeLevel = -1;
+    let activeType: string | null = null;
+    for (let i = 0; i < paraData.length; i++) {
+      const para = paraData[i]!;
+      const num = bulletAutoNumType(para.bulletStyle);
+      if (num === null) {
+        counter = 0;
+        activeLevel = -1;
+        activeType = null;
+        continue;
+      }
+      if (para.level !== activeLevel || num !== activeType) {
+        counter = 1;
+        activeLevel = para.level;
+        activeType = num;
+      } else {
+        counter += 1;
+      }
+      numberLabels[i] = formatAutoNum(num, counter);
+    }
+  }
+
   // Second pass — emit runs with scaled sizes.
   const paragraphs: string[] = [];
-  for (const para of paraData) {
+  for (let pi = 0; pi < paraData.length; pi++) {
+    const para = paraData[pi]!;
     const runHtmls = para.runs.map((run) =>
       renderRun(run.text, run.fmt, theme, run.sizePt * autoFitScale, run.fmt?.size === undefined),
     );
@@ -2053,12 +2177,14 @@ const renderTextBody = (
       'char' in para.bulletStyle
         ? para.bulletStyle.char
         : null;
+    const numberLabel = numberLabels[pi];
     const showBullet =
       para.bulletStyle === 'bullet' ||
       explicitChar !== null ||
+      numberLabel !== null ||
       (para.bulletStyle !== 'none' && para.level > 0);
     if (showBullet) {
-      const char = explicitChar ?? bulletChar(para.level);
+      const char = numberLabel ?? explicitChar ?? bulletChar(para.level);
       // Bullet style overrides: color, size %, fixed pt size, font face.
       const bulletStyles: string[] = [
         `margin-right:${(0.4 * defaultPt * PX_PER_PT * autoFitScale).toFixed(2)}px`,

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -2330,6 +2330,11 @@ const seriesMinMax = (spec: ChartSpec): { min: number; max: number } => {
   if (!Number.isFinite(max)) max = 1;
   if (max === min) max = min + 1;
   if (min > 0) min = 0; // include the zero line, like PowerPoint does
+  // Authored <c:valAx><c:scaling> overrides the computed range so the
+  // chart matches what the deck author saw in PowerPoint.
+  if (spec.valueAxis?.min !== undefined) min = spec.valueAxis.min;
+  if (spec.valueAxis?.max !== undefined) max = spec.valueAxis.max;
+  if (max === min) max = min + 1;
   return { min, max };
 };
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -25,6 +25,7 @@ export type { PresentationInput, SlideSize } from './fn.ts';
 export { SLIDE_SIZE_4_3, SLIDE_SIZE_16_9, SLIDE_SIZE_16_10 } from './fn.ts';
 export type { ImageFormat } from '../internal/opc/index.ts';
 export type {
+  ChartAxisScaling,
   ChartDataLabels,
   ChartKind,
   ChartSeries,

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -14,7 +14,13 @@ import {
   getAttrValue,
   qname,
 } from '../xml/index.ts';
-import type { ChartDataLabels, ChartKind, ChartSeries, ChartSpec } from './types.ts';
+import type {
+  ChartAxisScaling,
+  ChartDataLabels,
+  ChartKind,
+  ChartSeries,
+  ChartSpec,
+} from './types.ts';
 
 const NS_C = NS.chart;
 const NS_A = NS.dml;
@@ -280,11 +286,38 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     };
   }
 
+  // <c:valAx> lives on the plotArea (not on the plotted-kind element).
+  // Pull its <c:scaling><c:min/>/<c:max/> as the authored axis range.
+  let valueAxis: ChartAxisScaling | undefined;
+  const valAx = findFirst(plotArea, ['valAx']);
+  if (valAx) {
+    const scaling = firstChildElement(valAx, qname('c', 'scaling', NS_C));
+    if (scaling) {
+      const readNum = (local: string): number | undefined => {
+        const el = firstChildElement(scaling, qname('c', local, NS_C));
+        if (!el) return undefined;
+        const v = getAttrValue(el, ATTR_VAL);
+        if (v === null) return undefined;
+        const n = Number.parseFloat(v);
+        return Number.isFinite(n) ? n : undefined;
+      };
+      const min = readNum('min');
+      const max = readNum('max');
+      if (min !== undefined || max !== undefined) {
+        valueAxis = {
+          ...(min !== undefined ? { min } : {}),
+          ...(max !== undefined ? { max } : {}),
+        };
+      }
+    }
+  }
+
   return {
     kind,
     categories,
     series,
     ...(title !== undefined ? { title } : {}),
     ...(dataLabels !== undefined ? { dataLabels } : {}),
+    ...(valueAxis !== undefined ? { valueAxis } : {}),
   };
 };

--- a/src/internal/chartml/index.ts
+++ b/src/internal/chartml/index.ts
@@ -1,7 +1,13 @@
 // internal/chartml — c: namespace: charts + minimal xlsx writer for embedded data.
 // Allowed imports: internal/drawingml, internal/parts, internal/xml.
 
-export type { ChartDataLabels, ChartKind, ChartSeries, ChartSpec } from './types.ts';
+export type {
+  ChartAxisScaling,
+  ChartDataLabels,
+  ChartKind,
+  ChartSeries,
+  ChartSpec,
+} from './types.ts';
 export { buildChartSpaceDoc } from './chart-builder.ts';
 export { readChartSpec } from './chart-reader.ts';
 export type { DataRow } from './embedded-xlsx.ts';

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -39,6 +39,15 @@ export interface ChartDataLabels {
   readonly showPercent: boolean;
 }
 
+/**
+ * Authored value-axis scaling (`<c:valAx><c:scaling><c:min/>/<c:max/></c:scaling>`).
+ * When omitted, renderers compute the range from the series values.
+ */
+export interface ChartAxisScaling {
+  readonly min?: number;
+  readonly max?: number;
+}
+
 /** Full chart specification. */
 export interface ChartSpec {
   readonly kind: ChartKind;
@@ -49,4 +58,6 @@ export interface ChartSpec {
   readonly title?: string;
   /** Optional chart-level data-label toggles. */
   readonly dataLabels?: ChartDataLabels;
+  /** Optional value-axis scaling override (min / max). */
+  readonly valueAxis?: ChartAxisScaling;
 }


### PR DESCRIPTION
## Summary

- `ChartSpec.valueAxis` reads `<c:valAx><c:scaling>` min / max — charts with a fixed range render at the authored scale.
- Auto-numbered bullets — paragraphs with `'number'` or `{ autoNum }` render as `1., 2., 3.` / `A., B., C.` / `i., ii., iii.` etc. across the ECMA-376 `ST_TextAutoNumberScheme` token set. Counter resets on non-numbered paragraphs or level changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)