### PR TITLE
feat: chart <c:varyColors> for single-series bar/column

### DIFF
--- a/.changeset/chart-vary-colors.md
+++ b/.changeset/chart-vary-colors.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: chart `<c:varyColors>` for single-series bar / column.
+`ChartSpec.varyColors` carries the `<c:plottedKind><c:varyColors val="1"/>`
+flag. When set and the chart has exactly one series, the renderer
+assigns each data point a distinct accent color (mirroring
+PowerPoint's "Vary colors by point" toggle for column / bar). Pies
+already varied colors implicitly.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -2974,7 +2974,12 @@ const renderColumnChart = (
         const h = Math.abs(top - baseY);
         // invertIfNegative paints the negative bars in the inverted shade
         // of the series color (typically a darker / muted variant).
-        const baseColor = spec.series[s]?.color ?? colors[s % colors.length]!;
+        // varyColors (single-series): each data point gets a distinct
+        // accent color, mirroring PowerPoint's "Vary colors by point".
+        const baseColor =
+          spec.varyColors && spec.series.length === 1
+            ? colors[c % colors.length]!
+            : (spec.series[s]?.color ?? colors[s % colors.length]!);
         const fillColor =
           v < 0 && spec.series[s]?.invertIfNegative
             ? mixHex(baseColor, '#000000', 0.55)
@@ -3299,7 +3304,10 @@ const renderBarChart = (f: ChartFrame, spec: ChartSpec, colors: ReadonlyArray<st
         const tip = f.plotX + ((v - min) / range) * f.plotW;
         const x0 = Math.min(tip, baseX);
         const w = Math.abs(tip - baseX);
-        const baseColor = spec.series[s]?.color ?? colors[s % colors.length]!;
+        const baseColor =
+          spec.varyColors && spec.series.length === 1
+            ? colors[c % colors.length]!
+            : (spec.series[s]?.color ?? colors[s % colors.length]!);
         const fillColor =
           v < 0 && spec.series[s]?.invertIfNegative
             ? mixHex(baseColor, '#000000', 0.55)

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -982,6 +982,15 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     };
   }
 
+  // <c:barChart><c:varyColors val="1"/> etc. — single-series charts use
+  // it to color each data point uniquely.
+  let varyColors: boolean | undefined;
+  const vcEl = firstChildElement(plotted, qname('c', 'varyColors', NS_C));
+  if (vcEl) {
+    const v = getAttrValue(vcEl, ATTR_VAL);
+    varyColors = v === null || v === '1' || v === 'true';
+  }
+
   // <c:title><c:overlay val="1"/>
   let titleOverlay: boolean | undefined;
   const titleEl = firstChildElement(chart, NAME_TITLE);
@@ -1031,6 +1040,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     ...(overlapPct !== undefined ? { overlapPct } : {}),
     ...(legend !== undefined ? { legend } : {}),
     ...(titleOverlay !== undefined ? { titleOverlay } : {}),
+    ...(varyColors !== undefined ? { varyColors } : {}),
     ...(dispBlanksAs !== undefined ? { dispBlanksAs } : {}),
     ...(plotAreaFill !== undefined ? { plotAreaFill } : {}),
     ...(plotAreaStrokeColor !== undefined ? { plotAreaStrokeColor } : {}),

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -390,6 +390,13 @@ export interface ChartSpec {
   /** When `true`, the chart title overlays the plot area instead of taking a strip. */
   readonly titleOverlay?: boolean;
   /**
+   * `<c:barChart><c:varyColors val="1"/>` etc. — when `true` and the
+   * chart has a single series, each data point gets a distinct color
+   * from the palette. Pie / doughnut already vary colors implicitly;
+   * this flag is most useful for single-series bar / column.
+   */
+  readonly varyColors?: boolean;
+  /**
    * `<c:dispBlanksAs val="…"/>` — how line / area renderers should
    * treat `null` values in series:
    *


### PR DESCRIPTION
## Summary
- New `ChartSpec.varyColors` from `<c:plottedKind><c:varyColors val=…/>`.
- Renderer applies a per-point accent color on single-series clustered column / bar.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (785 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)