### PR TITLE
feat(site/playground): bar chart category labels honor rotation

### DIFF
--- a/.changeset/bar-category-axis-rotation.md
+++ b/.changeset/bar-category-axis-rotation.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat(site/playground): bar chart category-axis labels honor
+`categoryAxisLabelRotationDeg`. The horizontal-value renderer used
+the rotation field only for column charts (categories along the
+x-axis); now the bar variant (categories down the y-axis) also
+rotates each label around its anchor and widens its ellipsis budget
+for tilted labels.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -2853,15 +2853,21 @@ const renderCategoryAxis = (
   } else {
     // Categories down the y-axis (bar chart).
     const step = pointCount > 0 ? f.plotH / pointCount : 0;
+    const truncLen = labelRotationDeg && Math.abs(labelRotationDeg) >= 30 ? 28 : 14;
     for (let i = 0; i < pointCount; i++) {
       if (skip > 1 && i % skip !== 0) continue;
       const cy = f.plotY + (i + 0.5) * step;
+      const lx = f.plotX - 4;
       const truncated =
-        labels[i] !== undefined && labels[i]!.length > 14
-          ? `${labels[i]!.slice(0, 12)}…`
+        labels[i] !== undefined && labels[i]!.length > truncLen
+          ? `${labels[i]!.slice(0, truncLen - 2)}…`
           : (labels[i] ?? '');
+      const transform =
+        labelRotationDeg && labelRotationDeg !== 0
+          ? ` transform="rotate(${labelRotationDeg} ${px(lx)} ${px(cy)})"`
+          : '';
       out.push(
-        `<text x="${px(f.plotX - 4)}" y="${px(cy)}" text-anchor="end" dominant-baseline="middle" ${axisTickAttrs(labelStyle)}>${escapeXml(truncated)}</text>`,
+        `<text x="${px(lx)}" y="${px(cy)}" text-anchor="end" dominant-baseline="middle" ${axisTickAttrs(labelStyle)}${transform}>${escapeXml(truncated)}</text>`,
       );
     }
   }


### PR DESCRIPTION
## Summary
- Vertical (bar) category-axis labels now honor `categoryAxisLabelRotationDeg`.
- Truncation budget widens for tilted labels.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (785 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)