### PR TITLE
feat: chart <c:legendEntry><c:delete> series hiding

### DIFF
--- a/.changeset/chart-legend-hidden-entries.md
+++ b/.changeset/chart-legend-hidden-entries.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: chart `<c:legend><c:legendEntry><c:delete val="1"/>` honored.
+`ChartSpec.legend.hiddenIndices` carries the series indices the
+author wants suppressed from the legend (typically trendline series).
+The playground filters the parallel legend arrays (names, colors,
+marker glyphs) in lock-step so the remaining entries stay aligned,
+without affecting plotted data.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -3809,11 +3809,11 @@ const renderChart = (
     spec.titleOverlay ?? false,
     spec.legend?.overlay ?? false,
   );
-  const seriesNamesForLegend: string[] =
+  const allNamesForLegend: string[] =
     spec.kind === 'pie' || spec.kind === 'doughnut'
       ? Array.from(spec.categories)
       : spec.series.map((s) => s.name);
-  const seriesColorsForLegend: string[] =
+  const allColorsForLegend: string[] =
     spec.kind === 'pie' || spec.kind === 'doughnut'
       ? spec.categories.map(
           (_, i) =>
@@ -3823,6 +3823,16 @@ const renderChart = (
             '#888',
         )
       : spec.series.map((s, i) => s.color ?? colors[i % colors.length] ?? '#888');
+  // `<c:legendEntry><c:delete val="1"/>` hides specific series indices
+  // from the legend — typically trendline series. Filter the parallel
+  // arrays in lock-step so colors / names / markers stay aligned.
+  const hiddenSet = new Set(spec.legend?.hiddenIndices ?? []);
+  const seriesNamesForLegend = allNamesForLegend.filter((_, i) => !hiddenSet.has(i));
+  const seriesColorsForLegend = allColorsForLegend.filter((_, i) => !hiddenSet.has(i));
+  const markerSymbolsForLegend =
+    spec.kind === 'line' || spec.kind === 'area'
+      ? spec.series.map((s) => s.markerSymbol).filter((_, i) => !hiddenSet.has(i))
+      : undefined;
 
   // Count finite values across all series — when zero, draw a hint
   // label so an empty chart isn't indistinguishable from a working
@@ -3952,9 +3962,7 @@ const renderChart = (
           spec.legend?.textStyle,
           // Marker glyphs only carry visual meaning for line / area
           // charts; bar / column / pie use the swatch rect.
-          spec.kind === 'line' || spec.kind === 'area'
-            ? spec.series.map((s) => s.markerSymbol)
-            : undefined,
+          markerSymbolsForLegend,
         ),
     '</g>',
   ].join('');

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -997,12 +997,34 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     const overlay = ovEl ? getAttrValue(ovEl, ATTR_VAL) !== '0' : false;
     const txPr = firstChildElement(legendEl, qname('c', 'txPr', NS_C));
     const textStyle = txPr ? readLabelStyle(txPr) : undefined;
+    // <c:legendEntry><c:idx val="N"/><c:delete val="1"/> — series indices
+    // the author wants suppressed from the legend (trendlines often hide).
+    const hiddenIndices: number[] = [];
+    for (const c of legendEl.children) {
+      if (
+        c.kind !== 'element' ||
+        c.name.namespaceURI !== NS_C ||
+        c.name.localName !== 'legendEntry'
+      )
+        continue;
+      const idxEl = firstChildElement(c, qname('c', 'idx', NS_C));
+      const delEl = firstChildElement(c, qname('c', 'delete', NS_C));
+      if (!idxEl || !delEl) continue;
+      const delV = getAttrValue(delEl, ATTR_VAL);
+      const isDeleted = delV === null || delV === '1' || delV === 'true';
+      if (!isDeleted) continue;
+      const idxV = getAttrValue(idxEl, ATTR_VAL);
+      if (idxV === null) continue;
+      const n = Number.parseInt(idxV, 10);
+      if (Number.isFinite(n) && n >= 0) hiddenIndices.push(n);
+    }
     const position: 'r' | 't' | 'b' | 'l' | 'tr' =
       tok === 'r' || tok === 't' || tok === 'b' || tok === 'l' || tok === 'tr' ? tok : 'r';
     legend = {
       position,
       ...(overlay ? { overlay } : {}),
       ...(textStyle !== undefined ? { textStyle } : {}),
+      ...(hiddenIndices.length > 0 ? { hiddenIndices } : {}),
     };
   }
 

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -408,6 +408,14 @@ export interface ChartSpec {
      * shape as `titleStyle`.
      */
     readonly textStyle?: ChartTextStyle;
+    /**
+     * Series indices that the legend hides via `<c:legend><c:legendEntry>
+     * <c:idx val="N"/><c:delete val="1"/></c:legendEntry>`. Renderers
+     * filter them from the legend list while still plotting them.
+     * Common use: keep a trendline series in the data but drop its
+     * legend entry.
+     */
+    readonly hiddenIndices?: ReadonlyArray<number>;
   };
   /** When `true`, the chart title overlays the plot area instead of taking a strip. */
   readonly titleOverlay?: boolean;


### PR DESCRIPTION
## Summary
- `ChartSpec.legend.hiddenIndices` from `<c:legend><c:legendEntry><c:idx/><c:delete val="1"/></c:legendEntry>`.
- Renderer filters legend names / colors / marker symbols by index — series still plot.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (785 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)