### PR TITLE
feat: chart axis tick labels honor <c:txPr>

### DIFF
--- a/.changeset/axis-tick-label-style.md
+++ b/.changeset/axis-tick-label-style.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: chart axis *tick labels* honor authored `<c:txPr>` font / color.
+`ChartSpec.categoryAxisLabelStyle` and `valueAxisLabelStyle` carry the
+font / color extracted from `<c:catAx><c:txPr>` and `<c:valAx><c:txPr>`.
+A shared `axisTickAttrs` helper composes the SVG `font-*` / `fill`
+attributes; the value-axis renderer and category-axis renderer both
+project it onto every tick label.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -2574,7 +2574,20 @@ interface AxisSpec {
   readonly numberFormat?: string;
   /** When `false`, gridlines aren't painted (only the tick labels). */
   readonly majorGridlines?: boolean;
+  /** Optional authored tick-label font / color from `<c:valAx><c:txPr>`. */
+  readonly labelStyle?: ChartTextStyle;
 }
+
+// Builds the `font-family / font-size / fill / weight` SVG attribute
+// string for axis tick labels. Defaults match PowerPoint's stock 10pt
+// muted-gray look; authored `<c:txPr>` overrides take over.
+const axisTickAttrs = (style: ChartTextStyle | undefined): string => {
+  const sz = style?.sizePt ?? 10;
+  const fill = style?.color ?? '#6B7280';
+  const weight = style?.bold ? ' font-weight="600"' : '';
+  const italic = style?.italic ? ' font-style="italic"' : '';
+  return `font-family="sans-serif" font-size="${sz.toFixed(1)}" fill="${fill}"${weight}${italic}`;
+};
 
 const renderValueAxis = (f: ChartFrame, axis: AxisSpec): string => {
   // Honour the authored majorUnit when present; otherwise let niceTicks
@@ -2600,7 +2613,7 @@ const renderValueAxis = (f: ChartFrame, axis: AxisSpec): string => {
       }
       // Numeric label, right-aligned to the plot's left edge.
       out.push(
-        `<text x="${px(f.plotX - 4)}" y="${px(yp)}" text-anchor="end" dominant-baseline="middle" font-family="sans-serif" font-size="10" fill="#6B7280">${escapeXml(formatAxisLabel(t, axis.numberFormat))}</text>`,
+        `<text x="${px(f.plotX - 4)}" y="${px(yp)}" text-anchor="end" dominant-baseline="middle" ${axisTickAttrs(axis.labelStyle)}>${escapeXml(formatAxisLabel(t, axis.numberFormat))}</text>`,
       );
     } else {
       const xp = f.plotX + ((t - axis.min) / range) * f.plotW;
@@ -2610,7 +2623,7 @@ const renderValueAxis = (f: ChartFrame, axis: AxisSpec): string => {
         );
       }
       out.push(
-        `<text x="${px(xp)}" y="${px(f.plotY + f.plotH + 12)}" text-anchor="middle" dominant-baseline="middle" font-family="sans-serif" font-size="10" fill="#6B7280">${escapeXml(formatAxisLabel(t, axis.numberFormat))}</text>`,
+        `<text x="${px(xp)}" y="${px(f.plotY + f.plotH + 12)}" text-anchor="middle" dominant-baseline="middle" ${axisTickAttrs(axis.labelStyle)}>${escapeXml(formatAxisLabel(t, axis.numberFormat))}</text>`,
       );
     }
   }
@@ -2624,6 +2637,7 @@ const renderCategoryAxis = (
   cats: ReadonlyArray<string>,
   pointCount: number,
   skip = 1,
+  labelStyle?: ChartTextStyle,
 ): string => {
   const labels: string[] = [];
   for (let i = 0; i < pointCount; i++) {
@@ -2642,7 +2656,7 @@ const renderCategoryAxis = (
           ? `${labels[i]!.slice(0, 12)}…`
           : (labels[i] ?? '');
       out.push(
-        `<text x="${px(cx)}" y="${px(f.plotY + f.plotH + 12)}" text-anchor="middle" dominant-baseline="middle" font-family="sans-serif" font-size="10" fill="#6B7280">${escapeXml(truncated)}</text>`,
+        `<text x="${px(cx)}" y="${px(f.plotY + f.plotH + 12)}" text-anchor="middle" dominant-baseline="middle" ${axisTickAttrs(labelStyle)}>${escapeXml(truncated)}</text>`,
       );
     }
   } else {
@@ -2656,7 +2670,7 @@ const renderCategoryAxis = (
           ? `${labels[i]!.slice(0, 12)}…`
           : (labels[i] ?? '');
       out.push(
-        `<text x="${px(f.plotX - 4)}" y="${px(cy)}" text-anchor="end" dominant-baseline="middle" font-family="sans-serif" font-size="10" fill="#6B7280">${escapeXml(truncated)}</text>`,
+        `<text x="${px(f.plotX - 4)}" y="${px(cy)}" text-anchor="end" dominant-baseline="middle" ${axisTickAttrs(labelStyle)}>${escapeXml(truncated)}</text>`,
       );
     }
   }
@@ -3558,6 +3572,7 @@ const renderChart = (
       ...(spec.valueAxisMajorGridlines !== undefined
         ? { majorGridlines: spec.valueAxisMajorGridlines }
         : {}),
+      ...(spec.valueAxisLabelStyle !== undefined ? { labelStyle: spec.valueAxisLabelStyle } : {}),
     };
     const valueAxis: AxisSpec =
       spec.kind === 'bar'
@@ -3575,6 +3590,7 @@ const renderChart = (
         spec.categories,
         N,
         spec.categoryAxisTickLabelSkip ?? 1,
+        spec.categoryAxisLabelStyle,
       );
     }
   }

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -712,8 +712,10 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
   // readTitle's projection.
   let categoryAxisTitle: string | undefined;
   let categoryAxisTitleStyle: ChartTextStyle | undefined;
