### PR TITLE
feat: chart legend font / color (legend.textStyle)

### DIFF
--- a/.changeset/legend-text-style.md
+++ b/.changeset/legend-text-style.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: chart legend honors authored `<c:txPr>` font / color.
+`ChartSpec.legend.textStyle` carries the same `ChartTextStyle` shape
+used for the chart title and axis titles. The playground renderer
+projects font-size, bold, italic, and fill color onto every legend
+label across all four position layouts (right / left / top / bottom /
+top-right).

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -2702,8 +2702,15 @@ const renderChartLegend = (
   names: ReadonlyArray<string>,
   colors: ReadonlyArray<string>,
   position: 'r' | 't' | 'b' | 'l' | 'tr' = 'b',
+  textStyle?: ChartTextStyle,
 ): string => {
   if (names.length === 0) return '';
+  // Authored <c:txPr> font / weight / color overrides the 11pt #374151 default.
+  const sz = textStyle?.sizePt ?? 11;
+  const fill = textStyle?.color ?? '#374151';
+  const weight = textStyle?.bold ? ' font-weight="600"' : '';
+  const italic = textStyle?.italic ? ' font-style="italic"' : '';
+  const textAttrs = `font-family="sans-serif" font-size="${sz.toFixed(1)}" fill="${fill}"${weight}${italic}`;
   const out: string[] = [];
   if (position === 'b') {
     // Default: horizontal row centered at the bottom.
@@ -2717,7 +2724,7 @@ const renderChartLegend = (
       const labelX = swatchX + 14;
       out.push(
         `<rect x="${px(swatchX)}" y="${px(swatchY)}" width="9" height="9" fill="${colors[i % colors.length]}"/>`,
-        `<text x="${px(labelX)}" y="${px(f.legendY)}" dominant-baseline="middle" font-family="sans-serif" font-size="11" fill="#374151">${escapeXml(names[i] ?? `Series ${i + 1}`)}</text>`,
+        `<text x="${px(labelX)}" y="${px(f.legendY)}" dominant-baseline="middle" ${textAttrs}>${escapeXml(names[i] ?? `Series ${i + 1}`)}</text>`,
       );
     }
     return out.join('');
@@ -2731,7 +2738,7 @@ const renderChartLegend = (
       const cx = startX + i * itemPx;
       out.push(
         `<rect x="${px(cx + 4)}" y="${px(yTop)}" width="9" height="9" fill="${colors[i % colors.length]}"/>`,
-        `<text x="${px(cx + 18)}" y="${px(yTop + 8)}" dominant-baseline="middle" font-family="sans-serif" font-size="11" fill="#374151">${escapeXml(names[i] ?? `Series ${i + 1}`)}</text>`,
+        `<text x="${px(cx + 18)}" y="${px(yTop + 8)}" dominant-baseline="middle" ${textAttrs}>${escapeXml(names[i] ?? `Series ${i + 1}`)}</text>`,
       );
     }
     return out.join('');
@@ -2745,7 +2752,7 @@ const renderChartLegend = (
     const yp = yStart + i * lineH;
     out.push(
       `<rect x="${px(xCol)}" y="${px(yp - 4)}" width="9" height="9" fill="${colors[i % colors.length]}"/>`,
-      `<text x="${px(xCol + 14)}" y="${px(yp + 4)}" dominant-baseline="middle" font-family="sans-serif" font-size="11" fill="#374151">${escapeXml(names[i] ?? `Series ${i + 1}`)}</text>`,
+      `<text x="${px(xCol + 14)}" y="${px(yp + 4)}" dominant-baseline="middle" ${textAttrs}>${escapeXml(names[i] ?? `Series ${i + 1}`)}</text>`,
     );
   }
   return out.join('');
@@ -3640,6 +3647,7 @@ const renderChart = (
           seriesNamesForLegend,
           seriesColorsForLegend,
           spec.legend?.position ?? 'b',
+          spec.legend?.textStyle,
         ),
     '</g>',
   ].join('');

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -810,11 +810,15 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     const tok = posEl ? getAttrValue(posEl, ATTR_VAL) : null;
     const ovEl = firstChildElement(legendEl, qname('c', 'overlay', NS_C));
     const overlay = ovEl ? getAttrValue(ovEl, ATTR_VAL) !== '0' : false;
-    if (tok === 'r' || tok === 't' || tok === 'b' || tok === 'l' || tok === 'tr') {
-      legend = { position: tok, ...(overlay ? { overlay } : {}) };
-    } else {
-      legend = { position: 'r', ...(overlay ? { overlay } : {}) };
-    }
+    const txPr = firstChildElement(legendEl, qname('c', 'txPr', NS_C));
+    const textStyle = txPr ? readLabelStyle(txPr) : undefined;
+    const position: 'r' | 't' | 'b' | 'l' | 'tr' =
+      tok === 'r' || tok === 't' || tok === 'b' || tok === 'l' || tok === 'tr' ? tok : 'r';
+    legend = {
+      position,
+      ...(overlay ? { overlay } : {}),
+      ...(textStyle !== undefined ? { textStyle } : {}),
+    };
   }
 
   // <c:title><c:overlay val="1"/>

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -280,6 +280,12 @@ export interface ChartSpec {
     position: 'r' | 't' | 'b' | 'l' | 'tr' | null;
     /** When `true`, legend overlays the plot area instead of taking a strip. */
     readonly overlay?: boolean;
+    /**
+     * Authored font / color on the legend's text. From `<c:legend><c:txPr>`'s
+     * first `<a:p><a:pPr><a:defRPr>` (or `<a:r><a:rPr>` as fallback). Same
+     * shape as `titleStyle`.
+     */
+    readonly textStyle?: ChartTextStyle;
   };
   /** When `true`, the chart title overlays the plot area instead of taking a strip. */
   readonly titleOverlay?: boolean;


### PR DESCRIPTION
## Summary
- Adds `ChartSpec.legend.textStyle` populated from `<c:legend><c:txPr>`.
- Renderer threads size / weight / italic / fill through every legend layout.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (785 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)