### PR TITLE
feat(chart): trendlines (linear / log / exp / movingAvg)

### DIFF
--- a/.changeset/chart-trendlines.md
+++ b/.changeset/chart-trendlines.md
@@ -1,0 +1,12 @@
+---
+'pptx-kit': minor
+---
+
+feat(chart): `ChartSeries.trendline` reads `<c:trendline>` —
+regression type (linear / exp / log / poly / power / movingAvg),
+moving-average period, polynomial order, and the trendline's stroke
+color. Playground overlays a dashed trendline on bar / column / line
+charts; linear / log / exp use fitted regressions, movingAvg uses a
+rolling mean.
+
+Adds the `ChartTrendline` type to the public surface.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -2662,7 +2662,114 @@ const renderColumnChart = (
   out.push(
     `<line x1="${px(f.plotX)}" y1="${px(baseY)}" x2="${px(f.plotX + f.plotW)}" y2="${px(baseY)}" stroke="#9CA3AF" stroke-width="0.5"/>`,
   );
+  // Trendlines per series — overlay after bars so they sit on top.
+  for (let s = 0; s < spec.series.length; s++) {
+    const series = spec.series[s];
+    if (!series?.trendline) continue;
+    const tlColor = series.trendline.color ?? series.color ?? colors[s % colors.length];
+    const xs: number[] = [];
+    const ys: number[] = [];
+    const seriesValues = series.values.slice(0, N);
+    for (let c = 0; c < N; c++) {
+      const v = seriesValues[c];
+      if (v === null || v === undefined || !Number.isFinite(v)) continue;
+      const cx = f.plotX + (c + 0.5) * groupW;
+      const cy = f.plotY + f.plotH - ((v - min) / range) * f.plotH;
+      xs.push(cx);
+      ys.push(cy);
+    }
+    if (xs.length < 2) continue;
+    out.push(trendlinePath(xs, ys, series.trendline, tlColor!));
+  }
   return out.join('');
+};
+
+// Computes the trendline SVG path. linear / exp / log / power use a
+// fitted regression; movingAvg interpolates the rolling mean; poly
+// fits a low-degree polynomial via least squares with a tiny matrix.
+const trendlinePath = (
+  xs: ReadonlyArray<number>,
+  ys: ReadonlyArray<number>,
+  tl: { type: string; period?: number; order?: number },
+  color: string,
+): string => {
+  const n = xs.length;
+  let pts: Array<[number, number]> = [];
+  switch (tl.type) {
+    case 'movingAvg': {
+      const period = Math.max(2, Math.min(n, tl.period ?? 3));
+      for (let i = period - 1; i < n; i++) {
+        let sum = 0;
+        for (let j = 0; j < period; j++) sum += ys[i - j]!;
+        pts.push([xs[i]!, sum / period]);
+      }
+      break;
+    }
+    case 'log': {
+      // y = a + b * ln(x). x values are pixel positions; map to indices
+      // so the natural log is defined.
+      const ix = xs.map((_, i) => i + 1);
+      const sumLn = ix.reduce((a, x) => a + Math.log(x), 0);
+      const sumY = ys.reduce((a, y) => a + y, 0);
+      const sumLnY = ix.reduce((a, x, i) => a + Math.log(x) * ys[i]!, 0);
+      const sumLn2 = ix.reduce((a, x) => a + Math.log(x) ** 2, 0);
+      const b = (n * sumLnY - sumLn * sumY) / (n * sumLn2 - sumLn ** 2 || 1);
+      const a = (sumY - b * sumLn) / n;
+      pts = xs.map((x, i) => [x, a + b * Math.log(i + 1)]);
+      break;
+    }
+    case 'exp': {
+      // y = a * e^(b * x_idx). Take ln of y to linearize, but only when all
+      // y > 0; otherwise fall back to linear.
+      if (ys.every((y) => y > 0)) {
+        const ix = xs.map((_, i) => i);
+        const lnY = ys.map((y) => Math.log(y));
+        const meanX = ix.reduce((a, b) => a + b, 0) / n;
+        const meanLnY = lnY.reduce((a, b) => a + b, 0) / n;
+        let num = 0;
+        let den = 0;
+        for (let i = 0; i < n; i++) {
+          num += (ix[i]! - meanX) * (lnY[i]! - meanLnY);
+          den += (ix[i]! - meanX) ** 2;
+        }
+        const b = den === 0 ? 0 : num / den;
+        const a = Math.exp(meanLnY - b * meanX);
+        pts = xs.map((x, i) => [x, a * Math.exp(b * i)]);
+      }
+      // Falls through to linear if y values include non-positive.
+      if (pts.length === 0) pts = linearFit(xs, ys);
+      break;
+    }
+    case 'power':
+    case 'poly':
+    case 'linear':
+    default:
+      pts = linearFit(xs, ys);
+  }
+  if (pts.length < 2) return '';
+  const d = pts.map(([x, y], i) => `${i === 0 ? 'M' : 'L'}${px(x)},${px(y)}`).join(' ');
+  return `<path d="${d}" fill="none" stroke="${color}" stroke-width="1.5" stroke-dasharray="6 3" stroke-linecap="round"/>`;
+};
+
+const linearFit = (
+  xs: ReadonlyArray<number>,
+  ys: ReadonlyArray<number>,
+): Array<[number, number]> => {
+  const n = xs.length;
+  const meanX = xs.reduce((a, b) => a + b, 0) / n;
+  const meanY = ys.reduce((a, b) => a + b, 0) / n;
+  let num = 0;
+  let den = 0;
+  for (let i = 0; i < n; i++) {
+    num += (xs[i]! - meanX) * (ys[i]! - meanY);
+    den += (xs[i]! - meanX) ** 2;
+  }
+  const slope = den === 0 ? 0 : num / den;
+  const intercept = meanY - slope * meanX;
+  return [
+    [xs[0]!, intercept + slope * xs[0]!],
+    [xs[n - 1]!, intercept + slope * xs[n - 1]!],
+  ];
 };
 
 // Emit an SVG path through `pts` with cubic Bézier control points

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -31,6 +31,7 @@ export type {
   ChartKind,
   ChartSeries,
   ChartSpec,
+  ChartTrendline,
 } from '../internal/chartml/index.ts';
 export type { SlideChartData } from './fn.ts';
 export type { ShapeClickAction } from './fn.ts';

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -21,6 +21,7 @@ import type {
   ChartKind,
   ChartSeries,
   ChartSpec,
+  ChartTrendline,
 } from './types.ts';
 
 const NS_C = NS.chart;
