### PR TITLE
feat(chart): smooth-line rendering

### DIFF
--- a/.changeset/chart-smooth.md
+++ b/.changeset/chart-smooth.md
@@ -1,0 +1,8 @@
+---
+'pptx-kit': minor
+---
+
+feat(chart): `ChartSeries.smooth` reads `<c:smooth val="1"/>`. Playground
+line / area renderer interpolates a cubic-Bézier curve through the
+data points (Catmull-Rom-to-Bezier with 0.5 tension) when `smooth` is
+true, matching PowerPoint's "smooth line" preset visually.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -2620,6 +2620,31 @@ const renderColumnChart = (
   return out.join('');
 };
 
+// Emit an SVG path through `pts` with cubic Bézier control points
+// derived from each pair's neighbours (Catmull-Rom-to-Bezier). The
+// `tension` is fixed at 0.5 — close to what PowerPoint's smooth-line
+// preset produces visually.
+const smoothPath = (pts: ReadonlyArray<[number, number]>): string => {
+  if (pts.length < 2) return '';
+  const tension = 0.5;
+  const parts: string[] = [];
+  const [x0, y0] = pts[0]!;
+  parts.push(`M${px(x0)},${px(y0)}`);
+  for (let i = 0; i < pts.length - 1; i++) {
+    const [,] = pts[i]!;
+    const p0 = pts[i - 1] ?? pts[i]!;
+    const p1 = pts[i]!;
+    const p2 = pts[i + 1]!;
+    const p3 = pts[i + 2] ?? p2;
+    const cp1x = p1[0] + ((p2[0] - p0[0]) * tension) / 3;
+    const cp1y = p1[1] + ((p2[1] - p0[1]) * tension) / 3;
+    const cp2x = p2[0] - ((p3[0] - p1[0]) * tension) / 3;
+    const cp2y = p2[1] - ((p3[1] - p1[1]) * tension) / 3;
+    parts.push(`C${px(cp1x)},${px(cp1y)} ${px(cp2x)},${px(cp2y)} ${px(p2[0])},${px(p2[1])}`);
+  }
+  return parts.join(' ');
+};
+
 // Trim long decimals; large numbers keep their integer form.
 const formatChartValue = (v: number): string => {
   if (!Number.isFinite(v)) return '';
@@ -2781,7 +2806,14 @@ const renderLineChart = (
       basePts.push([xp, yBase]);
       if (isStacked) accumulated[c] = top;
     }
-    const dPath = pts.map(([xp, yp], i) => `${i === 0 ? 'M' : 'L'}${px(xp)},${px(yp)}`).join(' ');
+    // <c:smooth val="1"/> — interpolate a Catmull-Rom-style curve through
+    // the points by emitting cubic Bézier segments with control points
+    // derived from the immediate neighbours. Matches PowerPoint's
+    // "smooth line" visual within reasonable tolerance.
+    const dPath =
+      series.smooth && pts.length > 2
+        ? smoothPath(pts)
+        : pts.map(([xp, yp], i) => `${i === 0 ? 'M' : 'L'}${px(xp)},${px(yp)}`).join(' ');
     if (fill) {
       // Walk back along the baseline (or the previous series's top for
       // stacked) to close the area.

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -285,11 +285,15 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     const color = readSeriesColor(ser);
     // <c:dPt> data-point overrides — sparse map idx → color.
     const pointColors = readDataPointColors(ser);
+    // <c:smooth val="1"/> — line / area / scatter only.
+    const smoothEl = firstChildElement(ser, qname('c', 'smooth', NS_C));
+    const smooth = smoothEl !== null && getAttrValue(smoothEl, ATTR_VAL) !== '0';
     series.push({
       name,
       values: values ?? [],
       ...(color !== undefined ? { color } : {}),
       ...(pointColors !== undefined ? { pointColors } : {}),
+      ...(smoothEl !== null ? { smooth } : {}),
     });
   }
 

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -29,6 +29,12 @@ export interface ChartSeries {
    * single-series-color default.
    */
   readonly pointColors?: ReadonlyArray<string | null>;
+  /**
+   * Line-smoothing toggle (`<c:smooth val="1"/>`) — only meaningful for
+   * line / scatter / area series. When `true`, the renderer interpolates
+   * a smooth curve through the data points instead of straight segments.
+   */
+  readonly smooth?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

`ChartSeries.smooth` reads `<c:smooth val="1"/>` and the line / area renderer projects it as a Catmull-Rom-to-Bezier cubic curve through the data points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)