### PR TITLE
feat(chart): per-series markers

### DIFF
--- a/.changeset/series-markers.md
+++ b/.changeset/series-markers.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat(chart): per-series marker symbol + size.
+`ChartSeries.markerSymbol` / `markerSizePt` read `<c:ser><c:marker>`
+(`<c:symbol val="…"/>` + `<c:size val="N"/>`). Playground line / area
+renderer emits the matching SVG glyph at each data point — circle /
+square / diamond / triangle / star / x / plus / dash / dot — sized
+per the authored point value. `none` hides the markers.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -102,6 +102,7 @@ import {
   isTableShape,
   type PresentationData,
   type PresentationTheme,
+  type ChartSeries,
   type ChartSpec,
   type GradientFillOptions,
   type ShapeBounds,
@@ -2891,6 +2892,50 @@ const smoothPath = (pts: ReadonlyArray<[number, number]>): string => {
   return parts.join(' ');
 };
 
+// Per-series data-point marker glyph. `symbol` mirrors ECMA-376's
+// ST_MarkerStyle (subset). `auto` resolves to a small filled circle.
+const seriesMarker = (
+  symbol: NonNullable<ChartSeries['markerSymbol']>,
+  cx: number,
+  cy: number,
+  r: number,
+  color: string,
+): string => {
+  switch (symbol) {
+    case 'square':
+      return `<rect x="${px(cx - r)}" y="${px(cy - r)}" width="${px(r * 2)}" height="${px(r * 2)}" fill="${color}"/>`;
+    case 'diamond':
+      return `<polygon points="${px(cx)},${px(cy - r)} ${px(cx + r)},${px(cy)} ${px(cx)},${px(cy + r)} ${px(cx - r)},${px(cy)}" fill="${color}"/>`;
+    case 'triangle':
+      return `<polygon points="${px(cx)},${px(cy - r)} ${px(cx + r)},${px(cy + r)} ${px(cx - r)},${px(cy + r)}" fill="${color}"/>`;
+    case 'star':
+      // 5-point star, rough; good enough at marker scale.
+      return `<polygon points="${(() => {
+        const pts: string[] = [];
+        for (let i = 0; i < 10; i++) {
+          const ang = -Math.PI / 2 + (i * Math.PI) / 5;
+          const rr = i % 2 === 0 ? r : r * 0.45;
+          pts.push(`${px(cx + rr * Math.cos(ang))},${px(cy + rr * Math.sin(ang))}`);
+        }
+        return pts.join(' ');
+      })()}" fill="${color}"/>`;
+    case 'x':
+      return `<g stroke="${color}" stroke-width="1.2" stroke-linecap="round"><line x1="${px(cx - r)}" y1="${px(cy - r)}" x2="${px(cx + r)}" y2="${px(cy + r)}"/><line x1="${px(cx - r)}" y1="${px(cy + r)}" x2="${px(cx + r)}" y2="${px(cy - r)}"/></g>`;
+    case 'plus':
+      return `<g stroke="${color}" stroke-width="1.2" stroke-linecap="round"><line x1="${px(cx - r)}" y1="${px(cy)}" x2="${px(cx + r)}" y2="${px(cy)}"/><line x1="${px(cx)}" y1="${px(cy - r)}" x2="${px(cx)}" y2="${px(cy + r)}"/></g>`;
+    case 'dash':
+      return `<line x1="${px(cx - r)}" y1="${px(cy)}" x2="${px(cx + r)}" y2="${px(cy)}" stroke="${color}" stroke-width="${Math.max(1.5, r * 0.6).toFixed(2)}" stroke-linecap="round"/>`;
+    case 'dot':
+      return `<circle cx="${px(cx)}" cy="${px(cy)}" r="${(r * 0.6).toFixed(2)}" fill="${color}"/>`;
+    case 'picture':
+    case 'auto':
+    case 'circle':
+    case 'none':
+    default:
+      return `<circle cx="${px(cx)}" cy="${px(cy)}" r="${px(r)}" fill="${color}"/>`;
+  }
+};
+
 // Trim long decimals; large numbers keep their integer form.
 const formatChartValue = (v: number): string => {
   if (!Number.isFinite(v)) return '';
@@ -3098,8 +3143,16 @@ const renderLineChart = (
     );
     if (!isStacked) {
       // Data point markers — only meaningful on the clustered layout.
-      for (const [xp, yp] of pts) {
-        out.push(`<circle cx="${px(xp)}" cy="${px(yp)}" r="2.2" fill="${color}"/>`);
+      // markerSymbol='none' hides the markers; everything else picks a
+      // shape and the marker size from the series (default ~5pt → ~2.2
+      // radius for compatibility with the previous render).
+      const symbol = series.markerSymbol ?? 'auto';
+      if (symbol !== 'none') {
+        const size = series.markerSizePt ?? 5;
+        const r = Math.max(1, size * 0.5);
+        for (const [xp, yp] of pts) {
+          out.push(seriesMarker(symbol, xp, yp, r, color));
+        }
       }
     }
     // Trendline overlay per series (only meaningful on the clustered

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -275,6 +275,44 @@ const readSeriesColor = (ser: XmlElement): string | undefined => {
   return v !== null ? `#${v.toUpperCase()}` : undefined;
 };
 
+// Per-series marker symbol + size from <c:ser><c:marker>.
+const readSeriesMarker = (
+  ser: XmlElement,
+): { markerSymbol?: ChartSeries['markerSymbol']; markerSizePt?: number } => {
+  const m = firstChildElement(ser, qname('c', 'marker', NS_C));
+  if (!m) return {};
+  const out: { markerSymbol?: ChartSeries['markerSymbol']; markerSizePt?: number } = {};
+  const symEl = firstChildElement(m, qname('c', 'symbol', NS_C));
+  if (symEl) {
+    const v = getAttrValue(symEl, ATTR_VAL);
+    if (
+      v === 'none' ||
+      v === 'auto' ||
+      v === 'circle' ||
+      v === 'square' ||
+      v === 'diamond' ||
+      v === 'triangle' ||
+      v === 'star' ||
+      v === 'x' ||
+      v === 'plus' ||
+      v === 'dash' ||
+      v === 'dot' ||
+      v === 'picture'
+    ) {
+      out.markerSymbol = v;
+    }
+  }
+  const sizeEl = firstChildElement(m, qname('c', 'size', NS_C));
+  if (sizeEl) {
+    const v = getAttrValue(sizeEl, ATTR_VAL);
+    if (v !== null) {
+      const n = Number.parseInt(v, 10);
+      if (Number.isFinite(n) && n > 0) out.markerSizePt = n;
+    }
+  }
+  return out;
+};
+
 // Per-series line stroke width + dash from <c:ser><c:spPr><a:ln>.
 const readSeriesLineProps = (ser: XmlElement): { lineWidthEmu?: number; lineDash?: string } => {
   const spPr = firstChildElement(ser, NAME_SP_PR_C);
@@ -372,6 +410,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     const values = valEl !== null ? readNumRef(valEl) : null;
     const color = readSeriesColor(ser);
     const { lineWidthEmu, lineDash } = readSeriesLineProps(ser);
+    const { markerSymbol, markerSizePt } = readSeriesMarker(ser);
     // <c:dPt> data-point overrides — sparse map idx → color.
     const pointColors = readDataPointColors(ser);
     // <c:smooth val="1"/> — line / area / scatter only.
@@ -402,6 +441,8 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
       ...(color !== undefined ? { color } : {}),
       ...(lineWidthEmu !== undefined ? { lineWidthEmu } : {}),
       ...(lineDash !== undefined ? { lineDash } : {}),
+      ...(markerSymbol !== undefined ? { markerSymbol } : {}),
+      ...(markerSizePt !== undefined ? { markerSizePt } : {}),
       ...(pointColors !== undefined ? { pointColors } : {}),
       ...(smoothEl !== null ? { smooth } : {}),
       ...(trendline !== undefined ? { trendline } : {}),

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -34,6 +34,30 @@ export interface ChartSeries {
    */
   readonly lineDash?: string;
   /**
+   * Optional marker style for line / scatter series (`<c:ser><c:marker>`).
+   * `none` hides the markers; the others render the matching glyph at
+   * each data point. Defaults to `auto`, which renderers map to a small
+   * filled circle.
+   */
+  readonly markerSymbol?:
+    | 'none'
+    | 'auto'
+    | 'circle'
+    | 'square'
+    | 'diamond'
+    | 'triangle'
+    | 'star'
+    | 'x'
+    | 'plus'
+    | 'dash'
+    | 'dot'
+    | 'picture';
+  /**
+   * Marker size in points (`<c:marker><c:size val="N"/>`). PowerPoint
+   * default ~5. Only meaningful when `markerSymbol` isn't `none`.
+   */
+  readonly markerSizePt?: number;
+  /**
    * Optional per-data-point color overrides, indexed by point index
    * (`<c:dPt><c:idx val="N"/><c:spPr><a:solidFill>…`). Sparse — only
    * the indices that author an override appear. Pie / doughnut decks


### PR DESCRIPTION
ChartSeries.markerSymbol + markerSizePt. Playground emits the matching glyph per data point.