### PR TITLE
feat(site/playground): comment badge tooltip carries comment text

### DIFF
--- a/.changeset/playground-comment-tooltip.md
+++ b/.changeset/playground-comment-tooltip.md
@@ -1,0 +1,8 @@
+---
+'pptx-kit': minor
+---
+
+feat(site/playground): comment badge tooltip carries the comment
+texts. The `N cmt` badge's `title=` attribute now joins each
+comment's body text so hovering surfaces the review remarks
+without opening PowerPoint.

--- a/site/src/routes/playground/+page.svelte
+++ b/site/src/routes/playground/+page.svelte
@@ -44,6 +44,7 @@
     hasAnimations: boolean;
     hidden: boolean;
     commentCount: number;
+    commentTexts: string;
     layoutType: string | null;
     chartCount: number;
     mediaCount: number;
@@ -105,6 +106,10 @@
           hasAnimations: slideHasAnimations(slide),
           hidden: isSlideHidden(slide),
           commentCount: getSlideComments(slide).length,
+          commentTexts: getSlideComments(slide)
+            .map((c) => c.text)
+            .filter((t) => t.length > 0)
+            .join('\n'),
           layoutType,
           chartCount: getSlideCharts(slide).length,
           mediaCount: getSlideMediaPartNames(pres, slide).length,
@@ -287,7 +292,7 @@
             {#if s.hidden}<span class="s-badge s-badge-hidden" title='show="0" — hidden from slideshow'>hidden</span>{/if}
             {#if s.hasTransition}<span class="s-badge" title="slide carries <p:transition>">trans</span>{/if}
             {#if s.hasAnimations}<span class="s-badge" title="slide carries <p:timing>">anim</span>{/if}
-            {#if s.commentCount > 0}<span class="s-badge" title="slide has authored review comments">{s.commentCount} cmt</span>{/if}
+            {#if s.commentCount > 0}<span class="s-badge" title={s.commentTexts || 'slide has authored review comments'}>{s.commentCount} cmt</span>{/if}
             {#if s.chartCount > 0}<span class="s-badge" title="number of <p:graphicFrame> chart shapes on the slide">{s.chartCount} chart</span>{/if}
             {#if s.mediaCount > 0}<span class="s-badge" title="number of media parts (images / audio / video) the slide references">{s.mediaCount} media</span>{/if}
             <span class="s-len">{s.textLength} chars · {s.shapeKinds.length} shapes</span>


### PR DESCRIPTION
## Summary
- Joins each comment's body text into the `N cmt` badge's `title=` so hovering surfaces the review remarks.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (785 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)