### PR TITLE
feat(site/playground): line / area chart value data labels

### DIFF
--- a/.changeset/line-chart-data-labels.md
+++ b/.changeset/line-chart-data-labels.md
@@ -1,0 +1,9 @@
+---
+'pptx-kit': minor
+---
+
+feat(site/playground): line and area charts paint per-point value labels
+when `<c:dLbls><c:showVal val="1"/>` is set. Labels sit just above each
+marker and route through the chart number-format projector (so
+`<c:numFmt formatCode="0%"/>` etc. apply the same as on bar / pie).
+Honors the per-series → chart-level cascade.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -3319,6 +3319,22 @@ const renderLineChart = (
         }
       }
     }
+    // Per-point value labels for line / area charts. Sits above the
+    // marker so the line / fill stays unobscured. Honors the same
+    // per-series → chart-level cascade as bar / pie.
+    const showLineLabel = series.dataLabels?.showValue ?? spec.dataLabels?.showValue ?? false;
+    if (showLineLabel) {
+      for (let c = 0; c < N; c++) {
+        const p = ptsRaw[c];
+        if (p === null) continue;
+        const v = series.values[c];
+        if (v === null || v === undefined || !Number.isFinite(v)) continue;
+        const [xp, yp] = p;
+        out.push(
+          `<text x="${px(xp)}" y="${px(yp - 5)}" text-anchor="middle" font-family="sans-serif" font-size="9" fill="#374151">${formatDataLabelValue(spec, s, v as number)}</text>`,
+        );
+      }
+    }
     // Trendline overlay per series (only meaningful on the clustered
     // layout — stacked already shows the cumulative shape).
     if (!isStacked && series.trendline) {


### PR DESCRIPTION
## Summary
- Line / area charts now paint per-point value labels when `<c:showVal val=\"1\"/>` is set.
- Labels route through the same number-format projector as bar / pie.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (785 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)