### PR TITLE
feat: getSlideMasterPartName

### DIFF
--- a/.changeset/slide-master-part-name.md
+++ b/.changeset/slide-master-part-name.md
@@ -1,0 +1,9 @@
+---
+'pptx-kit': minor
+---
+
+feat: `getSlideMasterPartName(slide)` returns the part-name of the
+slide master the slide inherits from. Useful for multi-master decks
+where different slides live under different brand templates and the
+caller needs to scope theme / fontScheme / clrMap lookups to the
+correct master.

--- a/src/api/fn.ts
+++ b/src/api/fn.ts
@@ -2819,6 +2819,27 @@ export const getSlideMasterCount = (pres: PresentationData): number => {
  * Returns an empty array when `presentation.xml` or its `.rels`
  * are missing.
  */
+/**
+ * Returns the part name of the slide master a slide inherits from
+ * (`/ppt/slideMasters/slideMaster1.xml`), or `null` when the slide
+ * has no layout or its layout has no master rel.
+ *
+ * Useful for multi-master decks where different slides live under
+ * different brand templates and the caller needs to scope theme /
+ * fontScheme / clrMap lookups to the correct master.
+ */
+export const getSlideMasterPartName = (slide: SlideData): string | null => {
+  const layout = getSlideLayout(slide);
+  if (!layout) return null;
+  const pkg = slide[INTERNAL_PACKAGE];
+  const layoutPartName = partName(layout[LAYOUT_PART_NAME]);
+  const layoutRels = pkg.getRels(layoutPartName);
+  if (!layoutRels) return null;
+  const masterRel = layoutRels.items.find((r) => r.type === REL_TYPES.slideMaster);
+  if (!masterRel) return null;
+  return resolveTarget(layoutPartName, masterRel.target);
+};
+
 export const getSlideMasterPartNames = (pres: PresentationData): ReadonlyArray<string> => {
   const pkg = pres[INTERNAL_PACKAGE];
   const presPart = pkg.getPart(PRES_PART_NAME);

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -297,6 +297,7 @@ export {
   getSlideLayouts,
   getSlideLayoutType,
   getSlideMasterCount,
+  getSlideMasterPartName,
   getSlideMasterPartNames,
   getSlideMediaPartNames,
   getSlideNotes,


### PR DESCRIPTION
Walk slide → layout → master rel for the actual master a slide inherits from.