### PR TITLE
feat: bodyPr cascade (anchor / wrap / vert / margins)

### DIFF
--- a/.changeset/bodypr-cascade.md
+++ b/.changeset/bodypr-cascade.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: `getShapeBodyPrEffective(pres, shape)` — `<a:bodyPr>` cascade
+covering anchor, wrap, vertical-text direction, and inset margins.
+Walks shape → layout placeholder → master placeholder bodyPr the same
+way the rPr / pPr cascades do. Playground uses it so placeholders
+inherit text alignment / margins from the layout / master without
+each slide having to re-author them.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -37,6 +37,7 @@ import {
   getShapeFlip,
   getShapeGradientFill,
   getShapePatternFill,
+  getShapeBodyPrEffective,
   getShapeChartKind,
   getShapeChartSpec,
   getShapeHyperlink,
@@ -1906,12 +1907,26 @@ const renderTextBody = (
   if (paragraphCount === 0) return '';
 
   const defaultPt = placeholderDefaultPt(phType);
-  const anchor = getShapeTextAnchor(shape) ?? 'top';
-  const margins = getShapeTextMargins(shape);
-  const lIns = margins?.left ?? DEFAULT_INSET_X;
-  const tIns = margins?.top ?? DEFAULT_INSET_Y;
-  const rIns = margins?.right ?? DEFAULT_INSET_X;
-  const bIns = margins?.bottom ?? DEFAULT_INSET_Y;
+  // Effective body-property cascade — anchor, wrap, vert, margins all
+  // inherit from the layout / master placeholder when the slide doesn't
+  // override them.
+  let effectiveBody: ReturnType<typeof getShapeBodyPrEffective>;
+  try {
+    effectiveBody = getShapeBodyPrEffective(pres, shape);
+  } catch {
+    effectiveBody = {
+      anchor: getShapeTextAnchor(shape),
+      wrap: null,
+      vert: getShapeTextDirection(shape),
+      margins: getShapeTextMargins(shape) ?? { left: null, top: null, right: null, bottom: null },
+    };
+  }
+  const anchor = effectiveBody.anchor ?? 'top';
+  const margins = effectiveBody.margins;
+  const lIns = margins.left ?? DEFAULT_INSET_X;
+  const tIns = margins.top ?? DEFAULT_INSET_Y;
+  const rIns = margins.right ?? DEFAULT_INSET_X;
+  const bIns = margins.bottom ?? DEFAULT_INSET_Y;
 
   const innerX = bounds.x + lIns;
   const innerY = bounds.y + tIns;
@@ -2216,7 +2231,7 @@ const renderTextBody = (
   // primitive for the common cases (East-Asian, Mongolian, vert);
   // wordArtVert / wordArtVertRtl stack characters without rotation
   // which writing-mode also covers via "vertical-lr".
-  const vert = getShapeTextDirection(shape);
+  const vert = effectiveBody.vert ?? getShapeTextDirection(shape);
   let writingMode = '';
   let extraTransform = '';
   if (vert === 'vert' || vert === 'eaVert') {

--- a/src/api/fn.ts
+++ b/src/api/fn.ts
@@ -4553,6 +4553,130 @@ export const getShapeTextMargins = (
   };
 };
 
+/**
+ * Resolves the effective `<a:bodyPr>` properties — anchor, wrap, vertical
+ * direction, and inset margins — by walking the layout / master cascade
+ * the same way `getShapeRunFormatEffective` walks rPr. Returns the
+ * innermost value that the cascade supplies, or `null` for properties
+ * neither the shape nor any inherited placeholder authors.
+ *
+ * Companion to `getShapeTextAnchor` / `getShapeTextWrap` /
+ * `getShapeTextDirection` / `getShapeTextMargins`, which only report the
+ * literal value on the shape itself.
+ */
+export const getShapeBodyPrEffective = (
+  pres: PresentationData,
+  shape: SlideShapeData,
+): {
+  anchor: TextAnchor | null;
+  wrap: TextWrap | null;
+  vert: ReturnType<typeof getShapeTextDirection>;
+  margins: { left: number | null; top: number | null; right: number | null; bottom: number | null };
+} => {
+  const result = {
+    anchor: null as TextAnchor | null,
+    wrap: null as TextWrap | null,
+    vert: null as ReturnType<typeof getShapeTextDirection>,
+    margins: {
+      left: null as number | null,
+      top: null as number | null,
+      right: null as number | null,
+      bottom: null as number | null,
+    },
+  };
+  const parseBodyPr = (bodyPr: XmlElement): void => {
+    if (result.anchor === null) {
+      const a = getAttrValue(bodyPr, qname('', 'anchor', ''));
+      if (a === 't') result.anchor = 'top';
+      else if (a === 'ctr') result.anchor = 'center';
+      else if (a === 'b') result.anchor = 'bottom';
+    }
+    if (result.wrap === null) {
+      const w = getAttrValue(bodyPr, qname('', 'wrap', ''));
+      if (w === 'square') result.wrap = 'square';
+      else if (w === 'none') result.wrap = 'none';
+    }
+    if (result.vert === null) {
+      const v = getAttrValue(bodyPr, qname('', 'vert', ''));
+      if (
+        v === 'vert' ||
+        v === 'vert270' ||
+        v === 'wordArtVert' ||
+        v === 'eaVert' ||
+        v === 'mongolianVert' ||
+        v === 'wordArtVertRtl'
+      )
+        result.vert = v;
+    }
+    for (const side of ['l', 't', 'r', 'b'] as const) {
+      const target =
+        side === 'l' ? 'left' : side === 't' ? 'top' : side === 'r' ? 'right' : 'bottom';
+      if (result.margins[target] !== null) continue;
+      const v = getAttrValue(bodyPr, qname('', `${side}Ins`, ''));
+      if (v === null) continue;
+      const n = Number.parseInt(v, 10);
+      if (Number.isFinite(n)) result.margins[target] = n;
+    }
+  };
+
+  // 1. The shape's own bodyPr.
+  const txBody = firstChildElement(shape[SHAPE_ELEMENT], NAME_TX_BODY_FN);
+  if (txBody) {
+    const bodyPr = firstChildElement(txBody, NAME_A_BODY_PR);
+    if (bodyPr) parseBodyPr(bodyPr);
+  }
+
+  // 2-3. Walk layout placeholder and master placeholder bodyPr.
+  const phIdx = getShapePlaceholderIdx(shape);
+  const phType = getShapePlaceholderType(shape);
+  const slide = shape[SHAPE_SLIDE];
+  const layout = getSlideLayout(slide);
+  if (!layout) return result;
+
+  const findPh = (
+    shapes: ReadonlyArray<{
+      placeholderIdx: number | null;
+      placeholderType: string | null;
+      element: XmlElement;
+    }>,
+  ): XmlElement | null => {
+    let match = phIdx !== null ? shapes.find((s) => s.placeholderIdx === phIdx) : undefined;
+    if (!match && phType !== null) {
+      match = shapes.find((s) => s.placeholderType === phType);
+    }
+    return match?.element ?? null;
+  };
+
+  const layoutPhEl = findPh(layout[LAYOUT_PART].shapes);
+  if (layoutPhEl) {
+    const layoutTxBody = firstChildElement(layoutPhEl, NAME_TX_BODY_FN);
+    if (layoutTxBody) {
+      const bodyPr = firstChildElement(layoutTxBody, NAME_A_BODY_PR);
+      if (bodyPr) parseBodyPr(bodyPr);
+    }
+  }
+
+  const pkg = pres[INTERNAL_PACKAGE];
+  const layoutPartName = partName(layout[LAYOUT_PART_NAME]);
+  const layoutRels = pkg.getRels(layoutPartName);
+  if (!layoutRels) return result;
+  const masterRel = layoutRels.items.find((r) => r.type === REL_TYPES.slideMaster);
+  if (!masterRel) return result;
+  const masterPart = pkg.getPart(resolveTarget(layoutPartName, masterRel.target));
+  if (!masterPart) return result;
+  const masterRoot = parseXml(decode(masterPart.data)).root;
+  const { shapes: masterShapes } = readShapeTreeFromCsldRoot(masterRoot, 'sldMaster');
+  const masterPhEl = findPh(masterShapes);
+  if (masterPhEl) {
+    const masterTxBody = firstChildElement(masterPhEl, NAME_TX_BODY_FN);
+    if (masterTxBody) {
+      const bodyPr = firstChildElement(masterTxBody, NAME_A_BODY_PR);
+      if (bodyPr) parseBodyPr(bodyPr);
+    }
+  }
+  return result;
+};
+
 export const setShapeTextAnchor = (shape: SlideShapeData, anchor: TextAnchor): void => {
   const txBody = requireTxBody(shape);
   let bodyPr = firstChildElement(txBody, NAME_A_BODY_PR);

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -187,6 +187,7 @@ export {
   getShapeAnimation,
   getShapeAt,
   getShapeBounds,
+  getShapeBodyPrEffective,
   getShapeBoundsResolved,
   getShapeCenter,
   getShapeChartCategories,


### PR DESCRIPTION
## Summary

`getShapeBodyPrEffective(pres, shape)` resolves anchor / wrap / vertical-text direction / inset margins through the same shape → layout placeholder → master placeholder chain the rPr and pPr cascades use. Playground wires it through so placeholders pick up the master's text-frame settings without each slide having to repeat them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)