### PR TITLE
feat(site/playground): make slide-number an anchor link

### DIFF
--- a/.changeset/playground-slide-anchor-link.md
+++ b/.changeset/playground-slide-anchor-link.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat(site/playground): make the per-slide number an anchor link.
+Each slide's two-digit index in the head row is now an `<a
+href="#slide-N">` link, so users can right-click → "Copy link
+address" to share a deep link to a specific slide. Paired with the
+`id="slide-N"` already on each `<li>`, the link also scrolls the
+slide into view when clicked.

--- a/site/src/routes/playground/+page.svelte
+++ b/site/src/routes/playground/+page.svelte
@@ -281,7 +281,7 @@
         {/if}
         <li id={`slide-${s.index}`}>
           <div class="s-head">
-            <span class="s-num">{String(s.index).padStart(2, '0')}</span>
+            <a class="s-num" href={`#slide-${s.index}`} title="copy link to this slide">{String(s.index).padStart(2, '0')}</a>
             <span class="s-title">{s.title || '(untitled)'}</span>
             {#if s.layoutType}<span class="s-badge" title="slide layout type from <p:sldLayout type=…>">{s.layoutType}</span>{/if}
             {#if s.hidden}<span class="s-badge s-badge-hidden" title='show="0" — hidden from slideshow'>hidden</span>{/if}
@@ -536,6 +536,11 @@
     font-size: 11.5px;
     color: var(--accent);
     font-weight: 500;
+    text-decoration: none;
+  }
+
+  .s-num:hover {
+    text-decoration: underline;
   }
 
   .s-title {


### PR DESCRIPTION
## Summary
- Each slide's two-digit number is now an `<a href="#slide-N">` so users can right-click → copy link.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (785 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)