### PR TITLE
feat: axis title font / color

### DIFF
--- a/.changeset/axis-title-style.md
+++ b/.changeset/axis-title-style.md
@@ -1,0 +1,9 @@
+---
+'pptx-kit': minor
+---
+
+feat: chart axis titles honor authored `<a:rPr>` font / color.
+`ChartSpec.categoryAxisTitleStyle` and `valueAxisTitleStyle` carry the
+same `ChartTextStyle` shape as `titleStyle`. The playground renderer
+projects size / bold / italic / fill onto both axis title labels,
+sharing the helper that drives the chart title.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -3603,12 +3603,20 @@ const renderChart = (
       : '';
 
   // Axis titles — value title is rotated -90° to read along the y-axis
-  // tick stack; category title sits below the x-axis.
+  // tick stack; category title sits below the x-axis. Authored
+  // <a:rPr sz/b/i> + solidFill override the 11pt semibold default.
+  const axisTitleAttrs = (style: ChartTextStyle | undefined): string => {
+    const sz = style?.sizePt ?? 11;
+    const fill = style?.color ?? '#374151';
+    const weight = style?.bold === false ? '400' : '600';
+    const italicAttr = style?.italic ? ' font-style="italic"' : '';
+    return `font-family="sans-serif" font-size="${sz.toFixed(1)}" fill="${fill}" font-weight="${weight}"${italicAttr}`;
+  };
   const valueAxisTitleSvg = spec.valueAxisTitle
-    ? `<text x="${px(f.plotX - 26)}" y="${px(f.plotY + f.plotH / 2)}" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#374151" font-weight="600" transform="rotate(-90 ${px(f.plotX - 26)} ${px(f.plotY + f.plotH / 2)})">${escapeXml(spec.valueAxisTitle)}</text>`
+    ? `<text x="${px(f.plotX - 26)}" y="${px(f.plotY + f.plotH / 2)}" text-anchor="middle" ${axisTitleAttrs(spec.valueAxisTitleStyle)} transform="rotate(-90 ${px(f.plotX - 26)} ${px(f.plotY + f.plotH / 2)})">${escapeXml(spec.valueAxisTitle)}</text>`
     : '';
   const categoryAxisTitleSvg = spec.categoryAxisTitle
-    ? `<text x="${px(f.plotX + f.plotW / 2)}" y="${px(f.plotY + f.plotH + 16)}" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#374151" font-weight="600">${escapeXml(spec.categoryAxisTitle)}</text>`
+    ? `<text x="${px(f.plotX + f.plotW / 2)}" y="${px(f.plotY + f.plotH + 16)}" text-anchor="middle" ${axisTitleAttrs(spec.categoryAxisTitleStyle)}>${escapeXml(spec.categoryAxisTitle)}</text>`
     : '';
   return [
     `<g${transform}>`,

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -447,14 +447,21 @@ const readLabelStyle = (richHost: XmlElement): ChartTextStyle | undefined => {
   return undefined;
 };
 
-const readTitleStyle = (chart: XmlElement): ChartTextStyle | undefined => {
-  const title = firstChildElement(chart, NAME_TITLE);
-  if (!title) return undefined;
-  const tx = firstChildElement(title, NAME_TX);
+// Extracts the authored text style from a `<c:title>` element. Used for
+// both the chart-level title and axis titles, which share the
+// `<c:tx><c:rich>` shape.
+const readTitleStyleOf = (titleEl: XmlElement): ChartTextStyle | undefined => {
+  const tx = firstChildElement(titleEl, NAME_TX);
   if (!tx) return undefined;
   const rich = firstChildElement(tx, NAME_RICH);
   if (!rich) return undefined;
   return readLabelStyle(rich);
+};
+
+const readTitleStyle = (chart: XmlElement): ChartTextStyle | undefined => {
+  const title = firstChildElement(chart, NAME_TITLE);
+  if (!title) return undefined;
+  return readTitleStyleOf(title);
 };
 
 /**
@@ -704,7 +711,9 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
   // use the same rich-text container as the chart title, so reuse
   // readTitle's projection.
   let categoryAxisTitle: string | undefined;
+  let categoryAxisTitleStyle: ChartTextStyle | undefined;
   let valueAxisTitle: string | undefined;
+  let valueAxisTitleStyle: ChartTextStyle | undefined;
   let categoryAxisHidden: boolean | undefined;
   let valueAxisHidden: boolean | undefined;
   let categoryAxisTickLabelSkip: number | undefined;
@@ -730,6 +739,8 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
   if (catAx) {
     const t = readTitle(catAx);
     if (t !== undefined) categoryAxisTitle = t;
+    const catTitleEl = firstChildElement(catAx, NAME_TITLE);
+    if (catTitleEl) categoryAxisTitleStyle = readTitleStyleOf(catTitleEl);
     categoryAxisHidden = isHidden(catAx);
     categoryAxisOrientation = readAxisOrientation(catAx);
     const skipEl = firstChildElement(catAx, qname('c', 'tickLblSkip', NS_C));
@@ -756,6 +767,8 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
   if (valAx) {
     const t = readTitle(valAx);
     if (t !== undefined) valueAxisTitle = t;
+    const valTitleEl = firstChildElement(valAx, NAME_TITLE);
+    if (valTitleEl) valueAxisTitleStyle = readTitleStyleOf(valTitleEl);
     valueAxisHidden = isHidden(valAx);
     valueAxisOrientation = readAxisOrientation(valAx);
     valueAxisMajorGridlines = firstChildElement(valAx, qname('c', 'majorGridlines', NS_C)) !== null;
@@ -857,7 +870,9 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     ...(plotAreaFill !== undefined ? { plotAreaFill } : {}),
     ...(chartAreaFill !== undefined ? { chartAreaFill } : {}),
     ...(categoryAxisTitle !== undefined ? { categoryAxisTitle } : {}),
+    ...(categoryAxisTitleStyle !== undefined ? { categoryAxisTitleStyle } : {}),
     ...(valueAxisTitle !== undefined ? { valueAxisTitle } : {}),
+    ...(valueAxisTitleStyle !== undefined ? { valueAxisTitleStyle } : {}),
     ...(categoryAxisHidden !== undefined ? { categoryAxisHidden } : {}),
     ...(valueAxisHidden !== undefined ? { valueAxisHidden } : {}),
     ...(valueAxisMajorGridlines !== undefined ? { valueAxisMajorGridlines } : {}),

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -209,7 +209,11 @@ export interface ChartSpec {
   readonly chartAreaFill?: string;
   /** Optional axis title text (`<c:catAx><c:title>` / `<c:valAx><c:title>`). */
   readonly categoryAxisTitle?: string;
+  /** Authored font / color on the category-axis title (same `<a:rPr>` shape as `titleStyle`). */
+  readonly categoryAxisTitleStyle?: ChartTextStyle;
   readonly valueAxisTitle?: string;
+  /** Authored font / color on the value-axis title. */
+  readonly valueAxisTitleStyle?: ChartTextStyle;
   /** When `true`, value axis is hidden (`<c:valAx><c:delete val="1"/>`). */
   readonly valueAxisHidden?: boolean;
   /** When `true`, category axis is hidden (`<c:catAx><c:delete val="1"/>`). */


### PR DESCRIPTION
## Summary
- Adds `categoryAxisTitleStyle` and `valueAxisTitleStyle` (same `ChartTextStyle` as `titleStyle`).
- Renderer shares an `axisTitleAttrs` helper to project size / weight / italic / color onto both axis titles.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (785 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)