### PR TITLE
feat: chart value-axis <c:dispUnits>

### DIFF
--- a/.changeset/disp-units.md
+++ b/.changeset/disp-units.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: chart value-axis honors `<c:dispUnits><c:builtInUnit/>`.
+`ChartAxisScaling.displayUnits` carries the authored scale token
+(`hundreds`, `thousands`, `millions`, etc.). The playground divides
+each value-axis tick by the corresponding divisor before formatting,
+so charts authored "in millions" finally render as `10` / `20` /
+`30` instead of `10000000`.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -2612,7 +2612,30 @@ interface AxisSpec {
   readonly majorTickMark?: 'in' | 'out' | 'cross' | 'none';
   /** Authored tick-label rotation, in degrees. */
   readonly labelRotationDeg?: number;
+  /** Authored `<c:dispUnits>` value-axis scale token. */
+  readonly displayUnits?:
+    | 'hundreds'
+    | 'thousands'
+    | 'tenThousands'
+    | 'hundredThousands'
+    | 'millions'
+    | 'tenMillions'
+    | 'hundredMillions'
+    | 'billions'
+    | 'trillions';
 }
+
+const DISPLAY_UNIT_DIVISOR: Record<NonNullable<AxisSpec['displayUnits']>, number> = {
+  hundreds: 1e2,
+  thousands: 1e3,
+  tenThousands: 1e4,
+  hundredThousands: 1e5,
+  millions: 1e6,
+  tenMillions: 1e7,
+  hundredMillions: 1e8,
+  billions: 1e9,
+  trillions: 1e12,
+};
 
 // Builds the `font-family / font-size / fill / weight` SVG attribute
 // string for axis tick labels. Defaults match PowerPoint's stock 10pt
@@ -2671,7 +2694,12 @@ const renderValueAxis = (f: ChartFrame, axis: AxisSpec): string => {
       const rot = axis.labelRotationDeg ?? 0;
       const transform = rot ? ` transform="rotate(${rot} ${px(labelX)} ${px(yp)})"` : '';
       out.push(
-        `<text x="${px(labelX)}" y="${px(yp)}" text-anchor="end" dominant-baseline="middle" ${axisTickAttrs(axis.labelStyle)}${transform}>${escapeXml(formatAxisLabel(t, axis.numberFormat))}</text>`,
+        `<text x="${px(labelX)}" y="${px(yp)}" text-anchor="end" dominant-baseline="middle" ${axisTickAttrs(axis.labelStyle)}${transform}>${escapeXml(
+          formatAxisLabel(
+            axis.displayUnits ? t / DISPLAY_UNIT_DIVISOR[axis.displayUnits] : t,
+            axis.numberFormat,
+          ),
+        )}</text>`,
       );
     } else {
       const xp = f.plotX + ((t - axis.min) / range) * f.plotW;
@@ -2693,7 +2721,12 @@ const renderValueAxis = (f: ChartFrame, axis: AxisSpec): string => {
       const rotH = axis.labelRotationDeg ?? 0;
       const transformH = rotH ? ` transform="rotate(${rotH} ${px(xp)} ${px(horizLabelY)})"` : '';
       out.push(
-        `<text x="${px(xp)}" y="${px(horizLabelY)}" text-anchor="middle" dominant-baseline="middle" ${axisTickAttrs(axis.labelStyle)}${transformH}>${escapeXml(formatAxisLabel(t, axis.numberFormat))}</text>`,
+        `<text x="${px(xp)}" y="${px(horizLabelY)}" text-anchor="middle" dominant-baseline="middle" ${axisTickAttrs(axis.labelStyle)}${transformH}>${escapeXml(
+          formatAxisLabel(
+            axis.displayUnits ? t / DISPLAY_UNIT_DIVISOR[axis.displayUnits] : t,
+            axis.numberFormat,
+          ),
+        )}</text>`,
       );
     }
   }
