### PR TITLE
feat(chart): legend position

### DIFF
--- a/.changeset/chart-legend-position.md
+++ b/.changeset/chart-legend-position.md
@@ -1,0 +1,9 @@
+---
+'pptx-kit': minor
+---
+
+feat(chart): `ChartSpec.legend` carries the `<c:legend><c:legendPos>`
+token — `'r' | 't' | 'b' | 'l' | 'tr'`. Playground projects each
+onto the appropriate edge (horizontal row for top / bottom, vertical
+stack for the side / corner positions). Charts whose `<c:legend>`
+sets `position` to `null` paint without a legend.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -2520,22 +2520,51 @@ const renderChartLegend = (
   f: ChartFrame,
   names: ReadonlyArray<string>,
   colors: ReadonlyArray<string>,
+  position: 'r' | 't' | 'b' | 'l' | 'tr' = 'b',
 ): string => {
   if (names.length === 0) return '';
-  const itemPx = Math.min(140, f.w / names.length);
-  const totalW = itemPx * names.length;
-  const startX = f.x + (f.w - totalW) / 2;
   const out: string[] = [];
+  if (position === 'b') {
+    // Default: horizontal row centered at the bottom.
+    const itemPx = Math.min(140, f.w / names.length);
+    const totalW = itemPx * names.length;
+    const startX = f.x + (f.w - totalW) / 2;
+    for (let i = 0; i < names.length; i++) {
+      const cx = startX + i * itemPx;
+      const swatchX = cx + 4;
+      const swatchY = f.legendY - 4;
+      const labelX = swatchX + 14;
+      out.push(
+        `<rect x="${px(swatchX)}" y="${px(swatchY)}" width="9" height="9" fill="${colors[i % colors.length]}"/>`,
+        `<text x="${px(labelX)}" y="${px(f.legendY)}" dominant-baseline="middle" font-family="sans-serif" font-size="11" fill="#374151">${escapeXml(names[i] ?? `Series ${i + 1}`)}</text>`,
+      );
+    }
+    return out.join('');
+  }
+  if (position === 't') {
+    const itemPx = Math.min(140, f.w / names.length);
+    const totalW = itemPx * names.length;
+    const startX = f.x + (f.w - totalW) / 2;
+    const yTop = f.y + 4;
+    for (let i = 0; i < names.length; i++) {
+      const cx = startX + i * itemPx;
+      out.push(
+        `<rect x="${px(cx + 4)}" y="${px(yTop)}" width="9" height="9" fill="${colors[i % colors.length]}"/>`,
+        `<text x="${px(cx + 18)}" y="${px(yTop + 8)}" dominant-baseline="middle" font-family="sans-serif" font-size="11" fill="#374151">${escapeXml(names[i] ?? `Series ${i + 1}`)}</text>`,
+      );
+    }
+    return out.join('');
+  }
+  // Right / Top-Right / Left — vertical stack along the chosen edge.
+  const lineH = 14;
+  const yStart = f.y + 12;
+  const xCol =
+    position === 'l' ? f.x + 6 : position === 'tr' ? f.x + f.w - 100 : /* 'r' */ f.x + f.w - 100;
   for (let i = 0; i < names.length; i++) {
-    const cx = startX + i * itemPx;
-    const swatchX = cx + 4;
-    const swatchY = f.legendY - 4;
-    const labelX = swatchX + 14;
+    const yp = yStart + i * lineH;
     out.push(
-      `<rect x="${px(swatchX)}" y="${px(swatchY)}" width="9" height="9" fill="${colors[i % colors.length]}"/>`,
-    );
-    out.push(
-      `<text x="${px(labelX)}" y="${px(f.legendY)}" dominant-baseline="middle" font-family="sans-serif" font-size="11" fill="#374151">${escapeXml(names[i] ?? `Series ${i + 1}`)}</text>`,
+      `<rect x="${px(xCol)}" y="${px(yp - 4)}" width="9" height="9" fill="${colors[i % colors.length]}"/>`,
+      `<text x="${px(xCol + 14)}" y="${px(yp + 4)}" dominant-baseline="middle" font-family="sans-serif" font-size="11" fill="#374151">${escapeXml(names[i] ?? `Series ${i + 1}`)}</text>`,
     );
   }
   return out.join('');
@@ -3176,7 +3205,14 @@ const renderChart = (
     axes,
     plot,
     emptyHint,
-    renderChartLegend(f, seriesNamesForLegend, seriesColorsForLegend),
+    spec.legend?.position === null
+      ? ''
+      : renderChartLegend(
+          f,
+          seriesNamesForLegend,
+          seriesColorsForLegend,
+          spec.legend?.position ?? 'b',
+        ),
     '</g>',
   ].join('');
 };

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -457,6 +457,22 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     }
   }
 
+  // <c:legend> sits on the chart element (not the plotArea). Read the
+  // position; PowerPoint defaults to 'r' (right) when the element is
+  // present but has no legendPos. Absent legend element means renderers
+  // fall back to whatever they show by default.
+  let legend: ChartSpec['legend'];
+  const legendEl = firstChildElement(chart, qname('c', 'legend', NS_C));
+  if (legendEl) {
+    const posEl = firstChildElement(legendEl, qname('c', 'legendPos', NS_C));
+    const tok = posEl ? getAttrValue(posEl, ATTR_VAL) : null;
+    if (tok === 'r' || tok === 't' || tok === 'b' || tok === 'l' || tok === 'tr') {
+      legend = { position: tok };
+    } else {
+      legend = { position: 'r' };
+    }
+  }
+
   return {
     kind,
     categories,
@@ -467,5 +483,6 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     ...(grouping !== undefined ? { grouping } : {}),
     ...(gapWidthPct !== undefined ? { gapWidthPct } : {}),
     ...(overlapPct !== undefined ? { overlapPct } : {}),
+    ...(legend !== undefined ? { legend } : {}),
   };
 };

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -117,4 +117,13 @@ export interface ChartSpec {
    * Defaults to 0 (clustered) / 100 (stacked).
    */
   readonly overlapPct?: number;
+  /**
+   * Optional legend configuration. `position` mirrors
+   * `<c:legend><c:legendPos val="…"/>` — `'r'` (right) is the default,
+   * `'t'`, `'b'`, `'l'`, `'tr'` (top-right) the other tokens. `null`
+   * for `position` means no legend at all (the chart explicitly hides
+   * it). `undefined` overall means the chart didn't author a legend
+   * element — renderers should fall back to their own default.
+   */
+  readonly legend?: { position: 'r' | 't' | 'b' | 'l' | 'tr' | null };
 }


### PR DESCRIPTION
ChartSpec.legend reads <c:legendPos>. Playground renders the legend at the requested edge.