+  let categoryAxisLabelStyle: ChartTextStyle | undefined;
   let valueAxisTitle: string | undefined;
   let valueAxisTitleStyle: ChartTextStyle | undefined;
+  let valueAxisLabelStyle: ChartTextStyle | undefined;
   let categoryAxisHidden: boolean | undefined;
   let valueAxisHidden: boolean | undefined;
   let categoryAxisTickLabelSkip: number | undefined;
@@ -741,6 +743,8 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     if (t !== undefined) categoryAxisTitle = t;
     const catTitleEl = firstChildElement(catAx, NAME_TITLE);
     if (catTitleEl) categoryAxisTitleStyle = readTitleStyleOf(catTitleEl);
+    const catTxPr = firstChildElement(catAx, qname('c', 'txPr', NS_C));
+    if (catTxPr) categoryAxisLabelStyle = readLabelStyle(catTxPr);
     categoryAxisHidden = isHidden(catAx);
     categoryAxisOrientation = readAxisOrientation(catAx);
     const skipEl = firstChildElement(catAx, qname('c', 'tickLblSkip', NS_C));
@@ -769,6 +773,8 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     if (t !== undefined) valueAxisTitle = t;
     const valTitleEl = firstChildElement(valAx, NAME_TITLE);
     if (valTitleEl) valueAxisTitleStyle = readTitleStyleOf(valTitleEl);
+    const valTxPr = firstChildElement(valAx, qname('c', 'txPr', NS_C));
+    if (valTxPr) valueAxisLabelStyle = readLabelStyle(valTxPr);
     valueAxisHidden = isHidden(valAx);
     valueAxisOrientation = readAxisOrientation(valAx);
     valueAxisMajorGridlines = firstChildElement(valAx, qname('c', 'majorGridlines', NS_C)) !== null;
@@ -875,8 +881,10 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     ...(chartAreaFill !== undefined ? { chartAreaFill } : {}),
     ...(categoryAxisTitle !== undefined ? { categoryAxisTitle } : {}),
     ...(categoryAxisTitleStyle !== undefined ? { categoryAxisTitleStyle } : {}),
+    ...(categoryAxisLabelStyle !== undefined ? { categoryAxisLabelStyle } : {}),
     ...(valueAxisTitle !== undefined ? { valueAxisTitle } : {}),
     ...(valueAxisTitleStyle !== undefined ? { valueAxisTitleStyle } : {}),
+    ...(valueAxisLabelStyle !== undefined ? { valueAxisLabelStyle } : {}),
     ...(categoryAxisHidden !== undefined ? { categoryAxisHidden } : {}),
     ...(valueAxisHidden !== undefined ? { valueAxisHidden } : {}),
     ...(valueAxisMajorGridlines !== undefined ? { valueAxisMajorGridlines } : {}),

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -211,9 +211,13 @@ export interface ChartSpec {
   readonly categoryAxisTitle?: string;
   /** Authored font / color on the category-axis title (same `<a:rPr>` shape as `titleStyle`). */
   readonly categoryAxisTitleStyle?: ChartTextStyle;
+  /** Authored font / color on the category-axis *tick labels* — `<c:catAx><c:txPr>`. */
+  readonly categoryAxisLabelStyle?: ChartTextStyle;
   readonly valueAxisTitle?: string;
   /** Authored font / color on the value-axis title. */
   readonly valueAxisTitleStyle?: ChartTextStyle;
+  /** Authored font / color on the value-axis *tick labels* — `<c:valAx><c:txPr>`. */
+  readonly valueAxisLabelStyle?: ChartTextStyle;
   /** When `true`, value axis is hidden (`<c:valAx><c:delete val="1"/>`). */
   readonly valueAxisHidden?: boolean;
   /** When `true`, category axis is hidden (`<c:catAx><c:delete val="1"/>`). */


### PR DESCRIPTION
## Summary
- `ChartSpec.categoryAxisLabelStyle` / `valueAxisLabelStyle` populated from `<c:catAx><c:txPr>` / `<c:valAx><c:txPr>`.
- Shared `axisTickAttrs` helper projects size / color / weight / italic onto value-axis and category-axis ticks.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (785 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)