### PR TITLE
feat: chart value-axis tick label rotation

### DIFF
--- a/.changeset/value-axis-label-rotation.md
+++ b/.changeset/value-axis-label-rotation.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: chart value-axis tick labels honor `<c:valAx><c:txPr><a:bodyPr
+rot="N"/>`. `ChartSpec.valueAxisLabelRotationDeg` returns the rotation
+in degrees (converted from OOXML's 60000ths-of-a-degree). The
+playground renders each value-axis tick label with a
+`transform=rotate()` around its anchor, symmetric to the
+`categoryAxisLabelRotationDeg` we already projected.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -2593,6 +2593,8 @@ interface AxisSpec {
   readonly majorGridlineColor?: string;
   /** Major-tick mark mode from `<c:valAx><c:majorTickMark val="…"/>`. */
   readonly majorTickMark?: 'in' | 'out' | 'cross' | 'none';
+  /** Authored tick-label rotation, in degrees. */
+  readonly labelRotationDeg?: number;
 }
 
 // Builds the `font-family / font-size / fill / weight` SVG attribute
@@ -2646,8 +2648,13 @@ const renderValueAxis = (f: ChartFrame, axis: AxisSpec): string => {
         );
       }
       // Numeric label, right-aligned to the plot's left edge.
+      // Authored <c:txPr><a:bodyPr rot="N"/> rotates around the
+      // label anchor.
+      const labelX = f.plotX - 4;
+      const rot = axis.labelRotationDeg ?? 0;
+      const transform = rot ? ` transform="rotate(${rot} ${px(labelX)} ${px(yp)})"` : '';
       out.push(
-        `<text x="${px(f.plotX - 4)}" y="${px(yp)}" text-anchor="end" dominant-baseline="middle" ${axisTickAttrs(axis.labelStyle)}>${escapeXml(formatAxisLabel(t, axis.numberFormat))}</text>`,
+        `<text x="${px(labelX)}" y="${px(yp)}" text-anchor="end" dominant-baseline="middle" ${axisTickAttrs(axis.labelStyle)}${transform}>${escapeXml(formatAxisLabel(t, axis.numberFormat))}</text>`,
       );
     } else {
       const xp = f.plotX + ((t - axis.min) / range) * f.plotW;
@@ -2665,8 +2672,11 @@ const renderValueAxis = (f: ChartFrame, axis: AxisSpec): string => {
           `<line x1="${px(xp)}" y1="${px(ty1)}" x2="${px(xp)}" y2="${px(ty2)}" stroke="#9CA3AF" stroke-width="0.5"/>`,
         );
       }
+      const horizLabelY = f.plotY + f.plotH + 12;
+      const rotH = axis.labelRotationDeg ?? 0;
+      const transformH = rotH ? ` transform="rotate(${rotH} ${px(xp)} ${px(horizLabelY)})"` : '';
       out.push(
-        `<text x="${px(xp)}" y="${px(f.plotY + f.plotH + 12)}" text-anchor="middle" dominant-baseline="middle" ${axisTickAttrs(axis.labelStyle)}>${escapeXml(formatAxisLabel(t, axis.numberFormat))}</text>`,
+        `<text x="${px(xp)}" y="${px(horizLabelY)}" text-anchor="middle" dominant-baseline="middle" ${axisTickAttrs(axis.labelStyle)}${transformH}>${escapeXml(formatAxisLabel(t, axis.numberFormat))}</text>`,
       );
     }
   }
@@ -3712,6 +3722,9 @@ const renderChart = (
         : {}),
       ...(spec.valueAxisMajorTickMark !== undefined
         ? { majorTickMark: spec.valueAxisMajorTickMark }
+        : {}),
+      ...(spec.valueAxisLabelRotationDeg !== undefined
+        ? { labelRotationDeg: spec.valueAxisLabelRotationDeg }
         : {}),
     };
     const valueAxis: AxisSpec =

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -742,6 +742,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
   let categoryAxisTitleStyle: ChartTextStyle | undefined;
   let categoryAxisLabelStyle: ChartTextStyle | undefined;
   let categoryAxisLabelRotationDeg: number | undefined;
+  let valueAxisLabelRotationDeg: number | undefined;
   let valueAxisMajorTickMark: ChartSpec['valueAxisMajorTickMark'];
   let categoryAxisMajorTickMark: ChartSpec['categoryAxisMajorTickMark'];
   const readTickMark = (axis: XmlElement): 'in' | 'out' | 'cross' | 'none' | undefined => {
@@ -825,7 +826,17 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     const valTitleEl = firstChildElement(valAx, NAME_TITLE);
     if (valTitleEl) valueAxisTitleStyle = readTitleStyleOf(valTitleEl);
     const valTxPr = firstChildElement(valAx, qname('c', 'txPr', NS_C));
-    if (valTxPr) valueAxisLabelStyle = readLabelStyle(valTxPr);
+    if (valTxPr) {
+      valueAxisLabelStyle = readLabelStyle(valTxPr);
+      const bodyPr = firstChildElement(valTxPr, qname('a', 'bodyPr', NS_A));
+      if (bodyPr) {
+        const rotRaw = getAttrValue(bodyPr, qname('', 'rot', ''));
+        if (rotRaw !== null) {
+          const n = Number.parseInt(rotRaw, 10);
+          if (Number.isFinite(n)) valueAxisLabelRotationDeg = n / 60000;
+        }
+      }
+    }
     valueAxisHidden = isHidden(valAx);
     valueAxisOrientation = readAxisOrientation(valAx);
     valueAxisMajorTickMark = readTickMark(valAx);
@@ -978,6 +989,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     ...(valueAxisMajorGridlines !== undefined ? { valueAxisMajorGridlines } : {}),
     ...(valueAxisMajorGridlineColor !== undefined ? { valueAxisMajorGridlineColor } : {}),
     ...(valueAxisMajorTickMark !== undefined ? { valueAxisMajorTickMark } : {}),
+    ...(valueAxisLabelRotationDeg !== undefined ? { valueAxisLabelRotationDeg } : {}),
     ...(categoryAxisMajorTickMark !== undefined ? { categoryAxisMajorTickMark } : {}),
     ...(valueAxisMinorGridlines !== undefined ? { valueAxisMinorGridlines } : {}),
     ...(categoryAxisTickLabelSkip !== undefined ? { categoryAxisTickLabelSkip } : {}),

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -264,6 +264,12 @@ export interface ChartSpec {
   readonly valueAxisTitleStyle?: ChartTextStyle;
   /** Authored font / color on the value-axis *tick labels* — `<c:valAx><c:txPr>`. */
   readonly valueAxisLabelStyle?: ChartTextStyle;
+  /**
+   * Authored rotation on the value-axis tick labels, in degrees. From
+   * `<c:valAx><c:txPr><a:bodyPr rot="N"/>` (N in 60000ths of a degree).
+   * Same sense as `categoryAxisLabelRotationDeg`.
+   */
+  readonly valueAxisLabelRotationDeg?: number;
   /** When `true`, value axis is hidden (`<c:valAx><c:delete val="1"/>`). */
   readonly valueAxisHidden?: boolean;
   /** When `true`, category axis is hidden (`<c:catAx><c:delete val="1"/>`). */


### PR DESCRIPTION
## Summary
- `ChartSpec.valueAxisLabelRotationDeg` from `<c:valAx><c:txPr><a:bodyPr rot=…/>`.
- Renderer rotates each tick label around its anchor.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (785 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)