### PR TITLE
feat: chart axis major tick marks (<c:majorTickMark>)

### DIFF
--- a/.changeset/axis-tick-marks.md
+++ b/.changeset/axis-tick-marks.md
@@ -1,0 +1,9 @@
+---
+'pptx-kit': minor
+---
+
+feat: chart value-axis tick marks. `ChartSpec.valueAxisMajorTickMark`
+and `categoryAxisMajorTickMark` carry `<c:majorTickMark val="in|out|
+cross|none"/>`. The playground value-axis renderer draws short stubs
+on the appropriate side of the plot edge (default `out` matches
+PowerPoint's stock look); `none` suppresses them entirely.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -2591,6 +2591,8 @@ interface AxisSpec {
   readonly labelStyle?: ChartTextStyle;
   /** Optional authored major-gridline color from `<c:majorGridlines><c:spPr><a:ln>`. */
   readonly majorGridlineColor?: string;
+  /** Major-tick mark mode from `<c:valAx><c:majorTickMark val="…"/>`. */
+  readonly majorTickMark?: 'in' | 'out' | 'cross' | 'none';
 }
 
 // Builds the `font-family / font-size / fill / weight` SVG attribute
@@ -2619,12 +2621,28 @@ const renderValueAxis = (f: ChartFrame, axis: AxisSpec): string => {
   const range = axis.max - axis.min || 1;
   const showGrid = axis.majorGridlines ?? true;
   const gridStroke = axis.majorGridlineColor ?? '#E5E7EB';
+  // Tick-mark mode: 'out' = stub outside the plot edge (default),
+  // 'in' = stub inside the plot, 'cross' = both, 'none' = no stub.
+  const tickMark = axis.majorTickMark ?? 'out';
+  const tickLen = 3;
   for (const t of ticks) {
     if (axis.orientation === 'vertical') {
       const yp = f.plotY + f.plotH - ((t - axis.min) / range) * f.plotH;
       if (showGrid) {
         out.push(
           `<line x1="${px(f.plotX)}" y1="${px(yp)}" x2="${px(f.plotX + f.plotW)}" y2="${px(yp)}" stroke="${gridStroke}" stroke-width="0.5"/>`,
+        );
+      }
+      if (tickMark !== 'none') {
+        const tx1 = tickMark === 'in' ? f.plotX : f.plotX - tickLen;
+        const tx2 =
+          tickMark === 'out'
+            ? f.plotX
+            : tickMark === 'cross'
+              ? f.plotX + tickLen
+              : f.plotX + tickLen;
+        out.push(
+          `<line x1="${px(tx1)}" y1="${px(yp)}" x2="${px(tx2)}" y2="${px(yp)}" stroke="#9CA3AF" stroke-width="0.5"/>`,
         );
       }
       // Numeric label, right-aligned to the plot's left edge.
@@ -2636,6 +2654,15 @@ const renderValueAxis = (f: ChartFrame, axis: AxisSpec): string => {
       if (showGrid) {
         out.push(
           `<line x1="${px(xp)}" y1="${px(f.plotY)}" x2="${px(xp)}" y2="${px(f.plotY + f.plotH)}" stroke="${gridStroke}" stroke-width="0.5"/>`,
+        );
+      }
+      if (tickMark !== 'none') {
+        const baseY = f.plotY + f.plotH;
+        const ty1 = tickMark === 'in' ? baseY : baseY + tickLen;
+        const ty2 =
+          tickMark === 'out' ? baseY : tickMark === 'cross' ? baseY - tickLen : baseY - tickLen;
+        out.push(
+          `<line x1="${px(xp)}" y1="${px(ty1)}" x2="${px(xp)}" y2="${px(ty2)}" stroke="#9CA3AF" stroke-width="0.5"/>`,
         );
       }
       out.push(
@@ -3682,6 +3709,9 @@ const renderChart = (
       ...(spec.valueAxisLabelStyle !== undefined ? { labelStyle: spec.valueAxisLabelStyle } : {}),
       ...(spec.valueAxisMajorGridlineColor !== undefined
         ? { majorGridlineColor: spec.valueAxisMajorGridlineColor }
+        : {}),
+      ...(spec.valueAxisMajorTickMark !== undefined
+        ? { majorTickMark: spec.valueAxisMajorTickMark }
         : {}),
     };
     const valueAxis: AxisSpec =

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -742,6 +742,15 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
   let categoryAxisTitleStyle: ChartTextStyle | undefined;
   let categoryAxisLabelStyle: ChartTextStyle | undefined;
   let categoryAxisLabelRotationDeg: number | undefined;
+  let valueAxisMajorTickMark: ChartSpec['valueAxisMajorTickMark'];
+  let categoryAxisMajorTickMark: ChartSpec['categoryAxisMajorTickMark'];
+  const readTickMark = (axis: XmlElement): 'in' | 'out' | 'cross' | 'none' | undefined => {
+    const el = firstChildElement(axis, qname('c', 'majorTickMark', NS_C));
+    if (!el) return undefined;
+    const v = getAttrValue(el, ATTR_VAL);
+    if (v === 'in' || v === 'out' || v === 'cross' || v === 'none') return v;
+    return undefined;
+  };
   let valueAxisTitle: string | undefined;
   let valueAxisTitleStyle: ChartTextStyle | undefined;
   let valueAxisLabelStyle: ChartTextStyle | undefined;
@@ -787,6 +796,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     }
     categoryAxisHidden = isHidden(catAx);
     categoryAxisOrientation = readAxisOrientation(catAx);
+    categoryAxisMajorTickMark = readTickMark(catAx);
     const skipEl = firstChildElement(catAx, qname('c', 'tickLblSkip', NS_C));
     if (skipEl) {
       const v = getAttrValue(skipEl, ATTR_VAL);
@@ -818,6 +828,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     if (valTxPr) valueAxisLabelStyle = readLabelStyle(valTxPr);
     valueAxisHidden = isHidden(valAx);
     valueAxisOrientation = readAxisOrientation(valAx);
+    valueAxisMajorTickMark = readTickMark(valAx);
     const majorGl = firstChildElement(valAx, qname('c', 'majorGridlines', NS_C));
     valueAxisMajorGridlines = majorGl !== null;
     if (majorGl) {
@@ -966,6 +977,8 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     ...(valueAxisHidden !== undefined ? { valueAxisHidden } : {}),
     ...(valueAxisMajorGridlines !== undefined ? { valueAxisMajorGridlines } : {}),
     ...(valueAxisMajorGridlineColor !== undefined ? { valueAxisMajorGridlineColor } : {}),
+    ...(valueAxisMajorTickMark !== undefined ? { valueAxisMajorTickMark } : {}),
+    ...(categoryAxisMajorTickMark !== undefined ? { categoryAxisMajorTickMark } : {}),
     ...(valueAxisMinorGridlines !== undefined ? { valueAxisMinorGridlines } : {}),
     ...(categoryAxisTickLabelSkip !== undefined ? { categoryAxisTickLabelSkip } : {}),
     ...(categoryAxisTickLabelPos !== undefined ? { categoryAxisTickLabelPos } : {}),

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -271,6 +271,17 @@ export interface ChartSpec {
   /** When the value-axis emits `<c:majorGridlines/>` — its gridlines are visible. */
   readonly valueAxisMajorGridlines?: boolean;
   /**
+   * Major-tick mark mode on the value axis (`<c:valAx><c:majorTickMark val="…"/>`):
+   *
+   *   - `'out'` — outside the plot edge (default)
+   *   - `'in'` — inside the plot
+   *   - `'cross'` — across the axis line
+   *   - `'none'` — no tick marks
+   */
+  readonly valueAxisMajorTickMark?: 'in' | 'out' | 'cross' | 'none';
+  /** Major-tick mark mode on the category axis (`<c:catAx><c:majorTickMark>`). */
+  readonly categoryAxisMajorTickMark?: 'in' | 'out' | 'cross' | 'none';
+  /**
    * Authored color on the value-axis major gridlines — `<c:valAx>
    * <c:majorGridlines><c:spPr><a:ln><a:solidFill><a:srgbClr val="…"/>`.
    * Returned as `#RRGGBB`. `undefined` falls back to the renderer's


### PR DESCRIPTION
## Summary
- `ChartSpec.valueAxisMajorTickMark` / `categoryAxisMajorTickMark` from `<c:majorTickMark val=…/>`.
- Renderer paints short stubs at each major tick on the value axis (out=default, in/cross/none honored).

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (785 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)