### PR TITLE
feat(site/playground): image bullets render a distinct glyph

### DIFF
--- a/.changeset/bullet-picture-render.md
+++ b/.changeset/bullet-picture-render.md
@@ -1,0 +1,9 @@
+---
+'pptx-kit': minor
+---
+
+feat(site/playground): paragraphs with image bullets (`<a:pPr><a:buBlip>`)
+render a filled-square glyph (■) instead of inheriting the default
+round bullet. The reader already exposed `isParagraphBulletPicture`;
+the playground now threads it through paragraph metadata so the
+visual cue lands.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -24,6 +24,7 @@ import {
   getParagraphAlignment,
   getParagraphBullet,
   getParagraphBulletStyle,
+  isParagraphBulletPicture,
   getParagraphIndent,
   getParagraphLevel,
   getParagraphLineSpacing,
@@ -2050,6 +2051,7 @@ const renderTextBody = (
     readonly level: number;
     readonly bulletStyle: ReturnType<typeof getParagraphBullet>;
     readonly bulletDetail: ReturnType<typeof getParagraphBulletStyle>;
+    readonly bulletIsPicture: boolean;
     readonly runs: RunData[];
     readonly lineSpacing: ReturnType<typeof getParagraphLineSpacing>;
     readonly spcBefPts: number | null;
@@ -2090,6 +2092,10 @@ const renderTextBody = (
     };
     try {
       bulletDetail = getParagraphBulletStyle(pres, shape, p);
+    } catch {}
+    let bulletIsPicture = false;
+    try {
+      bulletIsPicture = isParagraphBulletPicture(shape, p);
     } catch {}
     const lineSpacing: ReturnType<typeof getParagraphLineSpacing> = effective.lineSpacing;
     let spcBefPts: number | null = effective.spcBefPts;
@@ -2157,6 +2163,7 @@ const renderTextBody = (
       level,
       bulletStyle,
       bulletDetail,
+      bulletIsPicture,
       runs,
       lineSpacing,
       spcBefPts,
@@ -2331,9 +2338,15 @@ const renderTextBody = (
       para.bulletStyle === 'bullet' ||
       explicitChar !== null ||
       numberLabel !== null ||
+      para.bulletIsPicture ||
       (para.bulletStyle !== 'none' && para.level > 0);
     if (showBullet) {
-      const char = numberLabel ?? explicitChar ?? bulletChar(para.level);
+      // Image bullets (`<a:pPr><a:buBlip>`) don't surface their bytes
+      // here — fall back to a filled square so users see a distinct
+      // glyph rather than the inherited round bullet.
+      const char = para.bulletIsPicture
+        ? '■'
+        : (numberLabel ?? explicitChar ?? bulletChar(para.level));
       // Bullet style overrides: color, size %, fixed pt size, font face.
       const bulletStyles: string[] = [
         `margin-right:${(0.4 * defaultPt * PX_PER_PT * autoFitScale).toFixed(2)}px`,


### PR DESCRIPTION
## Summary
- Wires `isParagraphBulletPicture` into paragraph metadata.
- Image-bullet paragraphs now render as ■ instead of the inherited round bullet.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (785 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)