### PR TITLE
feat: pie / doughnut slice explosion

### DIFF
--- a/.changeset/pie-slice-explosion.md
+++ b/.changeset/pie-slice-explosion.md
@@ -1,0 +1,9 @@
+---
+'pptx-kit': minor
+---
+
+feat: pie / doughnut slice explosion. `ChartSeries.pointExplosions`
+exposes the per-data-point pull-out percentage from `<c:dPt><c:explosion val="N"/>`,
+and the playground renderer offsets exploded slices (and their labels)
+outward along the slice mid-angle. Matches the "pulled-out" pie look
+authors get from Excel's "Vary colors by point" toggle.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -3417,30 +3417,39 @@ const renderPieChart = (
     const end = acc + angle;
     acc = end;
     const largeArc = angle > Math.PI ? 1 : 0;
-    const ox1 = cx + radius * Math.cos(start);
-    const oy1 = cy + radius * Math.sin(start);
-    const ox2 = cx + radius * Math.cos(end);
-    const oy2 = cy + radius * Math.sin(end);
+    // <c:dPt><c:explosion val="N"/> shoves the slice outward along the
+    // mid-angle by N% of the radius (PowerPoint clamps to a sane max
+    // around 400, but in practice authors stay 0–60).
+    const explPct = series.pointExplosions?.[i] ?? 0;
+    const explOffset = (explPct / 100) * radius;
+    const midAngle = (start + end) / 2;
+    const sx = cx + Math.cos(midAngle) * explOffset;
+    const sy = cy + Math.sin(midAngle) * explOffset;
+    const ox1 = sx + radius * Math.cos(start);
+    const oy1 = sy + radius * Math.sin(start);
+    const ox2 = sx + radius * Math.cos(end);
+    const oy2 = sy + radius * Math.sin(end);
     // Per-slice color: <c:dPt> override wins, then series.color, then
     // accent palette fallback.
     const dptColor = series.pointColors?.[i];
     const color = dptColor ?? series.color ?? colors[i % colors.length];
     if (doughnut) {
-      const ix1 = cx + innerR * Math.cos(start);
-      const iy1 = cy + innerR * Math.sin(start);
-      const ix2 = cx + innerR * Math.cos(end);
-      const iy2 = cy + innerR * Math.sin(end);
+      const ix1 = sx + innerR * Math.cos(start);
+      const iy1 = sy + innerR * Math.sin(start);
+      const ix2 = sx + innerR * Math.cos(end);
+      const iy2 = sy + innerR * Math.sin(end);
       const d = `M${px(ox1)},${px(oy1)} A${px(radius)},${px(radius)} 0 ${largeArc} 1 ${px(ox2)},${px(oy2)} L${px(ix2)},${px(iy2)} A${px(innerR)},${px(innerR)} 0 ${largeArc} 0 ${px(ix1)},${px(iy1)} Z`;
       out.push(`<path d="${d}" fill="${color}" stroke="#FFFFFF" stroke-width="0.6"/>`);
     } else {
-      const d = `M${px(cx)},${px(cy)} L${px(ox1)},${px(oy1)} A${px(radius)},${px(radius)} 0 ${largeArc} 1 ${px(ox2)},${px(oy2)} Z`;
+      const d = `M${px(sx)},${px(sy)} L${px(ox1)},${px(oy1)} A${px(radius)},${px(radius)} 0 ${largeArc} 1 ${px(ox2)},${px(oy2)} Z`;
       out.push(`<path d="${d}" fill="${color}" stroke="#FFFFFF" stroke-width="0.6"/>`);
     }
     // Pie / doughnut data labels — value or percent at the slice midpoint.
+    // Track the explosion offset so labels move with their slice.
     const labelMid = (start + end) / 2;
     const labelR = doughnut ? (radius + innerR) / 2 : radius * 0.6;
-    const labelX = cx + labelR * Math.cos(labelMid);
-    const labelY = cy + labelR * Math.sin(labelMid);
+    const labelX = sx + labelR * Math.cos(labelMid);
+    const labelY = sy + labelR * Math.sin(labelMid);
     const labels: string[] = [];
     if (spec.dataLabels?.showValue) labels.push(formatDataLabelValue(spec, 0, v));
     if (spec.dataLabels?.showPercent) labels.push(`${((v / total) * 100).toFixed(0)}%`);

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -169,11 +169,20 @@ const readSeriesName = (ser: XmlElement): string => {
   return strs?.[0] ?? '';
 };
 
