### PR TITLE
feat(chart): per-series line width + dash

### DIFF
--- a/.changeset/series-line-stroke.md
+++ b/.changeset/series-line-stroke.md
@@ -1,0 +1,9 @@
+---
+'pptx-kit': minor
+---
+
+feat(chart): `ChartSeries.lineWidthEmu` and `lineDash` read
+`<c:ser><c:spPr><a:ln>` per-series stroke width and preset dash.
+Playground line / area renderer uses the authored stroke width
+(scaled to px) and projects the preset dash to the same
+`stroke-dasharray` cadence shape strokes use.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -3079,8 +3079,22 @@ const renderLineChart = (
         .join(' ');
       out.push(`<path d="${dPath} ${back} Z" fill="${color}" fill-opacity="0.55" stroke="none"/>`);
     }
+    // Authored line width / dash on the series (<c:ser><c:spPr><a:ln>).
+    const lineWPx = series.lineWidthEmu ? Math.max(0.3, series.lineWidthEmu / EMU_PER_PX) : 1.5;
+    const dashAttr = series.lineDash
+      ? (() => {
+          const sw = lineWPx;
+          const pat = DASH_PATTERNS[series.lineDash!];
+          if (!pat) return '';
+          const arr = pat
+            .split(' ')
+            .map((n) => (Number.parseFloat(n) * sw).toFixed(2))
+            .join(' ');
+          return ` stroke-dasharray="${arr}"`;
+        })()
+      : '';
     out.push(
-      `<path d="${dPath}" fill="none" stroke="${color}" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round"/>`,
+      `<path d="${dPath}" fill="none" stroke="${color}" stroke-width="${lineWPx.toFixed(2)}" stroke-linejoin="round" stroke-linecap="round"${dashAttr}/>`,
     );
     if (!isStacked) {
       // Data point markers — only meaningful on the clustered layout.

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -275,6 +275,26 @@ const readSeriesColor = (ser: XmlElement): string | undefined => {
   return v !== null ? `#${v.toUpperCase()}` : undefined;
 };
 
+// Per-series line stroke width + dash from <c:ser><c:spPr><a:ln>.
+const readSeriesLineProps = (ser: XmlElement): { lineWidthEmu?: number; lineDash?: string } => {
+  const spPr = firstChildElement(ser, NAME_SP_PR_C);
+  if (!spPr) return {};
+  const ln = firstChildElement(spPr, qname('a', 'ln', NS_A));
+  if (!ln) return {};
+  const out: { lineWidthEmu?: number; lineDash?: string } = {};
+  const w = getAttrValue(ln, qname('', 'w', ''));
+  if (w !== null) {
+    const n = Number.parseInt(w, 10);
+    if (Number.isFinite(n) && n > 0) out.lineWidthEmu = n;
+  }
+  const prstDash = firstChildElement(ln, qname('a', 'prstDash', NS_A));
+  if (prstDash) {
+    const v = getAttrValue(prstDash, ATTR_VAL);
+    if (v !== null) out.lineDash = v;
+  }
+  return out;
+};
+
 const readTitle = (chart: XmlElement): string | undefined => {
   const title = firstChildElement(chart, NAME_TITLE);
   if (!title) return undefined;
@@ -351,6 +371,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     }
     const values = valEl !== null ? readNumRef(valEl) : null;
     const color = readSeriesColor(ser);
+    const { lineWidthEmu, lineDash } = readSeriesLineProps(ser);
     // <c:dPt> data-point overrides — sparse map idx → color.
     const pointColors = readDataPointColors(ser);
     // <c:smooth val="1"/> — line / area / scatter only.
@@ -379,6 +400,8 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
       name,
       values: values ?? [],
       ...(color !== undefined ? { color } : {}),
+      ...(lineWidthEmu !== undefined ? { lineWidthEmu } : {}),
+      ...(lineDash !== undefined ? { lineDash } : {}),
       ...(pointColors !== undefined ? { pointColors } : {}),
       ...(smoothEl !== null ? { smooth } : {}),
       ...(trendline !== undefined ? { trendline } : {}),

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -22,6 +22,18 @@ export interface ChartSeries {
   /** Optional `#RRGGBB` fill override. Defaults to the theme's accent palette. */
   readonly color?: string;
   /**
+   * Optional line stroke width in EMU (`<c:ser><c:spPr><a:ln w="…"/>`).
+   * Only meaningful for line / area / scatter series. Default falls
+   * back to the renderer's own pick.
+   */
+  readonly lineWidthEmu?: number;
+  /**
+   * Optional line dash style token (`<c:ser><c:spPr><a:ln><a:prstDash
+   * val="…"/>`), e.g. `'dash'`, `'dot'`, `'sysDash'`. Only
+   * meaningful for line / area / scatter series.
+   */
+  readonly lineDash?: string;
+  /**
    * Optional per-data-point color overrides, indexed by point index
    * (`<c:dPt><c:idx val="N"/><c:spPr><a:solidFill>…`). Sparse — only
    * the indices that author an override appear. Pie / doughnut decks


### PR DESCRIPTION
Read <c:ser><c:spPr><a:ln> width and prstDash, apply in playground line / area.