### PR TITLE
feat(site/playground): cascade pattern bg through layout/master

### DIFF
--- a/.changeset/bg-pattern-cascade-render.md
+++ b/.changeset/bg-pattern-cascade-render.md
@@ -1,0 +1,8 @@
+---
+'pptx-kit': minor
+---
+
+feat(site/playground): apply the 3-level pattern bg cascade. When the
+slide reports `'pattern'` but doesn't author the actual pattern preset,
+the renderer now walks slide → layout → master pattern-fill readers,
+paralleling the gradient cascade.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -89,8 +89,10 @@ import {
   getSlideBackgroundPatternFill,
   getSlideLayout,
   getSlideLayoutBackground,
+  getSlideLayoutBackgroundPatternFill,
   getSlideLayoutBackgroundShapes,
   getSlideMasterBackground,
+  getSlideMasterBackgroundPatternFill,
   getSlideShapes,
   getSlideSize,
   getTableCellAlignment,
@@ -4231,7 +4233,14 @@ export const renderSlideSvg = (pres: PresentationData, slide: SlideData): string
       bgGradient = `<rect width="${E(W)}" height="${E(H)}" fill="${built.fillAttr}"/>`;
     }
   } else if (bg.kind === 'pattern') {
-    const pat = getSlideBackgroundPatternFill(pres, slide);
+    let pat = getSlideBackgroundPatternFill(pres, slide);
+    if (!pat) {
+      const layout = getSlideLayout(slide);
+      if (layout) {
+        pat = getSlideLayoutBackgroundPatternFill(pres, layout);
+        if (!pat) pat = getSlideMasterBackgroundPatternFill(pres, layout);
+      }
+    }
     if (pat) {
       const built = patternDef(pat);
       bgGradientDefs += built.defs;


### PR DESCRIPTION
## Summary
- Slide background `'pattern'` now falls back to layout, then master, matching the gradient cascade.
- Uses the readers shipped in #56.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (785 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)