### PR TITLE
feat: chart builder writes back axis extras

### DIFF
--- a/.changeset/chart-builder-axis-extras.md
+++ b/.changeset/chart-builder-axis-extras.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: chart builder writes back value-axis extras and tick marks.
+`<c:valAx>` now emits `<c:scaling><c:logBase>`, `<c:majorTickMark>`,
+and `<c:dispUnits><c:builtInUnit>` when authored on `ChartSpec`;
+`<c:catAx>` emits `<c:majorTickMark>`. Round-tripping a chart with
+these fields no longer drops them. Covered by a new round-trip test
+in `fn-chart-readback`.

--- a/src/internal/chartml/chart-builder.ts
+++ b/src/internal/chartml/chart-builder.ts
@@ -115,27 +115,44 @@ const seriesElement = (spec: ChartSpec, seriesIdx: number, sheet: string): XmlEl
 const CAT_AX_ID = 111111111;
 const VAL_AX_ID = 222222222;
 
-const catAxis = (): XmlElement =>
-  elem(c('catAx'), {
-    children: [
-      valNode(c('axId'), CAT_AX_ID),
-      elem(c('scaling'), { children: [valNode(c('orientation'), 'minMax')] }),
-      valNode(c('delete'), '0'),
-      valNode(c('axPos'), 'b'),
-      valNode(c('crossAx'), VAL_AX_ID),
-    ],
-  });
+const catAxis = (spec: ChartSpec): XmlElement => {
+  const children: XmlElement[] = [
+    valNode(c('axId'), CAT_AX_ID),
+    elem(c('scaling'), { children: [valNode(c('orientation'), 'minMax')] }),
+    valNode(c('delete'), '0'),
+    valNode(c('axPos'), 'b'),
+  ];
+  if (spec.categoryAxisMajorTickMark !== undefined) {
+    children.push(valNode(c('majorTickMark'), spec.categoryAxisMajorTickMark));
+  }
+  children.push(valNode(c('crossAx'), VAL_AX_ID));
+  return elem(c('catAx'), { children });
+};
 
-const valAxis = (): XmlElement =>
-  elem(c('valAx'), {
-    children: [
-      valNode(c('axId'), VAL_AX_ID),
-      elem(c('scaling'), { children: [valNode(c('orientation'), 'minMax')] }),
-      valNode(c('delete'), '0'),
-      valNode(c('axPos'), 'l'),
-      valNode(c('crossAx'), CAT_AX_ID),
-    ],
-  });
+const valAxis = (spec: ChartSpec): XmlElement => {
+  const scalingChildren: XmlElement[] = [valNode(c('orientation'), 'minMax')];
+  if (spec.valueAxis?.logBase !== undefined) {
+    scalingChildren.push(valNode(c('logBase'), spec.valueAxis.logBase));
+  }
+  const children: XmlElement[] = [
+    valNode(c('axId'), VAL_AX_ID),
+    elem(c('scaling'), { children: scalingChildren }),
+    valNode(c('delete'), '0'),
+    valNode(c('axPos'), 'l'),
+  ];
+  if (spec.valueAxisMajorTickMark !== undefined) {
+    children.push(valNode(c('majorTickMark'), spec.valueAxisMajorTickMark));
+  }
+  children.push(valNode(c('crossAx'), CAT_AX_ID));
+  if (spec.valueAxis?.displayUnits !== undefined) {
+    children.push(
+      elem(c('dispUnits'), {
+        children: [valNode(c('builtInUnit'), spec.valueAxis.displayUnits)],
+      }),
+    );
+  }
+  return elem(c('valAx'), { children });
+};
 
 const buildBarChart = (spec: ChartSpec, sheet: string, direction: 'col' | 'bar'): XmlElement => {
   const ser = spec.series.map((_, i) => seriesElement(spec, i, sheet));
@@ -305,7 +322,7 @@ export const buildChartSpaceDoc = (spec: ChartSpec): XmlDocument => {
   const axisless = spec.kind === 'pie' || spec.kind === 'doughnut';
   const plotAreaChildren: XmlElement[] = [elem(c('layout')), plotted];
   if (!axisless) {
-    plotAreaChildren.push(catAxis(), valAxis());
+    plotAreaChildren.push(catAxis(spec), valAxis(spec));
   }
   const plotArea = elem(c('plotArea'), { children: plotAreaChildren });
 

--- a/test/fn-chart-readback.test.ts
+++ b/test/fn-chart-readback.test.ts
@@ -79,6 +79,32 @@ describe('fn API: getSlideCharts', () => {
     expect(spec.titleStyle?.color).toBe('#FF0000');
   });
 
+  it('round-trips valueAxis extras (logBase / displayUnits / tickMark)', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'column',
+        categories: ['A', 'B'],
+        series: [{ name: 'X', values: [100, 200] }],
+        valueAxis: { logBase: 10, displayUnits: 'thousands' },
+        valueAxisMajorTickMark: 'cross',
+        categoryAxisMajorTickMark: 'none',
+      },
+    });
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const spec = getSlideCharts(getSlides(reloaded)[0]!)[0]!.spec!;
+    expect(spec.valueAxis?.logBase).toBe(10);
+    expect(spec.valueAxis?.displayUnits).toBe('thousands');
+    expect(spec.valueAxisMajorTickMark).toBe('cross');
+    expect(spec.categoryAxisMajorTickMark).toBe('none');
+  });
+
   it('distinguishes bar from column on the same barChart wire format', async () => {
     const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
     const slide = getSlides(pres)[0]!;


### PR DESCRIPTION
## Summary
- valAxis/catAxis emit `<c:scaling><c:logBase>`, `<c:majorTickMark>`, `<c:dispUnits><c:builtInUnit>` when authored.
- Round-trip test verifies all three survive read → save → reload.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (802 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)