### PR TITLE
feat: getSlideColorMapOverride

### DIFF
--- a/.changeset/color-map-override.md
+++ b/.changeset/color-map-override.md
@@ -1,0 +1,11 @@
+---
+'pptx-kit': minor
+---
+
+feat: `getSlideColorMapOverride(slide)` returns the slide's
+`<p:clrMapOvr><a:overrideClrMapping/>` token-remap, or `null` when the
+slide inherits the master's color map. Returned as a plain `Record`
+with the eight stable tokens (`bg1`, `tx1`, `bg2`, `tx2`, `accent1`-
+`accent6`, `hlink`, `folHlink`) keyed to their override targets.
+Useful for renderers that need to know when a slide reinterprets the
+theme's color story.

--- a/src/api/fn.ts
+++ b/src/api/fn.ts
@@ -7237,6 +7237,36 @@ export type SlideBackground =
   | { readonly kind: 'image' }
   | { readonly kind: 'inherit' };
 
+/**
+ * Reads the slide's color-map override (`<p:clrMapOvr><p:overrideClrMapping/>`).
+ * The mapping remaps the eight stable ECMA-376 color tokens (`bg1`,
+ * `tx1`, `bg2`, `tx2`, `accent1`–`accent6`, `hlink`, `folHlink`) to
+ * different theme positions. Returns `null` when the slide uses the
+ * master's color map unchanged (the overwhelming common case).
+ */
+export const getSlideColorMapOverride = (slide: SlideData): Record<string, string> | null => {
+  const root = slide[SLIDE_DOCUMENT].root;
+  let ovr: XmlElement | null = null;
+  for (const c of root.children) {
+    if (c.kind !== 'element') continue;
+    if (c.name.namespaceURI === NS.pml && c.name.localName === 'clrMapOvr') {
+      ovr = c;
+      break;
+    }
+  }
+  if (!ovr) return null;
+  const mapping = firstChildElement(ovr, qname('a', 'overrideClrMapping', NS.dml));
+  if (!mapping) return null;
+  // overrideClrMapping carries 12 attributes — bg1..folHlink — each
+  // pointing to the index the token is remapped to in the theme.
+  const out: Record<string, string> = {};
+  for (const a of mapping.attrs) {
+    if (a.name.namespaceURI !== '') continue;
+    out[a.name.localName] = a.value;
+  }
+  return Object.keys(out).length > 0 ? out : null;
+};
+
 export const getSlideBackground = (slide: SlideData): SlideBackground => {
   const cSld = firstChildElement(slide[SLIDE_DOCUMENT].root, NAME_CSLD);
   if (!cSld) return { kind: 'inherit' };

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -281,6 +281,7 @@ export {
   getSlideBackgroundPatternFill,
   getSlideBody,
   getSlideCharts,
+  getSlideColorMapOverride,
   getSlideCommentAuthors,
   getSlideComments,
   getSlideCount,


### PR DESCRIPTION
Read <p:clrMapOvr> token remap so renderers know when a slide reinterprets the theme's color scheme.