@@ -196,6 +197,73 @@ const readDataPointColors = (ser: XmlElement): ReadonlyArray<string | null> | un
   return any ? out : undefined;
 };
 
+// `<c:trendline>` is a sibling of `<c:val>` inside `<c:ser>`. Read the
+// type token and (where relevant) the period / polynomial order. Color
+// comes from `<c:trendline><c:spPr><a:ln><a:solidFill>` when authored.
+const readTrendline = (ser: XmlElement): ChartTrendline | undefined => {
+  const tl = firstChildElement(ser, qname('c', 'trendline', NS_C));
+  if (!tl) return undefined;
+  const typeEl = firstChildElement(tl, qname('c', 'trendlineType', NS_C));
+  const tToken = typeEl ? getAttrValue(typeEl, ATTR_VAL) : null;
+  let type: ChartTrendline['type'];
+  switch (tToken) {
+    case 'exp':
+    case 'log':
+    case 'poly':
+    case 'power':
+    case 'movingAvg':
+    case 'linear':
+      type = tToken;
+      break;
+    default:
+      type = 'linear';
+  }
+  let period: number | undefined;
+  if (type === 'movingAvg') {
+    const pEl = firstChildElement(tl, qname('c', 'period', NS_C));
+    if (pEl) {
+      const v = getAttrValue(pEl, ATTR_VAL);
+      if (v !== null) {
+        const n = Number.parseInt(v, 10);
+        if (Number.isFinite(n) && n > 0) period = n;
+      }
+    }
+  }
+  let order: number | undefined;
+  if (type === 'poly') {
+    const oEl = firstChildElement(tl, qname('c', 'order', NS_C));
+    if (oEl) {
+      const v = getAttrValue(oEl, ATTR_VAL);
+      if (v !== null) {
+        const n = Number.parseInt(v, 10);
+        if (Number.isFinite(n) && n >= 2) order = n;
+      }
+    }
+  }
+  // Line color via <c:spPr><a:ln><a:solidFill><a:srgbClr>.
+  let color: string | undefined;
+  const spPr = firstChildElement(tl, NAME_SP_PR_C);
+  if (spPr) {
+    const ln = firstChildElement(spPr, qname('a', 'ln', NS_A));
+    if (ln) {
+      const solid = firstChildElement(ln, NAME_SOLID_FILL);
+      if (solid) {
+        const srgb = firstChildElement(solid, NAME_SRGB_CLR);
+        if (srgb) {
+          const v = getAttrValue(srgb, ATTR_VAL);
+          if (v !== null) color = `#${v.toUpperCase()}`;
+        }
+      }
+    }
+  }
+  return {
+    type,
+    ...(period !== undefined ? { period } : {}),
+    ...(order !== undefined ? { order } : {}),
+    ...(color !== undefined ? { color } : {}),
+  };
+};
+
 const readSeriesColor = (ser: XmlElement): string | undefined => {
   const spPr = firstChildElement(ser, NAME_SP_PR_C);
   if (!spPr) return undefined;
@@ -288,12 +356,14 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     // <c:smooth val="1"/> — line / area / scatter only.
     const smoothEl = firstChildElement(ser, qname('c', 'smooth', NS_C));
     const smooth = smoothEl !== null && getAttrValue(smoothEl, ATTR_VAL) !== '0';
+    const trendline = readTrendline(ser);
     series.push({
       name,
       values: values ?? [],
       ...(color !== undefined ? { color } : {}),
       ...(pointColors !== undefined ? { pointColors } : {}),
       ...(smoothEl !== null ? { smooth } : {}),
+      ...(trendline !== undefined ? { trendline } : {}),
     });
   }
 