-// Walks `<c:ser><c:dPt>` overrides and returns a sparse array indexed
-// by point index. Returns `undefined` when no dPt overrides exist.
-const readDataPointColors = (ser: XmlElement): ReadonlyArray<string | null> | undefined => {
-  const out: Array<string | null> = [];
-  let any = false;
+// Walks `<c:ser><c:dPt>` overrides and returns sparse per-point arrays
+// for color (`<c:spPr><a:solidFill><a:srgbClr>`) and explosion
+// (`<c:explosion val="N"/>`). Returns `undefined` for each side when no
+// dPt authors the corresponding attribute.
+const readDataPointOverrides = (
+  ser: XmlElement,
+): {
+  readonly colors: ReadonlyArray<string | null> | undefined;
+  readonly explosions: ReadonlyArray<number | null> | undefined;
+} => {
+  const colors: Array<string | null> = [];
+  const explosions: Array<number | null> = [];
+  let anyColor = false;
+  let anyExplosion = false;
   for (const c of ser.children) {
     if (c.kind !== 'element' || c.name.namespaceURI !== NS_C || c.name.localName !== 'dPt')
       continue;
@@ -184,17 +193,35 @@ const readDataPointColors = (ser: XmlElement): ReadonlyArray<string | null> | un
     const idx = Number.parseInt(idxRaw, 10);
     if (!Number.isFinite(idx) || idx < 0) continue;
     const spPr = firstChildElement(c, NAME_SP_PR_C);
-    if (!spPr) continue;
-    const solidFill = firstChildElement(spPr, NAME_SOLID_FILL);
-    if (!solidFill) continue;
-    const srgb = firstChildElement(solidFill, NAME_SRGB_CLR);
-    if (!srgb) continue;
-    const val = getAttrValue(srgb, ATTR_VAL);
-    if (val === null) continue;
-    out[idx] = `#${val.toUpperCase()}`;
-    any = true;
+    if (spPr) {
+      const solidFill = firstChildElement(spPr, NAME_SOLID_FILL);
+      if (solidFill) {
+        const srgb = firstChildElement(solidFill, NAME_SRGB_CLR);
+        if (srgb) {
+          const val = getAttrValue(srgb, ATTR_VAL);
+          if (val !== null) {
+            colors[idx] = `#${val.toUpperCase()}`;
+            anyColor = true;
+          }
+        }
+      }
+    }
+    const explEl = firstChildElement(c, qname('c', 'explosion', NS_C));
+    if (explEl) {
+      const v = getAttrValue(explEl, ATTR_VAL);
+      if (v !== null) {
+        const n = Number.parseInt(v, 10);
+        if (Number.isFinite(n) && n > 0) {
+          explosions[idx] = n;
+          anyExplosion = true;
+        }
+      }
+    }
   }
-  return any ? out : undefined;
+  return {
+    colors: anyColor ? colors : undefined,
+    explosions: anyExplosion ? explosions : undefined,
+  };
 };
 
 // `<c:trendline>` is a sibling of `<c:val>` inside `<c:ser>`. Read the
@@ -414,8 +441,8 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     const invertEl = firstChildElement(ser, qname('c', 'invertIfNegative', NS_C));
     const invertIfNegative =
       invertEl !== null && getAttrValue(invertEl, ATTR_VAL) !== '0' ? true : undefined;
-    // <c:dPt> data-point overrides — sparse map idx → color.
-    const pointColors = readDataPointColors(ser);
+    // <c:dPt> data-point overrides — sparse maps idx → color / explosion.
+    const { colors: pointColors, explosions: pointExplosions } = readDataPointOverrides(ser);
     // <c:smooth val="1"/> — line / area / scatter only.
     const smoothEl = firstChildElement(ser, qname('c', 'smooth', NS_C));
     const smooth = smoothEl !== null && getAttrValue(smoothEl, ATTR_VAL) !== '0';
@@ -455,6 +482,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
       ...(markerSizePt !== undefined ? { markerSizePt } : {}),
       ...(invertIfNegative !== undefined ? { invertIfNegative } : {}),
       ...(pointColors !== undefined ? { pointColors } : {}),
+      ...(pointExplosions !== undefined ? { pointExplosions } : {}),
       ...(smoothEl !== null ? { smooth } : {}),
       ...(trendline !== undefined ? { trendline } : {}),
       ...(serDataLabels !== undefined ? { dataLabels: serDataLabels } : {}),

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -72,6 +72,13 @@ export interface ChartSeries {
    */
   readonly pointColors?: ReadonlyArray<string | null>;
   /**
+   * Optional per-data-point pie/doughnut slice explosion percentages
+   * (`<c:dPt><c:explosion val="N"/>`). Sparse — only the indices that
+   * author an explosion appear. The value is the radial offset as a
+   * percentage of the slice radius (`25` ≈ a quarter-radius pull-out).
+   */
+  readonly pointExplosions?: ReadonlyArray<number | null>;
+  /**
    * Line-smoothing toggle (`<c:smooth val="1"/>`) — only meaningful for
    * line / scatter / area series. When `true`, the renderer interpolates
    * a smooth curve through the data points instead of straight segments.


### PR DESCRIPTION
## Summary
- `ChartSeries.pointExplosions` carries the per-data-point `<c:explosion val>` percentage.
- Pie / doughnut renderer offsets exploded slices (and their labels) outward along the slice mid-angle.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (785 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)