### PR TITLE
feat: chart data labels honor <c:dLbls><c:numFmt>

### DIFF
--- a/.changeset/chart-datalabels-number-format.md
+++ b/.changeset/chart-datalabels-number-format.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: chart data labels honor `<c:dLbls><c:numFmt formatCode="…"/>`.
+`ChartDataLabels.numberFormat` exposes the format code on both
+chart-level and per-series toggle groups, and the playground renderer
+projects value labels through the same Excel-format subset the value
+axis already supports (`"0%"`, `"$#,##0"`, `"0.00"`, etc). Per-series
+formats win over the chart-level default.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -2819,7 +2819,9 @@ const renderColumnChart = (
         );
         if (showLabelFor(s) && Math.abs(v) > 0) {
           const labelY = (y0 + y1) / 2 + 3;
-          const labelText = isPercent ? `${Math.round(v * 100)}%` : formatChartValue(v);
+          const labelText = isPercent
+            ? `${Math.round(v * 100)}%`
+            : formatDataLabelValue(spec, s, v);
           out.push(
             `<text x="${px(x0 + barW / 2)}" y="${px(labelY)}" text-anchor="middle" font-family="sans-serif" font-size="9" fill="#FFFFFF" font-weight="600">${labelText}</text>`,
           );
@@ -2852,7 +2854,7 @@ const renderColumnChart = (
         if (showLabelFor(s)) {
           const labelY = v >= 0 ? y0 - 2 : y0 + h + 9;
           out.push(
-            `<text x="${px(x0 + barW / 2)}" y="${px(labelY)}" text-anchor="middle" font-family="sans-serif" font-size="9" fill="#374151">${formatChartValue(v)}</text>`,
+            `<text x="${px(x0 + barW / 2)}" y="${px(labelY)}" text-anchor="middle" font-family="sans-serif" font-size="9" fill="#374151">${formatDataLabelValue(spec, s, v)}</text>`,
           );
         }
       }
@@ -3051,6 +3053,15 @@ const formatChartValue = (v: number): string => {
   return v.toFixed(2).replace(/\.?0+$/, '');
 };
 
+// Resolves the data-label number format (`<c:dLbls><c:numFmt>`) with the
+// per-series override winning over the chart-level default, and projects
+// `v` through it. Falls back to `formatChartValue` when neither layer
+// authors a format.
+const formatDataLabelValue = (spec: ChartSpec, seriesIdx: number, v: number): string => {
+  const nf = spec.series[seriesIdx]?.dataLabels?.numberFormat ?? spec.dataLabels?.numberFormat;
+  return nf ? formatAxisLabel(v, nf) : formatChartValue(v);
+};
+
 const renderBarChart = (f: ChartFrame, spec: ChartSpec, colors: ReadonlyArray<string>): string => {
   const N = pointCount(spec);
   if (N === 0 || spec.series.length === 0) return '';
@@ -3110,7 +3121,9 @@ const renderBarChart = (f: ChartFrame, spec: ChartSpec, colors: ReadonlyArray<st
         );
         if (showLabelForBar(s) && Math.abs(v) > 0) {
           const labelX = (x0 + x1) / 2;
-          const labelText = isPercent ? `${Math.round(v * 100)}%` : formatChartValue(v);
+          const labelText = isPercent
+            ? `${Math.round(v * 100)}%`
+            : formatDataLabelValue(spec, s, v);
           out.push(
             `<text x="${px(labelX)}" y="${px(y0 + barH / 2 + 3)}" text-anchor="middle" font-family="sans-serif" font-size="9" fill="#FFFFFF" font-weight="600">${labelText}</text>`,
           );
@@ -3140,7 +3153,7 @@ const renderBarChart = (f: ChartFrame, spec: ChartSpec, colors: ReadonlyArray<st
           const labelX = v >= 0 ? x0 + w + 2 : x0 - 2;
           const anchor = v >= 0 ? 'start' : 'end';
           out.push(
-            `<text x="${px(labelX)}" y="${px(y0 + barH / 2 + 3)}" text-anchor="${anchor}" font-family="sans-serif" font-size="9" fill="#374151">${formatChartValue(v)}</text>`,
+            `<text x="${px(labelX)}" y="${px(y0 + barH / 2 + 3)}" text-anchor="${anchor}" font-family="sans-serif" font-size="9" fill="#374151">${formatDataLabelValue(spec, s, v)}</text>`,
           );
         }
       }
@@ -3413,7 +3426,7 @@ const renderPieChart = (
     const labelX = cx + labelR * Math.cos(labelMid);
     const labelY = cy + labelR * Math.sin(labelMid);
     const labels: string[] = [];
-    if (spec.dataLabels?.showValue) labels.push(formatChartValue(v));
+    if (spec.dataLabels?.showValue) labels.push(formatDataLabelValue(spec, 0, v));
     if (spec.dataLabels?.showPercent) labels.push(`${((v / total) * 100).toFixed(0)}%`);
     if (spec.dataLabels?.showCategory) {
       const catLabel = spec.categories[i];

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -431,11 +431,18 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
         const v = getAttrValue(el, ATTR_VAL);
         return v === null || v === '1' || v === 'true';
       };
+      const nfEl = firstChildElement(serDLblsEl, qname('c', 'numFmt', NS_C));
+      let numberFormat: string | undefined;
+      if (nfEl) {
+        const fc = getAttrValue(nfEl, qname('', 'formatCode', ''));
+        if (fc !== null && fc.length > 0 && fc !== 'General') numberFormat = fc;
+      }
       serDataLabels = {
         showValue: readToggle('showVal'),
         showCategory: readToggle('showCatName'),
         showSeriesName: readToggle('showSerName'),
         showPercent: readToggle('showPercent'),
+        ...(numberFormat !== undefined ? { numberFormat } : {}),
       };
     }
     series.push({
@@ -471,11 +478,18 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
       // Absent val attribute defaults to true per the schema's CT_Boolean.
       return v === null || v === '1' || v === 'true';
     };
+    const nfEl = firstChildElement(dLbls, qname('c', 'numFmt', NS_C));
+    let numberFormat: string | undefined;
+    if (nfEl) {
+      const fc = getAttrValue(nfEl, qname('', 'formatCode', ''));
+      if (fc !== null && fc.length > 0 && fc !== 'General') numberFormat = fc;
+    }
     dataLabels = {
       showValue: readToggle('showVal'),
       showCategory: readToggle('showCatName'),
       showSeriesName: readToggle('showSerName'),
       showPercent: readToggle('showPercent'),
+      ...(numberFormat !== undefined ? { numberFormat } : {}),
     };
   }
 

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -117,6 +117,13 @@ export interface ChartDataLabels {
   readonly showSeriesName: boolean;
   /** Percentage of total (for pie / doughnut). */
   readonly showPercent: boolean;
+  /**
+   * Number-format code from `<c:dLbls><c:numFmt formatCode="…"/>`. When
+   * set, value labels are projected through this Excel-style format
+   * (same subset the value axis honors: `"0%"`, `"#,##0"`, `"$#,##0"`,
+   * `"0.00"`). Independent of `ChartAxisScaling.numberFormat`.
+   */
+  readonly numberFormat?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- `ChartDataLabels.numberFormat` carries `<c:dLbls><c:numFmt formatCode>` at both chart-level and per-series scopes.
- Renderer projects value labels through the existing format subset (\`0%\`, \`\$#,##0\`, \`0.00\`, etc).

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (785 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)