### PR TITLE
feat(chart): gapWidth / overlap bar sizing

### DIFF
--- a/.changeset/chart-gap-overlap.md
+++ b/.changeset/chart-gap-overlap.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat(chart): `ChartSpec.gapWidthPct` and `overlapPct` read from
+`<c:gapWidth>` and `<c:overlap>` on bar / column plots. Playground
+sizes bars per ECMA-376 §21.2.2.75 — `barW = groupW / (clusterUnits +
+gapWidth/100)` with `clusterUnits = 1 + (S - 1)(1 - overlap/100)` —
+so authored bar spacing matches PowerPoint instead of the hard-coded
+0.8 / 0.7 ratios.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -2581,7 +2581,15 @@ const renderColumnChart = (
   }
   const range = max - min || 1;
   const groupW = f.plotW / N;
-  const barW = isStacked ? groupW * 0.7 : (groupW * 0.8) / spec.series.length;
+  // gapWidth + overlap shape bar geometry per ECMA-376 §21.2.2.75:
+  //   barW = groupW / (clusterUnits + gapWidth/100)
+  //   clusterUnits = 1 + (S − 1) × (1 − overlap/100)  (clustered)
+  //   clusterUnits = 1                                  (stacked)
+  const gapPctC = (spec.gapWidthPct ?? 150) / 100;
+  const overlapPctC = (spec.overlapPct ?? (isStacked ? 100 : 0)) / 100;
+  const Sc = spec.series.length;
+  const clusterUnitsC = isStacked ? 1 : 1 + (Sc - 1) * (1 - overlapPctC);
+  const barW = groupW / Math.max(0.5, clusterUnitsC + gapPctC);
   const baseY = f.plotY + f.plotH - ((0 - min) / range) * f.plotH;
   const showLabel = spec.dataLabels?.showValue ?? false;
   const out: string[] = [];
@@ -2624,9 +2632,14 @@ const renderColumnChart = (
         else negAcc = stackedTop;
       }
     } else {
+      // Clustered cluster width respects overlap. Center the cluster
+      // inside groupW so the inter-cluster gap stays even on both sides.
+      const clusterW = barW * clusterUnitsC;
+      const clusterStartX = f.plotX + c * groupW + (groupW - clusterW) / 2;
+      const stride = barW * (1 - overlapPctC);
       for (let s = 0; s < spec.series.length; s++) {
         const v = spec.series[s]?.values[c] ?? 0;
-        const x0 = f.plotX + c * groupW + groupW * 0.1 + s * barW;
+        const x0 = clusterStartX + s * stride;
         const top = f.plotY + f.plotH - ((v - min) / range) * f.plotH;
         const y0 = Math.min(top, baseY);
         const h = Math.abs(top - baseY);
@@ -2710,7 +2723,11 @@ const renderBarChart = (f: ChartFrame, spec: ChartSpec, colors: ReadonlyArray<st
   }
   const range = max - min || 1;
   const groupH = f.plotH / N;
-  const barH = isStacked ? groupH * 0.7 : (groupH * 0.8) / spec.series.length;
+  const gapPctB = (spec.gapWidthPct ?? 150) / 100;
+  const overlapPctB = (spec.overlapPct ?? (isStacked ? 100 : 0)) / 100;
+  const Sb = spec.series.length;
+  const clusterUnitsB = isStacked ? 1 : 1 + (Sb - 1) * (1 - overlapPctB);
+  const barH = groupH / Math.max(0.5, clusterUnitsB + gapPctB);
   const baseX = f.plotX + ((0 - min) / range) * f.plotW;
   const showLabel = spec.dataLabels?.showValue ?? false;
   const out: string[] = [];
@@ -2746,9 +2763,12 @@ const renderBarChart = (f: ChartFrame, spec: ChartSpec, colors: ReadonlyArray<st
         else negAcc = stackedTop;
       }
     } else {
+      const clusterH = barH * clusterUnitsB;
+      const clusterStartY = f.plotY + c * groupH + (groupH - clusterH) / 2;
+      const strideB = barH * (1 - overlapPctB);
       for (let s = 0; s < spec.series.length; s++) {
         const v = spec.series[s]?.values[c] ?? 0;
-        const y0 = f.plotY + c * groupH + groupH * 0.1 + s * barH;
+        const y0 = clusterStartY + s * strideB;
         const tip = f.plotX + ((v - min) / range) * f.plotW;
         const x0 = Math.min(tip, baseX);
         const w = Math.abs(tip - baseX);

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -363,6 +363,30 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     }
   }
 
+  // <c:gapWidth> and <c:overlap> live on the plotted-kind element and
+  // tune the bar / column spacing. PowerPoint defaults: gapWidth=150
+  // (1.5× bar width gap), overlap=0 (clustered) or 100 (stacked).
+  let gapWidthPct: number | undefined;
+  let overlapPct: number | undefined;
+  if (kind === 'column' || kind === 'bar') {
+    const gwEl = firstChildElement(plotted, qname('c', 'gapWidth', NS_C));
+    if (gwEl) {
+      const v = getAttrValue(gwEl, ATTR_VAL);
+      if (v !== null) {
+        const n = Number.parseInt(v, 10);
+        if (Number.isFinite(n)) gapWidthPct = n;
+      }
+    }
+    const ovEl = firstChildElement(plotted, qname('c', 'overlap', NS_C));
+    if (ovEl) {
+      const v = getAttrValue(ovEl, ATTR_VAL);
+      if (v !== null) {
+        const n = Number.parseInt(v, 10);
+        if (Number.isFinite(n)) overlapPct = n;
+      }
+    }
+  }
+
   return {
     kind,
     categories,
@@ -371,5 +395,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     ...(dataLabels !== undefined ? { dataLabels } : {}),
     ...(valueAxis !== undefined ? { valueAxis } : {}),
     ...(grouping !== undefined ? { grouping } : {}),
+    ...(gapWidthPct !== undefined ? { gapWidthPct } : {}),
+    ...(overlapPct !== undefined ? { overlapPct } : {}),
   };
 };

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -88,4 +88,15 @@ export interface ChartSpec {
   readonly valueAxis?: ChartAxisScaling;
   /** Bar / column / area grouping mode. Absent for line / pie. */
   readonly grouping?: ChartGrouping;
+  /**
+   * Gap between adjacent bar groups in `<c:gapWidth val="N"/>` units
+   * (0..500, percent of bar width). Default 150 (= 1.5×) in PowerPoint.
+   */
+  readonly gapWidthPct?: number;
+  /**
+   * Overlap of adjacent bars within a category in `<c:overlap val="N"/>`
+   * percent (-100..100). Negative pulls bars apart, positive overlaps.
+   * Defaults to 0 (clustered) / 100 (stacked).
+   */
+  readonly overlapPct?: number;
 }


### PR DESCRIPTION
Bar / column renderer sizes bars per the ECMA-376 formula using authored gapWidth and overlap.