### PR TITLE
test: chart-reader unit tests for recently-added optional fields

### DIFF
--- a/test/fn-chart-reader-extras.test.ts
+++ b/test/fn-chart-reader-extras.test.ts
@@ -1,0 +1,274 @@
+// Chart reader: verifies the recently-added optional fields surface
+// correctly when their underlying XML is authored. Each block is a
+// focused unit test that constructs a minimal `<c:chartSpace>` with
+// just enough markup to exercise one feature, parses via
+// `readChartSpec`, and asserts the expected `ChartSpec` shape.
+
+import { describe, expect, it } from 'vitest';
+import { readChartSpec } from '../src/internal/chartml/index.ts';
+import { parseXml } from '../src/internal/xml/index.ts';
+
+const wrap = (
+  innerChart: string,
+): string => `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+              xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <c:chart>${innerChart}</c:chart>
+</c:chartSpace>`;
+
+const MIN_PLOT_AREA = `
+  <c:plotArea>
+    <c:layout/>
+    <c:barChart>
+      <c:barDir val="col"/>
+      <c:grouping val="clustered"/>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:order val="0"/>
+        <c:tx><c:strLit><c:pt idx="0"><c:v>A</c:v></c:pt></c:strLit></c:tx>
+        <c:val><c:numLit><c:pt idx="0"><c:v>1</c:v></c:pt></c:numLit></c:val>
+      </c:ser>
+    </c:barChart>
+    <c:valAx>
+      <c:axId val="1"/>
+      <c:crossAx val="2"/>
+    </c:valAx>
+    <c:catAx>
+      <c:axId val="2"/>
+      <c:crossAx val="1"/>
+    </c:catAx>
+  </c:plotArea>`;
+
+describe('chart reader: extras', () => {
+  it('reads `<c:title><c:tx><c:rich><a:r><a:rPr>` titleStyle', () => {
+    const xml = wrap(`
+      <c:title>
+        <c:tx>
+          <c:rich>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p>
+              <a:r>
+                <a:rPr sz="2400" b="1">
+                  <a:solidFill><a:srgbClr val="2A5CAA"/></a:solidFill>
+                </a:rPr>
+                <a:t>Quarterly</a:t>
+              </a:r>
+            </a:p>
+          </c:rich>
+        </c:tx>
+      </c:title>
+      ${MIN_PLOT_AREA}
+    `);
+    const spec = readChartSpec(parseXml(xml).root)!;
+    expect(spec.title).toBe('Quarterly');
+    expect(spec.titleStyle).toEqual({ sizePt: 24, bold: true, color: '#2A5CAA' });
+  });
+
+  it('reads `<c:title><c:tx><c:strRef>` cell-reference titles', () => {
+    const xml = wrap(`
+      <c:title>
+        <c:tx>
+          <c:strRef>
+            <c:f>Sheet1!$A$1</c:f>
+            <c:strCache>
+              <c:ptCount val="1"/>
+              <c:pt idx="0"><c:v>Linked Title</c:v></c:pt>
+            </c:strCache>
+          </c:strRef>
+        </c:tx>
+      </c:title>
+      ${MIN_PLOT_AREA}
+    `);
+    const spec = readChartSpec(parseXml(xml).root)!;
+    expect(spec.title).toBe('Linked Title');
+  });
+
+  it('reads `<c:valAx><c:scaling><c:logBase>` log scale', () => {
+    const xml = wrap(`
+      <c:plotArea>
+        <c:layout/>
+        <c:barChart>
+          <c:barDir val="col"/>
+          <c:grouping val="clustered"/>
+          <c:ser>
+            <c:idx val="0"/>
+            <c:order val="0"/>
+            <c:tx><c:strLit><c:pt idx="0"><c:v>A</c:v></c:pt></c:strLit></c:tx>
+            <c:val><c:numLit><c:pt idx="0"><c:v>1</c:v></c:pt></c:numLit></c:val>
+          </c:ser>
+        </c:barChart>
+        <c:valAx>
+          <c:axId val="1"/>
+          <c:scaling><c:logBase val="10"/></c:scaling>
+          <c:crossAx val="2"/>
+        </c:valAx>
+        <c:catAx><c:axId val="2"/><c:crossAx val="1"/></c:catAx>
+      </c:plotArea>
+    `);
+    const spec = readChartSpec(parseXml(xml).root)!;
+    expect(spec.valueAxis?.logBase).toBe(10);
+  });
+
+  it('reads `<c:dispUnits><c:builtInUnit>` displayUnits', () => {
+    const xml = wrap(`
+      <c:plotArea>
+        <c:layout/>
+        <c:barChart>
+          <c:barDir val="col"/>
+          <c:grouping val="clustered"/>
+          <c:ser>
+            <c:idx val="0"/>
+            <c:order val="0"/>
+            <c:tx><c:strLit><c:pt idx="0"><c:v>A</c:v></c:pt></c:strLit></c:tx>
+            <c:val><c:numLit><c:pt idx="0"><c:v>1</c:v></c:pt></c:numLit></c:val>
+          </c:ser>
+        </c:barChart>
+        <c:valAx>
+          <c:axId val="1"/>
+          <c:dispUnits><c:builtInUnit val="millions"/></c:dispUnits>
+          <c:crossAx val="2"/>
+        </c:valAx>
+        <c:catAx><c:axId val="2"/><c:crossAx val="1"/></c:catAx>
+      </c:plotArea>
+    `);
+    const spec = readChartSpec(parseXml(xml).root)!;
+    expect(spec.valueAxis?.displayUnits).toBe('millions');
+  });
+
+  it('reads `<c:legend><c:legendEntry><c:delete>` hidden series indices', () => {
+    const xml = wrap(`
+      ${MIN_PLOT_AREA}
+      <c:legend>
+        <c:legendPos val="r"/>
+        <c:legendEntry>
+          <c:idx val="2"/>
+          <c:delete val="1"/>
+        </c:legendEntry>
+        <c:legendEntry>
+          <c:idx val="0"/>
+          <c:delete val="1"/>
+        </c:legendEntry>
+      </c:legend>
+    `);
+    const spec = readChartSpec(parseXml(xml).root)!;
+    expect(spec.legend?.hiddenIndices).toEqual([2, 0]);
+  });
+
+  it('reads `<c:catAx><c:majorTickMark>` tickMark mode', () => {
+    const xml = wrap(`
+      <c:plotArea>
+        <c:layout/>
+        <c:barChart>
+          <c:barDir val="col"/>
+          <c:grouping val="clustered"/>
+          <c:ser>
+            <c:idx val="0"/>
+            <c:order val="0"/>
+            <c:tx><c:strLit><c:pt idx="0"><c:v>A</c:v></c:pt></c:strLit></c:tx>
+            <c:val><c:numLit><c:pt idx="0"><c:v>1</c:v></c:pt></c:numLit></c:val>
+          </c:ser>
+        </c:barChart>
+        <c:valAx>
+          <c:axId val="1"/>
+          <c:majorTickMark val="cross"/>
+          <c:crossAx val="2"/>
+        </c:valAx>
+        <c:catAx>
+          <c:axId val="2"/>
+          <c:majorTickMark val="none"/>
+          <c:crossAx val="1"/>
+        </c:catAx>
+      </c:plotArea>
+    `);
+    const spec = readChartSpec(parseXml(xml).root)!;
+    expect(spec.valueAxisMajorTickMark).toBe('cross');
+    expect(spec.categoryAxisMajorTickMark).toBe('none');
+  });
+
+  it('reads `<c:catAx><c:numRef>` numeric/date categories', () => {
+    const xml = wrap(`
+      <c:plotArea>
+        <c:layout/>
+        <c:barChart>
+          <c:barDir val="col"/>
+          <c:grouping val="clustered"/>
+          <c:ser>
+            <c:idx val="0"/>
+            <c:order val="0"/>
+            <c:tx><c:strLit><c:pt idx="0"><c:v>A</c:v></c:pt></c:strLit></c:tx>
+            <c:cat>
+              <c:numRef>
+                <c:f>Sheet1!$A$1:$A$3</c:f>
+                <c:numCache>
+                  <c:formatCode>General</c:formatCode>
+                  <c:pt idx="0"><c:v>2024</c:v></c:pt>
+                  <c:pt idx="1"><c:v>2025</c:v></c:pt>
+                  <c:pt idx="2"><c:v>2026</c:v></c:pt>
+                </c:numCache>
+              </c:numRef>
+            </c:cat>
+            <c:val><c:numLit><c:pt idx="0"><c:v>1</c:v></c:pt></c:numLit></c:val>
+          </c:ser>
+        </c:barChart>
+        <c:valAx><c:axId val="1"/><c:crossAx val="2"/></c:valAx>
+        <c:catAx><c:axId val="2"/><c:crossAx val="1"/></c:catAx>
+      </c:plotArea>
+    `);
+    const spec = readChartSpec(parseXml(xml).root)!;
+    expect(spec.categories).toEqual(['2024', '2025', '2026']);
+  });
+
+  it('reads `<c:trendline><c:forward>/<c:backward>` extensions', () => {
+    const xml = wrap(`
+      <c:plotArea>
+        <c:layout/>
+        <c:lineChart>
+          <c:grouping val="standard"/>
+          <c:ser>
+            <c:idx val="0"/>
+            <c:order val="0"/>
+            <c:tx><c:strLit><c:pt idx="0"><c:v>A</c:v></c:pt></c:strLit></c:tx>
+            <c:trendline>
+              <c:trendlineType val="linear"/>
+              <c:forward val="3"/>
+              <c:backward val="1"/>
+            </c:trendline>
+            <c:val><c:numLit><c:pt idx="0"><c:v>1</c:v></c:pt></c:numLit></c:val>
+          </c:ser>
+        </c:lineChart>
+        <c:valAx><c:axId val="1"/><c:crossAx val="2"/></c:valAx>
+        <c:catAx><c:axId val="2"/><c:crossAx val="1"/></c:catAx>
+      </c:plotArea>
+    `);
+    const spec = readChartSpec(parseXml(xml).root)!;
+    const tl = spec.series[0]?.trendline;
+    expect(tl?.type).toBe('linear');
+    expect(tl?.forward).toBe(3);
+    expect(tl?.backward).toBe(1);
+  });
+
+  it('reads `<c:varyColors>` flag', () => {
+    const xml = wrap(`
+      <c:plotArea>
+        <c:layout/>
+        <c:barChart>
+          <c:varyColors val="1"/>
+          <c:barDir val="col"/>
+          <c:grouping val="clustered"/>
+          <c:ser>
+            <c:idx val="0"/>
+            <c:order val="0"/>
+            <c:tx><c:strLit><c:pt idx="0"><c:v>A</c:v></c:pt></c:strLit></c:tx>
+            <c:val><c:numLit><c:pt idx="0"><c:v>1</c:v></c:pt></c:numLit></c:val>
+          </c:ser>
+        </c:barChart>
+        <c:valAx><c:axId val="1"/><c:crossAx val="2"/></c:valAx>
+        <c:catAx><c:axId val="2"/><c:crossAx val="1"/></c:catAx>
+      </c:plotArea>
+    `);
+    const spec = readChartSpec(parseXml(xml).root)!;
+    expect(spec.varyColors).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- 9 focused unit tests verifying chart-reader extras: `titleStyle`, `strRef` titles, `logBase`, `displayUnits`, `hiddenIndices`, `majorTickMark`, numeric categories, `trendline.forward`/`backward`, `varyColors`.
- Total tests: 794 passing (was 785).
- No changeset — internal-only test additions.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (794 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)