### PR TITLE
feat(site/playground): show slide layout type as a badge

### DIFF
--- a/.changeset/playground-layout-type-badge.md
+++ b/.changeset/playground-layout-type-badge.md
@@ -1,0 +1,9 @@
+---
+'pptx-kit': minor
+---
+
+feat(site/playground): show the slide's layout type (`title`, `obj`,
+`twoObj`, `blank`, …) as a badge next to the slide title. Reads
+`<p:sldLayout type="…">` via `getSlideLayout` + `getSlideLayoutType`
+so deck audits can spot which layout each slide is bound to without
+opening PowerPoint.

--- a/site/src/routes/playground/+page.svelte
+++ b/site/src/routes/playground/+page.svelte
@@ -9,6 +9,8 @@
     getCoreProperties,
     getShapeKind,
     getSlideComments,
+    getSlideLayout,
+    getSlideLayoutType,
     getSlideNotes,
     getSlideShapes,
     getSlideTitle,
@@ -34,6 +36,7 @@
     hasAnimations: boolean;
     hidden: boolean;
     commentCount: number;
+    layoutType: string | null;
   };
 
   type PackagePart = { name: string; contentType: string; byteLength: number };
@@ -60,18 +63,23 @@
 
       const list = getSlides(pres);
       slideCount = list.length;
-      slides = list.map((slide, i) => ({
-        index: i + 1,
-        title: getSlideTitle(slide) ?? '',
-        textLength: getSlideTextLength(slide),
-        shapeKinds: getSlideShapes(slide).map((sh) => getShapeKind(sh)),
-        svg: renderSlideSvg(pres, slide),
-        notes: getSlideNotes(slide),
-        hasTransition: getSlideTransition(slide) !== null,
-        hasAnimations: slideHasAnimations(slide),
-        hidden: isSlideHidden(slide),
-        commentCount: getSlideComments(slide).length,
-      }));
+      slides = list.map((slide, i) => {
+        const layout = getSlideLayout(slide);
+        const layoutType = layout ? getSlideLayoutType(layout) : null;
+        return {
+          index: i + 1,
+          title: getSlideTitle(slide) ?? '',
+          textLength: getSlideTextLength(slide),
+          shapeKinds: getSlideShapes(slide).map((sh) => getShapeKind(sh)),
+          svg: renderSlideSvg(pres, slide),
+          notes: getSlideNotes(slide),
+          hasTransition: getSlideTransition(slide) !== null,
+          hasAnimations: slideHasAnimations(slide),
+          hidden: isSlideHidden(slide),
+          commentCount: getSlideComments(slide).length,
+          layoutType,
+        };
+      });
 
       parts = listPackageParts(pres)
         .slice()
@@ -201,6 +209,7 @@
           <div class="s-head">
             <span class="s-num">{String(s.index).padStart(2, '0')}</span>
             <span class="s-title">{s.title || '(untitled)'}</span>
+            {#if s.layoutType}<span class="s-badge" title="slide layout type from <p:sldLayout type=…>">{s.layoutType}</span>{/if}
             {#if s.hidden}<span class="s-badge s-badge-hidden" title='show="0" — hidden from slideshow'>hidden</span>{/if}
             {#if s.hasTransition}<span class="s-badge" title="slide carries <p:transition>">trans</span>{/if}
             {#if s.hasAnimations}<span class="s-badge" title="slide carries <p:timing>">anim</span>{/if}


### PR DESCRIPTION
## Summary
- Calls `getSlideLayoutType` for each slide and renders the layout token next to the slide title.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (785 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)