### PR TITLE
feat: chart title font / color (titleStyle)

### DIFF
--- a/.changeset/chart-title-style.md
+++ b/.changeset/chart-title-style.md
@@ -1,0 +1,11 @@
+---
+'pptx-kit': minor
+---
+
+feat: chart titles honor `<a:rPr>` font / color overrides.
+`ChartSpec.titleStyle` carries the authored size (in pt), bold, italic,
+and fill color extracted from the title's first `<a:r><a:rPr>` (or
+`<a:pPr><a:defRPr>` as fallback). The playground renderer projects
+those through to the SVG `<text>`. Templates that brand their chart
+titles to a non-default size / color finally render with the authored
+look.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -116,6 +116,7 @@ import {
   type PresentationTheme,
   type ChartSeries,
   type ChartSpec,
+  type ChartTextStyle,
   type GradientFillOptions,
   type ShapeBounds,
   type ShapeFill,
@@ -2685,9 +2686,15 @@ const seriesMinMax = (spec: ChartSpec): { min: number; max: number } => {
   return { min, max };
 };
 
-const renderChartTitle = (f: ChartFrame, title: string): string => {
+const renderChartTitle = (f: ChartFrame, title: string, style?: ChartTextStyle): string => {
   if (!title) return '';
-  return `<text x="${px(f.x + f.w / 2)}" y="${px(f.titleY)}" text-anchor="middle" dominant-baseline="middle" font-family="sans-serif" font-size="13" fill="#1F2937" font-weight="600">${escapeXml(title)}</text>`;
+  // Defaults match PowerPoint's stock title look (~14pt semibold dark
+  // gray); authored <a:rPr sz/b/i> + solidFill overrides take over.
+  const sz = style?.sizePt ?? 13;
+  const fill = style?.color ?? '#1F2937';
+  const weight = style?.bold === false ? '400' : '600';
+  const fontStyleAttr = style?.italic ? ' font-style="italic"' : '';
+  return `<text x="${px(f.x + f.w / 2)}" y="${px(f.titleY)}" text-anchor="middle" dominant-baseline="middle" font-family="sans-serif" font-size="${sz.toFixed(1)}" fill="${fill}" font-weight="${weight}"${fontStyleAttr}>${escapeXml(title)}</text>`;
 };
 
 const renderChartLegend = (
@@ -3612,7 +3619,7 @@ const renderChart = (
     spec.plotAreaFill
       ? `<rect x="${px(f.plotX)}" y="${px(f.plotY)}" width="${px(f.plotW)}" height="${px(f.plotH)}" fill="${spec.plotAreaFill}"/>`
       : '',
-    renderChartTitle(f, spec.title ?? ''),
+    renderChartTitle(f, spec.title ?? '', spec.titleStyle),
     axes,
     valueAxisTitleSvg,
     categoryAxisTitleSvg,

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -31,6 +31,7 @@ export type {
   ChartKind,
   ChartSeries,
   ChartSpec,
+  ChartTextStyle,
   ChartTrendline,
 } from '../internal/chartml/index.ts';
 export type { SlideChartData } from './fn.ts';

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -21,6 +21,7 @@ import type {
   ChartKind,
   ChartSeries,
   ChartSpec,
+  ChartTextStyle,
   ChartTrendline,
 } from './types.ts';
 
@@ -380,6 +381,82 @@ const readTitle = (chart: XmlElement): string | undefined => {
   return acc.length > 0 ? acc : undefined;
 };
 
+const NAME_A_RPR = qname('a', 'rPr', NS_A);
+const NAME_A_DEF_RPR = qname('a', 'defRPr', NS_A);
+const NAME_A_PPR = qname('a', 'pPr', NS_A);
+const NAME_A_SRGB = qname('a', 'srgbClr', NS_A);
+
+// Reads `<a:rPr>` / `<a:defRPr>` attributes (size in 100ths of a pt,
+// bold / italic) plus the first solidFill color inside it. Returns an
+// undefined-only style when nothing is authored — callers should drop
+// the style entirely in that case.
+const readRunStyle = (rPr: XmlElement): ChartTextStyle | undefined => {
+  let sizePt: number | undefined;
+  let bold: boolean | undefined;
+  let italic: boolean | undefined;
+  let color: string | undefined;
+  const szRaw = getAttrValue(rPr, qname('', 'sz', ''));
+  if (szRaw !== null) {
+    const n = Number.parseInt(szRaw, 10);
+    if (Number.isFinite(n) && n > 0) sizePt = n / 100;
+  }
+  const bRaw = getAttrValue(rPr, qname('', 'b', ''));
+  if (bRaw !== null) bold = bRaw === '1' || bRaw === 'true';
+  const iRaw = getAttrValue(rPr, qname('', 'i', ''));
+  if (iRaw !== null) italic = iRaw === '1' || iRaw === 'true';
+  const solidFill = firstChildElement(rPr, NAME_SOLID_FILL);
+  if (solidFill) {
+    const srgb = firstChildElement(solidFill, NAME_A_SRGB);
+    if (srgb) {
+      const v = getAttrValue(srgb, ATTR_VAL);
+      if (v !== null) color = `#${v.toUpperCase()}`;
+    }
+  }
+  if (sizePt === undefined && bold === undefined && italic === undefined && color === undefined) {
+    return undefined;
+  }
+  return {
+    ...(sizePt !== undefined ? { sizePt } : {}),
+    ...(bold !== undefined ? { bold } : {}),
+    ...(italic !== undefined ? { italic } : {}),
+    ...(color !== undefined ? { color } : {}),
+  };
+};
+
+// Reads the first authored `<a:rPr>` (or `<a:pPr><a:defRPr>`) inside a
+// chart label's `<c:rich>` block. Used for the chart title (and reusable
+// for axis labels later). Returns `undefined` when nothing is authored.
+const readLabelStyle = (richHost: XmlElement): ChartTextStyle | undefined => {
+  for (const p of allChildElements(richHost, NAME_P_DML)) {
+    for (const r of allChildElements(p, NAME_R_DML)) {
+      const rPr = firstChildElement(r, NAME_A_RPR);
+      if (rPr) {
+        const s = readRunStyle(rPr);
+        if (s) return s;
+      }
+    }
+    const pPr = firstChildElement(p, NAME_A_PPR);
+    if (pPr) {
+      const defRPr = firstChildElement(pPr, NAME_A_DEF_RPR);
+      if (defRPr) {
+        const s = readRunStyle(defRPr);
+        if (s) return s;
+      }
+    }
+  }
+  return undefined;
+};
+
+const readTitleStyle = (chart: XmlElement): ChartTextStyle | undefined => {
+  const title = firstChildElement(chart, NAME_TITLE);
+  if (!title) return undefined;
+  const tx = firstChildElement(title, NAME_TX);
+  if (!tx) return undefined;
+  const rich = firstChildElement(tx, NAME_RICH);
+  if (!rich) return undefined;
+  return readLabelStyle(rich);
+};
+
 /**
  * Parses a `<c:chartSpace>` element into a typed `ChartSpec`. Throws if
  * the root or any required child is missing. Returns `null` only when
@@ -491,6 +568,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
 
   const categories = categoriesFromFirst ?? [];
   const title = readTitle(chart);
+  const titleStyle = readTitleStyle(chart);
 
   // <c:dLbls> can sit either on the plotted-kind element (`barChart`,
   // `lineChart`, …) for chart-level defaults or on each `<c:ser>` for
@@ -765,6 +843,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     categories,
     series,
     ...(title !== undefined ? { title } : {}),
+    ...(titleStyle !== undefined ? { titleStyle } : {}),
     ...(dataLabels !== undefined ? { dataLabels } : {}),
     ...(valueAxis !== undefined ? { valueAxis } : {}),
     ...(grouping !== undefined ? { grouping } : {}),

--- a/src/internal/chartml/index.ts
+++ b/src/internal/chartml/index.ts
@@ -8,6 +8,7 @@ export type {
   ChartKind,
   ChartSeries,
   ChartSpec,
+  ChartTextStyle,
   ChartTrendline,
 } from './types.ts';
 export { buildChartSpaceDoc } from './chart-builder.ts';

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -165,6 +165,23 @@ export interface ChartAxisScaling {
  */
 export type ChartGrouping = 'clustered' | 'stacked' | 'percentStacked' | 'standard';
 
+/**
+ * Authored text style for a chart label (title / axis title / etc.).
+ * Read from the label's first `<a:rPr>` (and `<a:defRPr>` as fallback).
+ * All fields are optional — absent fields mean "fall back to the
+ * renderer's default for this label position."
+ */
+export interface ChartTextStyle {
+  /** Font size in points. From `<a:rPr sz="N"/>` where N is in 100ths of a pt. */
+  readonly sizePt?: number;
+  /** Bold flag from `<a:rPr b="1"/>`. */
+  readonly bold?: boolean;
+  /** Italic flag from `<a:rPr i="1"/>`. */
+  readonly italic?: boolean;
+  /** Fill color as `#RRGGBB` from `<a:rPr><a:solidFill><a:srgbClr/></a:solidFill>`. */
+  readonly color?: string;
+}
+
 /** Full chart specification. */
 export interface ChartSpec {
   readonly kind: ChartKind;
@@ -173,6 +190,8 @@ export interface ChartSpec {
   readonly series: ReadonlyArray<ChartSeries>;
   /** Optional chart title rendered above the plot area. */
   readonly title?: string;
+  /** Optional font / color overrides for the chart title. */
+  readonly titleStyle?: ChartTextStyle;
   /** Optional chart-level data-label toggles. */
   readonly dataLabels?: ChartDataLabels;
   /** Optional value-axis scaling override (min / max). */


### PR DESCRIPTION
## Summary
- New `ChartTextStyle` (sizePt / bold / italic / color) + `ChartSpec.titleStyle`.
- Reader extracts the first authored `<a:rPr>` (or `<a:defRPr>`) inside the chart title.
- Renderer projects size / weight / italic / fill color onto the SVG title.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (785 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)