### PR TITLE
feat(chart): line/area trendlines

### DIFF
--- a/.changeset/line-trendline.md
+++ b/.changeset/line-trendline.md
@@ -1,0 +1,9 @@
+---
+'pptx-kit': minor
+---
+
+feat(chart): line / area charts now overlay the per-series
+`<c:trendline>` when authored. Same regression types as the
+column-chart variant (linear / log / exp / movingAvg / poly+power
+fallback). Only emitted on the clustered layout — stacked plots
+already convey the cumulative shape.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -2992,6 +2992,22 @@ const renderLineChart = (
         out.push(`<circle cx="${px(xp)}" cy="${px(yp)}" r="2.2" fill="${color}"/>`);
       }
     }
+    // Trendline overlay per series (only meaningful on the clustered
+    // layout — stacked already shows the cumulative shape).
+    if (!isStacked && series.trendline) {
+      const finiteXs: number[] = [];
+      const finiteYs: number[] = [];
+      for (const [xp, yp] of pts) {
+        if (Number.isFinite(yp)) {
+          finiteXs.push(xp);
+          finiteYs.push(yp);
+        }
+      }
+      if (finiteXs.length >= 2) {
+        const tlColor = series.trendline.color ?? color;
+        out.push(trendlinePath(finiteXs, finiteYs, series.trendline, tlColor));
+      }
+    }
   }
   return out.join('');
 };


### PR DESCRIPTION
Line and area renderers overlay <c:trendline> regression / moving-average lines via the helper added in PR #16.