### PR TITLE
feat: slideHasAnimations + transition/anim badges in playground

### DIFF
--- a/.changeset/slide-has-animations.md
+++ b/.changeset/slide-has-animations.md
@@ -1,0 +1,11 @@
+---
+'pptx-kit': minor
+---
+
+feat: `slideHasAnimations(slide)` — per-slide animation predicate.
+Returns `true` when the slide carries a `<p:timing>` block (at least
+one authored animation effect). Complements the deck-wide
+`getPresentationSummary().hasAnimations`. The site playground uses
+it (plus `getSlideTransition`) to show small `anim` / `trans`
+badges next to each slide title so deck audits don't need to open
+PowerPoint.

--- a/site/src/routes/playground/+page.svelte
+++ b/site/src/routes/playground/+page.svelte
@@ -11,11 +11,13 @@
     getSlideNotes,
     getSlideShapes,
     getSlideTitle,
+    getSlideTransition,
     getSlides,
     getSlideTextLength,
     listPackageParts,
     loadPresentation,
     savePresentation,
+    slideHasAnimations,
   } from 'pptx-kit';
   import { renderSlideSvg } from '$lib/playground/render-slide';
 
@@ -26,6 +28,8 @@
     shapeKinds: string[];
     svg: string;
     notes: string | null;
+    hasTransition: boolean;
+    hasAnimations: boolean;
   };
 
   type PackagePart = { name: string; contentType: string; byteLength: number };
@@ -59,6 +63,8 @@
         shapeKinds: getSlideShapes(slide).map((sh) => getShapeKind(sh)),
         svg: renderSlideSvg(pres, slide),
         notes: getSlideNotes(slide),
+        hasTransition: getSlideTransition(slide) !== null,
+        hasAnimations: slideHasAnimations(slide),
       }));
 
       parts = listPackageParts(pres)
@@ -189,6 +195,8 @@
           <div class="s-head">
             <span class="s-num">{String(s.index).padStart(2, '0')}</span>
             <span class="s-title">{s.title || '(untitled)'}</span>
+            {#if s.hasTransition}<span class="s-badge" title="slide carries <p:transition>">trans</span>{/if}
+            {#if s.hasAnimations}<span class="s-badge" title="slide carries <p:timing>">anim</span>{/if}
             <span class="s-len">{s.textLength} chars · {s.shapeKinds.length} shapes</span>
           </div>
           <div class="s-canvas">
@@ -476,6 +484,17 @@
   .s-kinds code {
     font-size: 11px;
     padding: 0.1em 0.45em;
+  }
+
+  .s-badge {
+    display: inline-block;
+    padding: 0.05em 0.45em;
+    font-size: 10px;
+    font-family: var(--mono, monospace);
+    color: var(--muted, #4b5563);
+    background: var(--panel, #f1f5f9);
+    border-radius: 3px;
+    margin-left: 0.25em;
   }
 
   .s-notes {

--- a/src/api/fn/slides.ts
+++ b/src/api/fn/slides.ts
@@ -565,6 +565,18 @@ export const isSlideHidden = (slide: SlideData): boolean => {
 };
 
 /**
+ * Returns `true` when the slide carries a `<p:timing>` block — i.e.,
+ * has at least one authored animation effect. Per-slide complement to
+ * `getPresentationSummary().hasAnimations`, which only reports a
+ * deck-wide flag.
+ */
+export const slideHasAnimations = (slide: SlideData): boolean => {
+  return slide[SLIDE_DOCUMENT].root.children.some(
+    (c) => c.kind === 'element' && c.name.namespaceURI === NS.pml && c.name.localName === 'timing',
+  );
+};
+
+/**
  * Toggles the slide's visibility in the slideshow. Hiding adds
  * `show="0"`; showing removes the attribute (PowerPoint treats absence
  * as the default `show="1"`).

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -464,6 +464,7 @@ export {
   setThumbnail,
   pointInShape,
   shapesOverlap,
+  slideHasAnimations,
   slidesUsingMediaPart,
   sortSlides,
   swapSlides,


### PR DESCRIPTION
## Summary
- New `slideHasAnimations(slide)` — per-slide `<p:timing>` presence check.
- Playground shows `trans` / `anim` badges next to each slide title.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (785 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)