### PR TITLE
feat(site/playground): aria-label from authored alt text

### DIFF
--- a/.changeset/shape-aria-label.md
+++ b/.changeset/shape-aria-label.md
@@ -1,0 +1,9 @@
+---
+'pptx-kit': minor
+---
+
+feat(site/playground): shape `aria-label` from authored alt text.
+Each rendered shape with a non-empty alt title (or, as fallback,
+alt description) now exposes `role="img" aria-label="…"` on the
+root `<g>`. Screen readers announce decks the same way PowerPoint's
+Accessibility Inspector reports them, without affecting visuals.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -45,6 +45,8 @@ import {
   getShapeChartKind,
   getShapeChartSpec,
   getShapeClickAction,
+  getShapeAltTitle,
+  getShapeDescription,
   getShapeHyperlink,
   getShapeHyperlinkTooltip,
   getShapeName,
@@ -4511,7 +4513,9 @@ const renderShape = (
   const tooltip = getShapeHyperlinkTooltip(shape);
   // Expose the shape's authored name as a data attribute so DevTools /
   // Selenium / a11y inspections can identify a shape without having to
-  // parse SVG geometry. Cheap to emit, zero visual impact.
+  // parse SVG geometry. The PowerPoint alt-title / alt-description feed
+  // `aria-label` so screen readers announce decks the same way
+  // PowerPoint's Accessibility Inspector reports them.
   const shapeName = (() => {
     try {
       return getShapeName(shape);
@@ -4519,8 +4523,24 @@ const renderShape = (
       return null;
     }
   })();
+  const altTitle = (() => {
+    try {
+      return getShapeAltTitle(shape);
+    } catch {
+      return null;
+    }
+  })();
+  const altDesc = (() => {
+    try {
+      return getShapeDescription(shape);
+    } catch {
+      return null;
+    }
+  })();
+  const a11yLabel = altTitle ?? altDesc ?? null;
   const nameAttr = shapeName ? ` data-pptx-shape-name="${escapeXml(shapeName)}"` : '';
-  const inner = `${p.defs}${fxDefs}<g${transform}${nameAttr}>${geomSvg}${textOverlay}</g>`;
+  const ariaAttr = a11yLabel ? ` role="img" aria-label="${escapeXml(a11yLabel)}"` : '';
+  const inner = `${p.defs}${fxDefs}<g${transform}${nameAttr}${ariaAttr}>${geomSvg}${textOverlay}</g>`;
   const titleEl = tooltip ? `<title>${escapeXml(tooltip)}</title>` : '';
   if (url) {
     return `<a href="${escapeXml(url)}" target="_blank" rel="noopener noreferrer">${titleEl}${inner}</a>`;


### PR DESCRIPTION
## Summary
- Shape root `<g>` gets `role="img" aria-label="…"` from the authored alt title (or description as fallback).

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (785 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)