### PR TITLE
feat(chart): per-data-point colors (dPt)

### DIFF
--- a/.changeset/chart-dpt-colors.md
+++ b/.changeset/chart-dpt-colors.md
@@ -1,0 +1,9 @@
+---
+'pptx-kit': minor
+---
+
+feat: `ChartSeries.pointColors` — sparse map of per-data-point fill
+overrides read from `<c:ser><c:dPt><c:spPr><a:solidFill>`. Pie /
+doughnut decks almost always emit one of these per slice; the playground
+now paints each slice in its authored color (and reflects it in the
+legend swatches) rather than cycling through the accent palette.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -2654,7 +2654,10 @@ const renderPieChart = (
     const oy1 = cy + radius * Math.sin(start);
     const ox2 = cx + radius * Math.cos(end);
     const oy2 = cy + radius * Math.sin(end);
-    const color = colors[i % colors.length];
+    // Per-slice color: <c:dPt> override wins, then series.color, then
+    // accent palette fallback.
+    const dptColor = series.pointColors?.[i];
+    const color = dptColor ?? series.color ?? colors[i % colors.length];
     if (doughnut) {
       const ix1 = cx + innerR * Math.cos(start);
       const iy1 = cy + innerR * Math.sin(start);
@@ -2713,8 +2716,14 @@ const renderChart = (
       : spec.series.map((s) => s.name);
   const seriesColorsForLegend: string[] =
     spec.kind === 'pie' || spec.kind === 'doughnut'
-      ? spec.categories.map((_, i) => colors[i % colors.length] ?? '#888')
-      : spec.series.map((_, i) => colors[i % colors.length] ?? '#888');
+      ? spec.categories.map(
+          (_, i) =>
+            spec.series[0]?.pointColors?.[i] ??
+            spec.series[0]?.color ??
+            colors[i % colors.length] ??
+            '#888',
+        )
+      : spec.series.map((s, i) => s.color ?? colors[i % colors.length] ?? '#888');
 
   // Count finite values across all series — when zero, draw a hint
   // label so an empty chart isn't indistinguishable from a working

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -167,6 +167,34 @@ const readSeriesName = (ser: XmlElement): string => {
   return strs?.[0] ?? '';
 };
 
+// Walks `<c:ser><c:dPt>` overrides and returns a sparse array indexed
+// by point index. Returns `undefined` when no dPt overrides exist.
+const readDataPointColors = (ser: XmlElement): ReadonlyArray<string | null> | undefined => {
+  const out: Array<string | null> = [];
+  let any = false;
+  for (const c of ser.children) {
+    if (c.kind !== 'element' || c.name.namespaceURI !== NS_C || c.name.localName !== 'dPt')
+      continue;
+    const idxEl = firstChildElement(c, qname('c', 'idx', NS_C));
+    if (!idxEl) continue;
+    const idxRaw = getAttrValue(idxEl, ATTR_VAL);
+    if (idxRaw === null) continue;
+    const idx = Number.parseInt(idxRaw, 10);
+    if (!Number.isFinite(idx) || idx < 0) continue;
+    const spPr = firstChildElement(c, NAME_SP_PR_C);
+    if (!spPr) continue;
+    const solidFill = firstChildElement(spPr, NAME_SOLID_FILL);
+    if (!solidFill) continue;
+    const srgb = firstChildElement(solidFill, NAME_SRGB_CLR);
+    if (!srgb) continue;
+    const val = getAttrValue(srgb, ATTR_VAL);
+    if (val === null) continue;
+    out[idx] = `#${val.toUpperCase()}`;
+    any = true;
+  }
+  return any ? out : undefined;
+};
+
 const readSeriesColor = (ser: XmlElement): string | undefined => {
   const spPr = firstChildElement(ser, NAME_SP_PR_C);
   if (!spPr) return undefined;
@@ -254,10 +282,13 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     }
     const values = valEl !== null ? readNumRef(valEl) : null;
     const color = readSeriesColor(ser);
+    // <c:dPt> data-point overrides — sparse map idx → color.
+    const pointColors = readDataPointColors(ser);
     series.push({
       name,
       values: values ?? [],
       ...(color !== undefined ? { color } : {}),
+      ...(pointColors !== undefined ? { pointColors } : {}),
     });
   }
 

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -21,6 +21,14 @@ export interface ChartSeries {
   readonly values: ReadonlyArray<number | null>;
   /** Optional `#RRGGBB` fill override. Defaults to the theme's accent palette. */
   readonly color?: string;
+  /**
+   * Optional per-data-point color overrides, indexed by point index
+   * (`<c:dPt><c:idx val="N"/><c:spPr><a:solidFill>…`). Sparse — only
+   * the indices that author an override appear. Pie / doughnut decks
+   * almost always emit one of these per slice to break out of the
+   * single-series-color default.
+   */
+  readonly pointColors?: ReadonlyArray<string | null>;
 }
 
 /**


### PR DESCRIPTION
## Summary

`ChartSeries.pointColors` reads `<c:ser><c:dPt><c:spPr><a:solidFill>` overrides. Playground pie / doughnut paints each slice in its authored color and reflects it in the legend swatch order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)