### PR TITLE
feat(site/playground): center right / left legend vertically

### DIFF
--- a/.changeset/legend-right-center.md
+++ b/.changeset/legend-right-center.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat(site/playground): right / left chart legend stack centers
+vertically. Previously the `r` and `l` legend positions both
+stacked from a fixed `f.y + 12` top, the same as `tr`. PowerPoint
+vertically-centers right / left legends inside the chart area; the
+renderer now matches by computing `yStart` from the legend's total
+height. `tr` keeps the top-anchored stack.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -2962,8 +2962,10 @@ const renderChartLegend = (
     return out.join('');
   }
   // Right / Top-Right / Left — vertical stack along the chosen edge.
+  // 'r' / 'l' center the stack vertically; 'tr' pins it to the top.
   const lineH = 14;
-  const yStart = f.y + 12;
+  const totalH = names.length * lineH;
+  const yStart = position === 'tr' ? f.y + 12 : Math.max(f.y + 12, f.y + (f.h - totalH) / 2);
   const xCol =
     position === 'l' ? f.x + 6 : position === 'tr' ? f.x + f.w - 100 : /* 'r' */ f.x + f.w - 100;
   for (let i = 0; i < names.length; i++) {


### PR DESCRIPTION
## Summary
- Right / left chart legends now center vertically inside the chart area (matching PowerPoint).
- `tr` keeps the top-anchored stack.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (785 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)