### PR TITLE
feat: chart value-axis gridline color

### DIFF
--- a/.changeset/gridline-color.md
+++ b/.changeset/gridline-color.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: chart value-axis major gridlines honor authored stroke color.
+`ChartSpec.valueAxisMajorGridlineColor` extracts the
+`<c:majorGridlines><c:spPr><a:ln><a:solidFill><a:srgbClr/>` color and
+the playground renderer paints gridlines with it (falls through to the
+existing light-gray default when no color is authored). Branded
+templates with custom gridline tints finally render correctly.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -2576,6 +2576,8 @@ interface AxisSpec {
   readonly majorGridlines?: boolean;
   /** Optional authored tick-label font / color from `<c:valAx><c:txPr>`. */
   readonly labelStyle?: ChartTextStyle;
+  /** Optional authored major-gridline color from `<c:majorGridlines><c:spPr><a:ln>`. */
+  readonly majorGridlineColor?: string;
 }
 
 // Builds the `font-family / font-size / fill / weight` SVG attribute
@@ -2603,12 +2605,13 @@ const renderValueAxis = (f: ChartFrame, axis: AxisSpec): string => {
   const out: string[] = [];
   const range = axis.max - axis.min || 1;
   const showGrid = axis.majorGridlines ?? true;
+  const gridStroke = axis.majorGridlineColor ?? '#E5E7EB';
   for (const t of ticks) {
     if (axis.orientation === 'vertical') {
       const yp = f.plotY + f.plotH - ((t - axis.min) / range) * f.plotH;
       if (showGrid) {
         out.push(
-          `<line x1="${px(f.plotX)}" y1="${px(yp)}" x2="${px(f.plotX + f.plotW)}" y2="${px(yp)}" stroke="#E5E7EB" stroke-width="0.5"/>`,
+          `<line x1="${px(f.plotX)}" y1="${px(yp)}" x2="${px(f.plotX + f.plotW)}" y2="${px(yp)}" stroke="${gridStroke}" stroke-width="0.5"/>`,
         );
       }
       // Numeric label, right-aligned to the plot's left edge.
@@ -2619,7 +2622,7 @@ const renderValueAxis = (f: ChartFrame, axis: AxisSpec): string => {
       const xp = f.plotX + ((t - axis.min) / range) * f.plotW;
       if (showGrid) {
         out.push(
-          `<line x1="${px(xp)}" y1="${px(f.plotY)}" x2="${px(xp)}" y2="${px(f.plotY + f.plotH)}" stroke="#E5E7EB" stroke-width="0.5"/>`,
+          `<line x1="${px(xp)}" y1="${px(f.plotY)}" x2="${px(xp)}" y2="${px(f.plotY + f.plotH)}" stroke="${gridStroke}" stroke-width="0.5"/>`,
         );
       }
       out.push(
@@ -3573,6 +3576,9 @@ const renderChart = (
         ? { majorGridlines: spec.valueAxisMajorGridlines }
         : {}),
       ...(spec.valueAxisLabelStyle !== undefined ? { labelStyle: spec.valueAxisLabelStyle } : {}),
+      ...(spec.valueAxisMajorGridlineColor !== undefined
+        ? { majorGridlineColor: spec.valueAxisMajorGridlineColor }
+        : {}),
     };
     const valueAxis: AxisSpec =
       spec.kind === 'bar'

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -768,6 +768,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
   // means hidden" (matches ECMA-376 §21.2.2.122).
   let valueAxisMajorGridlines: boolean | undefined;
   let valueAxisMinorGridlines: boolean | undefined;
+  let valueAxisMajorGridlineColor: string | undefined;
   if (valAx) {
     const t = readTitle(valAx);
     if (t !== undefined) valueAxisTitle = t;
@@ -777,7 +778,25 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     if (valTxPr) valueAxisLabelStyle = readLabelStyle(valTxPr);
     valueAxisHidden = isHidden(valAx);
     valueAxisOrientation = readAxisOrientation(valAx);
-    valueAxisMajorGridlines = firstChildElement(valAx, qname('c', 'majorGridlines', NS_C)) !== null;
+    const majorGl = firstChildElement(valAx, qname('c', 'majorGridlines', NS_C));
+    valueAxisMajorGridlines = majorGl !== null;
+    if (majorGl) {
+      // <c:majorGridlines><c:spPr><a:ln><a:solidFill><a:srgbClr val="…"/>
+      const spPr = firstChildElement(majorGl, NAME_SP_PR_C);
+      if (spPr) {
+        const ln = firstChildElement(spPr, qname('a', 'ln', NS_A));
+        if (ln) {
+          const solid = firstChildElement(ln, NAME_SOLID_FILL);
+          if (solid) {
+            const srgb = firstChildElement(solid, NAME_SRGB_CLR);
+            if (srgb) {
+              const v = getAttrValue(srgb, ATTR_VAL);
+              if (v !== null) valueAxisMajorGridlineColor = `#${v.toUpperCase()}`;
+            }
+          }
+        }
+      }
+    }
     valueAxisMinorGridlines = firstChildElement(valAx, qname('c', 'minorGridlines', NS_C)) !== null;
   }
 
@@ -888,6 +907,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     ...(categoryAxisHidden !== undefined ? { categoryAxisHidden } : {}),
     ...(valueAxisHidden !== undefined ? { valueAxisHidden } : {}),
     ...(valueAxisMajorGridlines !== undefined ? { valueAxisMajorGridlines } : {}),
+    ...(valueAxisMajorGridlineColor !== undefined ? { valueAxisMajorGridlineColor } : {}),
     ...(valueAxisMinorGridlines !== undefined ? { valueAxisMinorGridlines } : {}),
     ...(categoryAxisTickLabelSkip !== undefined ? { categoryAxisTickLabelSkip } : {}),
     ...(categoryAxisTickLabelPos !== undefined ? { categoryAxisTickLabelPos } : {}),

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -224,6 +224,13 @@ export interface ChartSpec {
   readonly categoryAxisHidden?: boolean;
   /** When the value-axis emits `<c:majorGridlines/>` — its gridlines are visible. */
   readonly valueAxisMajorGridlines?: boolean;
+  /**
+   * Authored color on the value-axis major gridlines — `<c:valAx>
+   * <c:majorGridlines><c:spPr><a:ln><a:solidFill><a:srgbClr val="…"/>`.
+   * Returned as `#RRGGBB`. `undefined` falls back to the renderer's
+   * default (a light gray).
+   */
+  readonly valueAxisMajorGridlineColor?: string;
   /** When the value-axis emits `<c:minorGridlines/>` — minor gridlines are visible. */
   readonly valueAxisMinorGridlines?: boolean;
   /**


### PR DESCRIPTION
## Summary
- New `ChartSpec.valueAxisMajorGridlineColor` from `<c:majorGridlines><c:spPr><a:ln><a:solidFill><a:srgbClr/>`.
- Renderer paints gridlines with authored color, falling back to the existing default.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (785 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)