### PR TITLE
feat(chart): Excel quoted-literal prefix in axis numFmt

### DIFF
--- a/.changeset/chart-numfmt-quoted.md
+++ b/.changeset/chart-numfmt-quoted.md
@@ -1,0 +1,8 @@
+---
+'pptx-kit': minor
+---
+
+feat(chart): axis number formats now accept Excel's `"$"#,##0`
+quoted-literal prefix / suffix syntax. PowerPoint typically emits
+currency as `"$"#,##0` (or `"\$"#,##0`) rather than the bare `$`
+form, so the previous detection missed it.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -2417,22 +2417,35 @@ const formatTick = (v: number): string => {
 // Unrecognised formats fall through to formatTick.
 const formatAxisLabel = (v: number, formatCode: string | undefined): string => {
   if (!formatCode) return formatTick(v);
-  if (formatCode.includes('%')) {
-    // Strip surrounding chars except the % position; compute decimals
-    // from the format's fractional spec.
-    const decMatch = /0\.(0+)%/.exec(formatCode);
+  // Strip Excel "literal" quoted text. `"\$"#,##0` and `"$"#,##0`
+  // are both common encodings of "dollar prefix then formatted number".
+  let prefix = '';
+  let suffix = '';
+  let body = formatCode;
+  // Leading quoted literal (e.g. "$" or "\$").
+  const leadMatch = /^"((?:\\.|[^"\\])*)"/.exec(body);
+  if (leadMatch) {
+    prefix = leadMatch[1]!.replace(/\\(.)/g, '$1');
+    body = body.slice(leadMatch[0].length);
+  } else if (body.startsWith('$') || body.startsWith('¥') || /^[£€]/.test(body)) {
+    prefix = body[0]!;
+    body = body.slice(1);
+  }
+  // Trailing quoted literal (rarely a unit suffix like "kg").
+  const tailMatch = /"((?:\\.|[^"\\])*)"$/.exec(body);
+  if (tailMatch) {
+    suffix = tailMatch[1]!.replace(/\\(.)/g, '$1');
+    body = body.slice(0, body.length - tailMatch[0].length);
+  }
+  if (body.includes('%')) {
+    const decMatch = /0\.(0+)%/.exec(body);
     const dec = decMatch ? decMatch[1]!.length : 0;
-    return `${(v * 100).toFixed(dec)}%`;
+    return prefix + `${(v * 100).toFixed(dec)}%` + suffix;
   }
-  if (formatCode.startsWith('$') || formatCode.startsWith('¥') || /^[£€]/.test(formatCode)) {
-    const prefix = formatCode[0]!;
-    const body = formatCode.slice(1);
-    return prefix + formatWithGrouping(v, body);
+  if (body.includes('#,##') || /\.(0+)/.test(body) || /^0+$/.test(body)) {
+    return prefix + formatWithGrouping(v, body) + suffix;
   }
-  if (formatCode.includes('#,##')) {
-    return formatWithGrouping(v, formatCode);
-  }
-  return formatTick(v);
+  return prefix + formatTick(v) + suffix;
 };
 
 const formatWithGrouping = (v: number, fmt: string): string => {


### PR DESCRIPTION
PowerPoint emits currency formats as `"$"#,##0`; strip the quoted-literal and re-attach the prefix.