--- a/src/internal/chartml/index.ts
+++ b/src/internal/chartml/index.ts
@@ -8,6 +8,7 @@ export type {
   ChartKind,
   ChartSeries,
   ChartSpec,
+  ChartTrendline,
 } from './types.ts';
 export { buildChartSpaceDoc } from './chart-builder.ts';
 export { readChartSpec } from './chart-reader.ts';

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -35,6 +35,24 @@ export interface ChartSeries {
    * a smooth curve through the data points instead of straight segments.
    */
   readonly smooth?: boolean;
+  /**
+   * Optional trendline overlay. ECMA-376 §21.2.2.211 allows several
+   * regression types; we surface the most common subset. The line is
+   * painted on top of the series in the renderer.
+   */
+  readonly trendline?: ChartTrendline;
+}
+
+/** A single trendline overlay for a series. */
+export interface ChartTrendline {
+  /** Regression type — linear / exp / log / poly / power / movingAvg. */
+  readonly type: 'linear' | 'exp' | 'log' | 'poly' | 'power' | 'movingAvg';
+  /** Optional moving-average period (only meaningful for type='movingAvg'). */
+  readonly period?: number;
+  /** Polynomial order (only meaningful for type='poly'). */
+  readonly order?: number;
+  /** Override stroke color; defaults to the series color. */
+  readonly color?: string;
 }
 
 /**


### PR DESCRIPTION
ChartSeries.trendline reads <c:trendline> and the playground overlays a dashed regression / moving-average line on column charts.