### PR TITLE
feat(site/playground): expose getPresentationSummary in meta panel

### DIFF
--- a/.changeset/playground-presentation-summary.md
+++ b/.changeset/playground-presentation-summary.md
@@ -1,0 +1,9 @@
+---
+'pptx-kit': minor
+---
+
+feat(site/playground): expose `getPresentationSummary` data in the
+meta panel — theme name, layout / section counts, total shape count,
+and deck-wide flags (hidden slides, charts, comments, animations).
+Gives deck audits a one-glance overview without scrolling through
+every slide.

--- a/site/src/routes/playground/+page.svelte
+++ b/site/src/routes/playground/+page.svelte
@@ -7,6 +7,7 @@
   // does — type errors here break the build.
   import {
     getCoreProperties,
+    getPresentationSummary,
     getShapeKind,
     getSlideComments,
     getSlideLayout,
@@ -48,6 +49,7 @@
   let slideCount = $state<number>(0);
   let coreTitle = $state<string>('');
   let coreCreator = $state<string>('');
+  let summary = $state<ReturnType<typeof getPresentationSummary> | null>(null);
   let slides = $state<SlideSnapshot[]>([]);
   let parts = $state<PackagePart[]>([]);
   let lastBytes = $state<Uint8Array | null>(null);
@@ -60,6 +62,7 @@
       const core = getCoreProperties(pres);
       coreTitle = core?.title ?? '';
       coreCreator = core?.creator ?? '';
+      summary = getPresentationSummary(pres);
 
       const list = getSlides(pres);
       slideCount = list.length;
@@ -200,6 +203,32 @@
         <span class="label">core / creator</span>
         <span class="value">{coreCreator || '—'}</span>
       </div>
+      {#if summary}
+        <div class="cell">
+          <span class="label">theme</span>
+          <span class="value">{summary.themeName ?? '—'}</span>
+        </div>
+        <div class="cell">
+          <span class="label">layouts · sections</span>
+          <span class="value">{summary.layoutCount} · {summary.sectionCount}</span>
+        </div>
+        <div class="cell">
+          <span class="label">shapes (total)</span>
+          <span class="value">{summary.totalShapes}</span>
+        </div>
+        <div class="cell">
+          <span class="label">deck flags</span>
+          <span class="value">
+            {summary.hiddenSlideCount > 0 ? `${summary.hiddenSlideCount} hidden · ` : ''}{summary.hasCharts
+              ? 'charts · '
+              : ''}{summary.hasComments ? 'comments · ' : ''}{summary.hasAnimations
+              ? 'animations'
+              : ''}{!summary.hasCharts && !summary.hasComments && !summary.hasAnimations && summary.hiddenSlideCount === 0
+              ? '—'
+              : ''}
+          </span>
+        </div>
+      {/if}
     </div>
 
     <h2>Slides</h2>


### PR DESCRIPTION
## Summary
- Adds theme name, layout/section counts, total shape count, and deck-wide flag cells to the playground meta panel.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (785 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)