### PR TITLE
feat: chart category-axis label rotation

### DIFF
--- a/.changeset/category-axis-label-rotation.md
+++ b/.changeset/category-axis-label-rotation.md
@@ -1,0 +1,12 @@
+---
+'pptx-kit': minor
+---
+
+feat: chart category-axis tick labels honor `<a:bodyPr rot="N"/>`.
+`ChartSpec.categoryAxisLabelRotationDeg` carries the authored rotation
+(converted from OOXML's 60000ths-of-a-degree to plain degrees). The
+playground renderer rotates each tick label around its anchor and
+shifts the text-anchor side based on the sign of the rotation so dense
+charts with 45°/-45°/90° rotated labels render the way PowerPoint
+shows them. Rotated labels also get a longer truncation budget before
+ellipsization.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -2642,6 +2642,7 @@ const renderCategoryAxis = (
   pointCount: number,
   skip = 1,
   labelStyle?: ChartTextStyle,
+  labelRotationDeg?: number,
 ): string => {
   const labels: string[] = [];
   for (let i = 0; i < pointCount; i++) {
@@ -2651,16 +2652,35 @@ const renderCategoryAxis = (
   if (orientation === 'horizontal') {
     // Categories along x-axis (column / line / area charts).
     const step = pointCount > 1 ? f.plotW / pointCount : 0;
+    // Rotated labels need a longer truncation budget — PowerPoint
+    // doesn't ellipsize rotated labels until they actually overflow.
+    const truncLen = labelRotationDeg && Math.abs(labelRotationDeg) >= 30 ? 28 : 14;
     for (let i = 0; i < pointCount; i++) {
       if (skip > 1 && i % skip !== 0) continue;
       // Center labels under each category slot.
       const cx = f.plotX + (i + 0.5) * step;
+      const cy = f.plotY + f.plotH + 12;
       const truncated =
-        labels[i] !== undefined && labels[i]!.length > 14
-          ? `${labels[i]!.slice(0, 12)}…`
+        labels[i] !== undefined && labels[i]!.length > truncLen
+          ? `${labels[i]!.slice(0, truncLen - 2)}…`
           : (labels[i] ?? '');
+      // Authored <a:bodyPr rot="N"/> rotates the tick label. Pivot
+      // around the label anchor so rotated labels stay attached to
+      // their column.
+      const transform =
+        labelRotationDeg && labelRotationDeg !== 0
+          ? ` transform="rotate(${labelRotationDeg} ${px(cx)} ${px(cy)})"`
+          : '';
+      // When rotated, right-align to the pivot so the label leans
+      // toward its data point rather than overflowing the next column.
+      const anchor =
+        labelRotationDeg && labelRotationDeg > 0
+          ? 'end'
+          : labelRotationDeg && labelRotationDeg < 0
+            ? 'start'
+            : 'middle';
       out.push(
-        `<text x="${px(cx)}" y="${px(f.plotY + f.plotH + 12)}" text-anchor="middle" dominant-baseline="middle" ${axisTickAttrs(labelStyle)}>${escapeXml(truncated)}</text>`,
+        `<text x="${px(cx)}" y="${px(cy)}" text-anchor="${anchor}" dominant-baseline="middle" ${axisTickAttrs(labelStyle)}${transform}>${escapeXml(truncated)}</text>`,
       );
     }
   } else {
@@ -3669,6 +3689,7 @@ const renderChart = (
         N,
         spec.categoryAxisTickLabelSkip ?? 1,
         spec.categoryAxisLabelStyle,
+        spec.categoryAxisLabelRotationDeg,
       );
     }
   }

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -741,6 +741,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
   let categoryAxisTitle: string | undefined;
   let categoryAxisTitleStyle: ChartTextStyle | undefined;
   let categoryAxisLabelStyle: ChartTextStyle | undefined;
+  let categoryAxisLabelRotationDeg: number | undefined;
   let valueAxisTitle: string | undefined;
   let valueAxisTitleStyle: ChartTextStyle | undefined;
   let valueAxisLabelStyle: ChartTextStyle | undefined;
@@ -772,7 +773,18 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     const catTitleEl = firstChildElement(catAx, NAME_TITLE);
     if (catTitleEl) categoryAxisTitleStyle = readTitleStyleOf(catTitleEl);
     const catTxPr = firstChildElement(catAx, qname('c', 'txPr', NS_C));
-    if (catTxPr) categoryAxisLabelStyle = readLabelStyle(catTxPr);
+    if (catTxPr) {
+      categoryAxisLabelStyle = readLabelStyle(catTxPr);
+      // <c:txPr><a:bodyPr rot="N"/> — N is in 60000ths of a degree.
+      const bodyPr = firstChildElement(catTxPr, qname('a', 'bodyPr', NS_A));
+      if (bodyPr) {
+        const rotRaw = getAttrValue(bodyPr, qname('', 'rot', ''));
+        if (rotRaw !== null) {
+          const n = Number.parseInt(rotRaw, 10);
+          if (Number.isFinite(n)) categoryAxisLabelRotationDeg = n / 60000;
+        }
+      }
+    }
     categoryAxisHidden = isHidden(catAx);
     categoryAxisOrientation = readAxisOrientation(catAx);
     const skipEl = firstChildElement(catAx, qname('c', 'tickLblSkip', NS_C));
@@ -929,6 +941,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     ...(categoryAxisTitle !== undefined ? { categoryAxisTitle } : {}),
     ...(categoryAxisTitleStyle !== undefined ? { categoryAxisTitleStyle } : {}),
     ...(categoryAxisLabelStyle !== undefined ? { categoryAxisLabelStyle } : {}),
+    ...(categoryAxisLabelRotationDeg !== undefined ? { categoryAxisLabelRotationDeg } : {}),
     ...(valueAxisTitle !== undefined ? { valueAxisTitle } : {}),
     ...(valueAxisTitleStyle !== undefined ? { valueAxisTitleStyle } : {}),
     ...(valueAxisLabelStyle !== undefined ? { valueAxisLabelStyle } : {}),

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -241,6 +241,13 @@ export interface ChartSpec {
   readonly categoryAxisTitleStyle?: ChartTextStyle;
   /** Authored font / color on the category-axis *tick labels* — `<c:catAx><c:txPr>`. */
   readonly categoryAxisLabelStyle?: ChartTextStyle;
+  /**
+   * Authored rotation on the category-axis tick labels, in degrees. From
+   * `<c:catAx><c:txPr><a:bodyPr rot="N"/>` where N is in 60000ths of a
+   * degree. Positive values rotate clockwise (PowerPoint convention),
+   * matching the SVG `transform=rotate()` sense.
+   */
+  readonly categoryAxisLabelRotationDeg?: number;
   readonly valueAxisTitle?: string;
   /** Authored font / color on the value-axis title. */
   readonly valueAxisTitleStyle?: ChartTextStyle;


### PR DESCRIPTION
## Summary
- New `ChartSpec.categoryAxisLabelRotationDeg` from `<c:catAx><c:txPr><a:bodyPr rot=…/>`.
- Renderer rotates each tick label around its anchor and shifts the text-anchor based on rotation sign.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (785 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)