### PR TITLE
feat: chart data label separator (<c:separator>)

### DIFF
--- a/.changeset/data-label-separator.md
+++ b/.changeset/data-label-separator.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: chart data label separator. `ChartDataLabels.separator` carries
+the `<c:dLbls><c:separator>…</c:separator>` text used to join
+multiple label parts (value + percent + category etc.). The pie /
+doughnut renderer threads the per-series override, falling back to
+the chart-level separator and finally to a single space. Common
+values: `", "`, `"\n"`, `"; "`.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -3667,7 +3667,7 @@ const renderPieChart = (
     }
     if (labels.length > 0) {
       out.push(
-        `<text x="${px(labelX)}" y="${px(labelY)}" text-anchor="middle" dominant-baseline="middle" font-family="sans-serif" font-size="10" fill="${labelFill}" font-weight="600">${escapeXml(labels.join(' '))}</text>`,
+        `<text x="${px(labelX)}" y="${px(labelY)}" text-anchor="middle" dominant-baseline="middle" font-family="sans-serif" font-size="10" fill="${labelFill}" font-weight="600">${escapeXml(labels.join(spec.series[0]?.dataLabels?.separator ?? spec.dataLabels?.separator ?? ' '))}</text>`,
       );
     }
   }

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -502,6 +502,18 @@ const readDataLabelPosition = (dLbls: XmlElement): ChartDataLabelPosition | unde
   }
 };
 
+// `<c:dLbls><c:separator>…</c:separator>` — leaf text content; common
+// values are `" "`, `", "`, `"\n"`, `"; "`.
+const readDataLabelSeparator = (dLbls: XmlElement): string | undefined => {
+  const el = firstChildElement(dLbls, qname('c', 'separator', NS_C));
+  if (!el) return undefined;
+  let acc = '';
+  for (const c of el.children) {
+    if (c.kind === 'text' || c.kind === 'cdata') acc += c.data;
+  }
+  return acc.length > 0 ? acc : undefined;
+};
+
 /**
  * Parses a `<c:chartSpace>` element into a typed `ChartSpec`. Throws if
  * the root or any required child is missing. Returns `null` only when
@@ -587,6 +599,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
         if (fc !== null && fc.length > 0 && fc !== 'General') numberFormat = fc;
       }
       const position = readDataLabelPosition(serDLblsEl);
+      const separator = readDataLabelSeparator(serDLblsEl);
       serDataLabels = {
         showValue: readToggle('showVal'),
         showCategory: readToggle('showCatName'),
@@ -594,6 +607,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
         showPercent: readToggle('showPercent'),
         ...(numberFormat !== undefined ? { numberFormat } : {}),
         ...(position !== undefined ? { position } : {}),
+        ...(separator !== undefined ? { separator } : {}),
       };
     }
     series.push({
@@ -638,6 +652,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
       if (fc !== null && fc.length > 0 && fc !== 'General') numberFormat = fc;
     }
     const position = readDataLabelPosition(dLbls);
+    const separator = readDataLabelSeparator(dLbls);
     dataLabels = {
       showValue: readToggle('showVal'),
       showCategory: readToggle('showCatName'),
@@ -645,6 +660,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
       showPercent: readToggle('showPercent'),
       ...(numberFormat !== undefined ? { numberFormat } : {}),
       ...(position !== undefined ? { position } : {}),
+      ...(separator !== undefined ? { separator } : {}),
     };
   }
 

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -170,6 +170,14 @@ export interface ChartDataLabels {
    * `<c:dLbls><c:dLblPos val="…"/>`.
    */
   readonly position?: ChartDataLabelPosition;
+  /**
+   * Separator between concatenated label parts when more than one of
+   * `showValue` / `showCategory` / `showSeriesName` / `showPercent` is
+   * set. Read from `<c:dLbls><c:separator>…</c:separator>` (a
+   * leaf-text-only element). Common values: `" "` (default), `", "`,
+   * `"\n"`, `"; "`.
+   */
+  readonly separator?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- `ChartDataLabels.separator` from `<c:dLbls><c:separator>…</c:separator>`.
- Pie/doughnut renderer joins multiple label parts with the authored separator.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (785 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)