### PR TITLE
feat(site/playground): emit shape name as data attribute

### DIFF
--- a/.changeset/shape-name-data-attr.md
+++ b/.changeset/shape-name-data-attr.md
@@ -1,0 +1,9 @@
+---
+'pptx-kit': minor
+---
+
+feat(site/playground): each shape's authored name surfaces as a
+`data-pptx-shape-name` attribute on its root `<g>` element. Lets
+DevTools, a11y inspectors, or test selectors target shapes by their
+PowerPoint name without parsing SVG geometry. Cheap to emit and has
+no visual impact.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -47,6 +47,7 @@ import {
   getShapeClickAction,
   getShapeHyperlink,
   getShapeHyperlinkTooltip,
+  getShapeName,
   getShapeTextColumns,
   getShapeTextBodyRotationDeg,
   getShapeTextDirection,
@@ -4508,7 +4509,18 @@ const renderShape = (
   // separately.
   const url = getShapeHyperlink(shape);
   const tooltip = getShapeHyperlinkTooltip(shape);
-  const inner = `${p.defs}${fxDefs}<g${transform}>${geomSvg}${textOverlay}</g>`;
+  // Expose the shape's authored name as a data attribute so DevTools /
+  // Selenium / a11y inspections can identify a shape without having to
+  // parse SVG geometry. Cheap to emit, zero visual impact.
+  const shapeName = (() => {
+    try {
+      return getShapeName(shape);
+    } catch {
+      return null;
+    }
+  })();
+  const nameAttr = shapeName ? ` data-pptx-shape-name="${escapeXml(shapeName)}"` : '';
+  const inner = `${p.defs}${fxDefs}<g${transform}${nameAttr}>${geomSvg}${textOverlay}</g>`;
   const titleEl = tooltip ? `<title>${escapeXml(tooltip)}</title>` : '';
   if (url) {
     return `<a href="${escapeXml(url)}" target="_blank" rel="noopener noreferrer">${titleEl}${inner}</a>`;


### PR DESCRIPTION
## Summary
- Each rendered shape's authored PowerPoint name surfaces as `data-pptx-shape-name` on the root `<g>`.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (785 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)