### PR TITLE
fix: chart categories accept <c:cat><c:numRef> (numeric/date axes)

### DIFF
--- a/.changeset/chart-numeric-categories.md
+++ b/.changeset/chart-numeric-categories.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+fix: chart categories accept `<c:cat><c:numRef>` (numeric / date
+categories). Previously the category-axis dropped to an empty
+labels array when the chart authored a numeric category channel
+(common for date-axis line charts authored in Excel). Falls back
+to formatting each cached numeric value as a string so date /
+number cats appear on the axis instead of disappearing.

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -569,7 +569,19 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     const name = readSeriesName(ser);
     const cat = firstChildElement(ser, NAME_CAT);
     if (cat !== null && categoriesFromFirst === null) {
+      // `<c:cat>` is usually `<c:strRef>` (text categories), but date /
+      // numeric categories serialize as `<c:numRef>`. Fall back to the
+      // numeric channel formatted as a string so date / number cats
+      // still appear on the axis instead of disappearing entirely.
       categoriesFromFirst = readStringRef(cat) ?? null;
+      if (categoriesFromFirst === null) {
+        const nums = readNumRef(cat);
+        if (nums !== null) {
+          categoriesFromFirst = nums.map((n) =>
+            n === null || !Number.isFinite(n) ? '' : String(n),
+          );
+        }
+      }
     }
     let valEl = firstChildElement(ser, NAME_VAL);
     // Scatter / bubble charts carry numeric data on <c:yVal> rather


### PR DESCRIPTION
## Summary
- Chart category-axis labels now fall back to `<c:cat><c:numRef>` when `<c:strRef>` is absent.
- Numeric values from `<c:numCache>` are stringified so date / number axes render.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (785 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)