### PR TITLE
feat: chart title accepts <c:strRef> cell-reference text

### DIFF
--- a/.changeset/chart-title-strref.md
+++ b/.changeset/chart-title-strref.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: chart titles read `<c:tx><c:strRef>` workbook-cell references.
+Previously only literal `<c:rich>` titles surfaced; titles authored
+via Excel's "Link to source cell" wizard (which emits `<c:strRef>`
+with a `<c:strCache>` of the resolved text) now flow through to
+`ChartSpec.title` as the cached value. Affects the title shown above
+the chart and, transitively, axis-title rendering.

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -381,19 +381,30 @@ const readTitle = (chart: XmlElement): string | undefined => {
   if (!title) return undefined;
   const tx = firstChildElement(title, NAME_TX);
   if (!tx) return undefined;
+  // `<c:tx>` may carry either `<c:rich>` (literal) or `<c:strRef>` (cell
+  // reference, with its `<c:strCache>` holding the resolved string).
+  // Authors who type the title directly emit rich; chart wizards that
+  // wire the title to a cell emit strRef. Accept both.
   const rich = firstChildElement(tx, NAME_RICH);
-  if (!rich) return undefined;
-  let acc = '';
-  for (const p of allChildElements(rich, NAME_P_DML)) {
-    for (const r of allChildElements(p, NAME_R_DML)) {
-      const tEl = firstChildElement(r, NAME_T);
-      if (!tEl) continue;
-      for (const child of tEl.children) {
-        if (child.kind === 'text' || child.kind === 'cdata') acc += child.data;
+  if (rich) {
+    let acc = '';
+    for (const p of allChildElements(rich, NAME_P_DML)) {
+      for (const r of allChildElements(p, NAME_R_DML)) {
+        const tEl = firstChildElement(r, NAME_T);
+        if (!tEl) continue;
+        for (const child of tEl.children) {
+          if (child.kind === 'text' || child.kind === 'cdata') acc += child.data;
+        }
       }
     }
+    if (acc.length > 0) return acc;
   }
-  return acc.length > 0 ? acc : undefined;
+  const cells = readStringRef(tx);
+  if (cells && cells.length > 0) {
+    const text = cells.filter((s) => s.length > 0).join(' ');
+    if (text.length > 0) return text;
+  }
+  return undefined;
 };
 
 const NAME_A_RPR = qname('a', 'rPr', NS_A);


### PR DESCRIPTION
## Summary
- `readTitle` now falls back to `<c:tx><c:strRef><c:strCache>` when `<c:rich>` is absent.
- Also applies to axis titles (via shared `readTitleStyleOf` and `readTitle`).

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (785 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)