### PR TITLE
test: slideHasAnimations predicate coverage

### DIFF
--- a/test/fn-slide-has-animations.test.ts
+++ b/test/fn-slide-has-animations.test.ts
@@ -1,0 +1,34 @@
+// slideHasAnimations — predicate for "does this slide carry <p:timing>?"
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  getSlideShapes,
+  getSlides,
+  loadPresentation,
+  setShapeAnimation,
+  slideHasAnimations,
+} from '../src/api/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+describe('fn API: slideHasAnimations', () => {
+  it('returns false for slides without <p:timing>', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    for (const slide of getSlides(pres)) {
+      expect(slideHasAnimations(slide)).toBe(false);
+    }
+  });
+
+  it('flips true after setShapeAnimation', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const shape = getSlideShapes(slide)[0];
+    if (!shape) return;
+    expect(slideHasAnimations(slide)).toBe(false);
+    setShapeAnimation(shape, { effect: 'fadeIn' });
+    expect(slideHasAnimations(slide)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- 2 unit tests for `slideHasAnimations`: baseline and post-`setShapeAnimation`.
- Total tests: 796 passing (was 794).

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (796 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)