### PR TITLE
feat: chart builder writes back titleStyle

### DIFF
--- a/.changeset/chart-builder-title-style.md
+++ b/.changeset/chart-builder-title-style.md
@@ -1,0 +1,11 @@
+---
+'pptx-kit': minor
+---
+
+feat: chart builder writes back `ChartSpec.titleStyle`. Previously the
+reader picked up authored `<a:rPr sz/b/i><a:solidFill>` on chart
+titles but the builder dropped any incoming style, so round-tripping
+(read → save → reload) lost the title font / color. The builder now
+emits `<a:rPr>` attributes and an inner `<a:solidFill><a:srgbClr/>`
+when a `titleStyle` is provided. New round-trip test
+(`fn-chart-readback`) covers this; total tests 801.

--- a/src/internal/chartml/chart-builder.ts
+++ b/src/internal/chartml/chart-builder.ts
@@ -8,7 +8,7 @@
 // can render the chart without ever opening the workbook.
 
 import { NS, type XmlDocument, type XmlElement, attr, elem, qname, text } from '../xml/index.ts';
-import type { ChartSpec } from './types.ts';
+import type { ChartSpec, ChartTextStyle } from './types.ts';
 
 // QNames (chart `c:` namespace) --------------------------------------------
 
@@ -203,14 +203,47 @@ const buildAreaChart = (spec: ChartSpec, sheet: string): XmlElement => {
   });
 };
 
-const titleElement = (title: string): XmlElement => {
+// Builds an <a:rPr ...><a:solidFill><a:srgbClr/></a:solidFill></a:rPr>
+// payload from a ChartTextStyle. Returns the rPr children to splice
+// into the parent run / def-run-properties node.
+const rPrAttrsFromStyle = (
+  style: ChartTextStyle | undefined,
+): {
+  attrs: ReturnType<typeof attr>[];
+  children: XmlElement[];
+} => {
+  const attrs: ReturnType<typeof attr>[] = [];
+  const children: XmlElement[] = [];
+  if (style?.sizePt !== undefined) {
+    attrs.push(attr(qname('', 'sz', ''), String(Math.round(style.sizePt * 100))));
+  }
+  if (style?.bold === true) attrs.push(attr(qname('', 'b', ''), '1'));
+  if (style?.bold === false) attrs.push(attr(qname('', 'b', ''), '0'));
+  if (style?.italic === true) attrs.push(attr(qname('', 'i', ''), '1'));
+  if (style?.italic === false) attrs.push(attr(qname('', 'i', ''), '0'));
+  if (style?.color !== undefined) {
+    const hex = style.color.startsWith('#') ? style.color.slice(1) : style.color;
+    children.push(
+      elem(a('solidFill'), {
+        children: [elem(a('srgbClr'), { attrs: [attr(qname('', 'val', ''), hex.toUpperCase())] })],
+      }),
+    );
+  }
+  return { attrs, children };
+};
+
+const titleElement = (title: string, style?: ChartTextStyle): XmlElement => {
+  // defRPr stays 1400 (14pt) as the legacy default; the run-level
+  // <a:rPr> carries authored overrides so renderers honor them.
   const rPr = elem(a('defRPr'), { attrs: [attr(qname('', 'sz', ''), '1400')] });
   const pPr = elem(a('pPr'), { children: [rPr] });
+  const { attrs: runAttrs, children: runChildren } = rPrAttrsFromStyle(style);
+  const runRPr = elem(a('rPr'), {
+    attrs: [attr(qname('', 'lang', ''), 'en-US'), ...runAttrs],
+    children: runChildren,
+  });
   const tRun = elem(a('r'), {
-    children: [
-      elem(a('rPr'), { attrs: [attr(qname('', 'lang', ''), 'en-US')] }),
-      elem(a('t'), { children: [text(title)] }),
-    ],
+    children: [runRPr, elem(a('t'), { children: [text(title)] })],
   });
   const para = elem(a('p'), { children: [pPr, tRun] });
   const rich = elem(c('rich'), {
@@ -277,7 +310,7 @@ export const buildChartSpaceDoc = (spec: ChartSpec): XmlDocument => {
   const plotArea = elem(c('plotArea'), { children: plotAreaChildren });
 
   const chartChildren: XmlElement[] = [];
-  if (spec.title !== undefined) chartChildren.push(titleElement(spec.title));
+  if (spec.title !== undefined) chartChildren.push(titleElement(spec.title, spec.titleStyle));
   chartChildren.push(
     valNode(c('autoTitleDeleted'), spec.title !== undefined ? '0' : '1'),
     plotArea,

--- a/test/fn-chart-readback.test.ts
+++ b/test/fn-chart-readback.test.ts
@@ -53,6 +53,32 @@ describe('fn API: getSlideCharts', () => {
     expect(spec!.title).toBe('Quarterly');
   });
 
+  it('round-trips titleStyle through builder', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'column',
+        categories: ['A', 'B'],
+        series: [{ name: 'X', values: [1, 2] }],
+        title: 'Styled',
+        titleStyle: { sizePt: 18, bold: true, color: '#FF0000' },
+      },
+    });
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const charts = getSlideCharts(getSlides(reloaded)[0]!);
+    const spec = charts[0]!.spec!;
+    expect(spec.title).toBe('Styled');
+    expect(spec.titleStyle?.sizePt).toBe(18);
+    expect(spec.titleStyle?.bold).toBe(true);
+    expect(spec.titleStyle?.color).toBe('#FF0000');
+  });
+
   it('distinguishes bar from column on the same barChart wire format', async () => {
     const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
     const slide = getSlides(pres)[0]!;


### PR DESCRIPTION
## Summary
- The chart builder previously dropped `ChartSpec.titleStyle` on save; now emits `<a:rPr>` attrs + `<a:solidFill><a:srgbClr/>` when provided.
- Round-trip (read → save → reload) preserves authored title font / color.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (801 passing, 22 skipped — includes a new round-trip test)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)