@@ -3760,6 +3793,9 @@ const renderChart = (
         : {}),
       ...(spec.valueAxisLabelRotationDeg !== undefined
         ? { labelRotationDeg: spec.valueAxisLabelRotationDeg }
+        : {}),
+      ...(spec.valueAxis?.displayUnits !== undefined
+        ? { displayUnits: spec.valueAxis.displayUnits }
         : {}),
     };
     const valueAxis: AxisSpec =

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -698,6 +698,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     let majorUnit: number | undefined;
     let minorUnit: number | undefined;
     let logBase: number | undefined;
+    let displayUnits: ChartAxisScaling['displayUnits'];
     const scaling = firstChildElement(valAx, qname('c', 'scaling', NS_C));
     const readNumOn = (parent: XmlElement, local: string): number | undefined => {
       const el = firstChildElement(parent, qname('c', local, NS_C));
@@ -716,6 +717,27 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     }
     majorUnit = readNumOn(valAx, 'majorUnit');
     minorUnit = readNumOn(valAx, 'minorUnit');
+    // <c:dispUnits><c:builtInUnit val="hundreds|thousands|…"/>
+    const dispUnits = firstChildElement(valAx, qname('c', 'dispUnits', NS_C));
+    if (dispUnits) {
+      const builtIn = firstChildElement(dispUnits, qname('c', 'builtInUnit', NS_C));
+      if (builtIn) {
+        const v = getAttrValue(builtIn, ATTR_VAL);
+        switch (v) {
+          case 'hundreds':
+          case 'thousands':
+          case 'tenThousands':
+          case 'hundredThousands':
+          case 'millions':
+          case 'tenMillions':
+          case 'hundredMillions':
+          case 'billions':
+          case 'trillions':
+            displayUnits = v;
+            break;
+        }
+      }
+    }
     // <c:numFmt formatCode="…" sourceLinked="0|1"/> sits directly under
     // <c:valAx>. We surface the formatCode for renderers; sourceLinked
     // (whether to inherit Excel cell format) isn't useful at our layer.
@@ -733,7 +755,8 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
       majorUnit !== undefined ||
       minorUnit !== undefined ||
       numberFormat !== undefined ||
-      logBase !== undefined
+      logBase !== undefined ||
+      displayUnits !== undefined
     ) {
       valueAxis = {
         ...(min !== undefined ? { min } : {}),
@@ -742,6 +765,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
         ...(minorUnit !== undefined ? { minorUnit } : {}),
         ...(numberFormat !== undefined ? { numberFormat } : {}),
         ...(logBase !== undefined ? { logBase } : {}),
+        ...(displayUnits !== undefined ? { displayUnits } : {}),
       };
     }
   }

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -205,6 +205,28 @@ export interface ChartAxisScaling {
    * mapping to plot coordinates. Linear when omitted.
    */
   readonly logBase?: number;
+  /**
+   * Authored display-units scale from `<c:dispUnits><c:builtInUnit val="…"/>`.
+   * Token values map to divisors:
+   *
+   *   - `'hundreds'` (100), `'thousands'` (1e3), `'tenThousands'` (1e4),
+   *     `'hundredThousands'` (1e5), `'millions'` (1e6),
+   *     `'tenMillions'` (1e7), `'hundredMillions'` (1e8),
+   *     `'billions'` (1e9), `'trillions'` (1e12)
+   *
+   * Renderers divide axis labels by the divisor and may append a unit
+   * suffix ("K", "M", "B") for readability.
+   */
+  readonly displayUnits?:
+    | 'hundreds'
+    | 'thousands'
+    | 'tenThousands'
+    | 'hundredThousands'
+    | 'millions'
+    | 'tenMillions'
+    | 'hundredMillions'
+    | 'billions'
+    | 'trillions';
 }
 
 /**


### PR DESCRIPTION
## Summary
- `ChartAxisScaling.displayUnits` from `<c:valAx><c:dispUnits><c:builtInUnit val=…/>`.
- Renderer divides each tick value by the matching divisor before formatting.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (785 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)