### PR TITLE
feat(site/playground): per-run slide-jump click actions

### DIFF
--- a/.changeset/run-slide-jump-render.md
+++ b/.changeset/run-slide-jump-render.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat(site/playground): per-run slide-jump click actions render as
+in-page anchors. Mirrors the shape-level slide-jump support shipped
+in the prior batch — `getShapeRunClickAction` resolves to either a
+URL or `#slide-N` anchor, and the run-level `<a href>` wrapper
+respects whether the href is in-page (no `target=_blank`) or
+external.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -64,6 +64,7 @@ import {
   getShapeKind,
   getShapeParagraphCount,
   getShapeParagraphElements,
+  getShapeRunClickAction,
   getShapeRunHyperlink,
   getShapePlaceholderType,
   getShapePreset,
@@ -2151,6 +2152,18 @@ const renderTextBody = (
         }
         try {
           href = getShapeRunHyperlink(shape, p, rIdx) ?? undefined;
+          // Per-run slide-jump actions (`<a:hlinkClick action=
+          // "ppaction://hlinksldjump"/>`) resolve to an in-page anchor.
+          // Fall back to them only when no external URL was authored.
+          if (!href) {
+            const act = getShapeRunClickAction(shape, p, rIdx);
+            if (act?.kind === 'slide') {
+              const idx = getSlideIndex(pres, act.slide);
+              if (idx >= 0) href = `#slide-${idx + 1}`;
+            } else if (act?.kind === 'url') {
+              href = act.url;
+            }
+          }
         } catch {
           href = undefined;
         }
@@ -2281,9 +2294,10 @@ const renderTextBody = (
         run.sizePt * autoFitScale,
         run.fmt?.size === undefined,
       );
-      return run.href
-        ? `<a href="${escapeXml(run.href)}" target="_blank" rel="noopener noreferrer" style="color:inherit;text-decoration:inherit">${span}</a>`
-        : span;
+      if (!run.href) return span;
+      const isInPage = run.href.startsWith('#');
+      const targetAttrs = isInPage ? '' : ' target="_blank" rel="noopener noreferrer"';
+      return `<a href="${escapeXml(run.href)}"${targetAttrs} style="color:inherit;text-decoration:inherit">${span}</a>`;
     });
     // <a:lnSpc> — paragraph line spacing. spcPct multiplies, spcPts
     // sets a fixed point value. CSS line-height accepts both forms;


### PR DESCRIPTION
## Summary
- Per-run `<a:hlinkClick action="ppaction://hlinksldjump"/>` now resolves to `#slide-N`.
- Run-level `<a href>` skips `target=_blank` for in-page hash anchors.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (785 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)