### PR TITLE
feat(site/playground): slide-jump click actions render anchors

### DIFF
--- a/.changeset/slide-jump-render.md
+++ b/.changeset/slide-jump-render.md
@@ -1,0 +1,11 @@
+---
+'pptx-kit': minor
+---
+
+feat(site/playground): shapes with slide-jump click actions
+(`<a:hlinkClick action="ppaction://hlinksldjump"/>`) render as
+in-page hash anchors. The renderer resolves the target via
+`getShapeClickAction` and emits `<a href="#slide-N">`; each slide's
+`<li>` carries `id="slide-N"` so clicks scroll to the target slide.
+Plain URL click actions render the same way as shape-level
+hyperlinks (with `target="_blank"`).

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -44,6 +44,7 @@ import {
   getShapeBodyPrEffective,
   getShapeChartKind,
   getShapeChartSpec,
+  getShapeClickAction,
   getShapeHyperlink,
   getShapeTextColumns,
   getShapeTextBodyRotationDeg,
@@ -90,6 +91,7 @@ import {
   getSlideMasterBackgroundGradientFill,
   getSlideBackgroundImageBytes,
   getSlideBackgroundPatternFill,
+  getSlideIndex,
   getSlideLayout,
   getSlideLayoutBackground,
   getSlideLayoutBackgroundImageBytes,
@@ -4410,14 +4412,33 @@ const renderShape = (
   // and react badly to feGaussianBlur (DOM gets rasterized).
   geomSvg = `<g${filterAttr}>${geomSvg}</g>`;
 
-  // B6 — Shape-level hyperlinks. Wrap the rendered shape in an SVG
-  // <a href> so the playground preview is clickable, matching the
-  // PowerPoint slideshow's behavior. Per-run hyperlinks live on the
-  // text body and are handled by renderRun separately.
+  // B6 — Shape-level hyperlinks + slide-jump click actions. Wrap the
+  // rendered shape in an SVG <a href> so the playground preview is
+  // clickable, matching the PowerPoint slideshow's behavior. Per-run
+  // hyperlinks live on the text body and are handled by renderRun
+  // separately.
   const url = getShapeHyperlink(shape);
   const inner = `${p.defs}${fxDefs}<g${transform}>${geomSvg}${textOverlay}</g>`;
-  if (url)
+  if (url) {
     return `<a href="${escapeXml(url)}" target="_blank" rel="noopener noreferrer">${inner}</a>`;
+  }
+  // Slide-jump click actions resolve to a hash anchor — the playground
+  // gives each <li> an id="slide-N" so the browser jumps in-page.
+  const action = getShapeClickAction(shape);
+  if (action) {
+    let href: string | null = null;
+    if (action.kind === 'slide') {
+      const idx = getSlideIndex(pres, action.slide);
+      if (idx >= 0) href = `#slide-${idx + 1}`;
+    } else if (action.kind === 'url') {
+      href = action.url;
+    }
+    if (href !== null) {
+      const isInPage = href.startsWith('#');
+      const targetAttrs = isInPage ? '' : ' target="_blank" rel="noopener noreferrer"';
+      return `<a href="${escapeXml(href)}"${targetAttrs}>${inner}</a>`;
+    }
+  }
   return inner;
 };
 

--- a/site/src/routes/playground/+page.svelte
+++ b/site/src/routes/playground/+page.svelte
@@ -182,7 +182,7 @@
     <h2>Slides</h2>
     <ol class="slides">
       {#each slides as s (s.index)}
-        <li>
+        <li id={`slide-${s.index}`}>
           <div class="s-head">
             <span class="s-num">{String(s.index).padStart(2, '0')}</span>
             <span class="s-title">{s.title || '(untitled)'}</span>


### PR DESCRIPTION
## Summary
- Shape `<a:hlinkClick action="ppaction://hlinksldjump"/>` wraps in `<a href="#slide-N">`.
- Each `<li>` in the playground carries `id="slide-N"` so clicks scroll to the target slide.
- URL click actions also flow through this path (target=_blank).

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (785 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)