### PR TITLE
feat(site/playground): show validatePresentation results

### DIFF
--- a/.changeset/playground-validation-panel.md
+++ b/.changeset/playground-validation-panel.md
@@ -1,0 +1,9 @@
+---
+'pptx-kit': minor
+---
+
+feat(site/playground): show `validatePresentation` results. The
+playground now runs the validator after parsing and surfaces any
+issues in a dedicated panel (with severity tint and the offending
+part name when available). Lets users spot missing rels, dangling
+slide IDs, etc. without dropping into the test harness.

--- a/site/src/routes/playground/+page.svelte
+++ b/site/src/routes/playground/+page.svelte
@@ -8,6 +8,8 @@
   import {
     getCoreProperties,
     getPresentationSummary,
+    type ValidationIssue,
+    validatePresentation,
     getShapeKind,
     getSlideComments,
     getSlideLayout,
@@ -50,6 +52,7 @@
   let coreTitle = $state<string>('');
   let coreCreator = $state<string>('');
   let summary = $state<ReturnType<typeof getPresentationSummary> | null>(null);
+  let issues = $state<ReadonlyArray<ValidationIssue>>([]);
   let slides = $state<SlideSnapshot[]>([]);
   let parts = $state<PackagePart[]>([]);
   let lastBytes = $state<Uint8Array | null>(null);
@@ -63,6 +66,7 @@
       coreTitle = core?.title ?? '';
       coreCreator = core?.creator ?? '';
       summary = getPresentationSummary(pres);
+      issues = validatePresentation(pres);
 
       const list = getSlides(pres);
       slideCount = list.length;
@@ -230,6 +234,19 @@
         </div>
       {/if}
     </div>
+
+    {#if issues.length > 0}
+      <h2>Validation</h2>
+      <ul class="issues">
+        {#each issues as iss (iss.message)}
+          <li class={`issue issue-${iss.severity}`}>
+            <span class="issue-sev">{iss.severity}</span>
+            <span class="issue-msg">{iss.message}</span>
+            {#if iss.partName}<code class="issue-part">{iss.partName}</code>{/if}
+          </li>
+        {/each}
+      </ul>
+    {/if}
 
     <h2>Slides</h2>
     <ol class="slides">
@@ -546,6 +563,51 @@
   .s-badge-hidden {
     color: #92400e;
     background: #fef3c7;
+  }
+
+  .issues {
+    list-style: none;
+    margin: 0.5rem 0 1.5rem;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    font-size: 0.88rem;
+  }
+
+  .issue {
+    display: flex;
+    gap: 0.5rem;
+    padding: 0.35rem 0.55rem;
+    border-radius: 4px;
+    background: var(--panel, #f8fafc);
+  }
+
+  .issue-error {
+    color: #b91c1c;
+    background: #fee2e2;
+  }
+
+  .issue-warning {
+    color: #92400e;
+    background: #fef3c7;
+  }
+
+  .issue-sev {
+    font-family: var(--mono, monospace);
+    font-size: 11px;
+    text-transform: uppercase;
+    align-self: center;
+  }
+
+  .issue-msg {
+    flex: 1;
+  }
+
+  .issue-part {
+    font-family: var(--mono, monospace);
+    font-size: 11px;
+    opacity: 0.7;
   }
 
   .s-notes {


### PR DESCRIPTION
## Summary
- Runs `validatePresentation` after parse and renders the issues in a small panel.
- Severity-tinted (error red, warning amber), with the part name when present.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (785 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)