### PR TITLE
feat: chart builder writes back <c:legend> + <c:dispBlanksAs>

### DIFF
--- a/.changeset/chart-builder-legend.md
+++ b/.changeset/chart-builder-legend.md
@@ -1,0 +1,16 @@
+---
+'pptx-kit': minor
+---
+
+feat: chart builder writes back `<c:legend>` and `<c:dispBlanksAs>`.
+The chart-root previously emitted only the default legend / blanks
+behavior; the builder now:
+
+- emits `<c:legend>` with `legendPos`, `overlay`, and one
+  `<c:legendEntry><c:idx><c:delete val="1"/></c:legendEntry>` per
+  hidden series index — or skips the element when
+  `spec.legend.position === null` (author wants no legend)
+- threads `spec.dispBlanksAs` (`'gap' | 'zero' | 'span'`) into
+  `<c:dispBlanksAs>`
+
+Round-trip test added.

--- a/src/internal/chartml/chart-builder.ts
+++ b/src/internal/chartml/chart-builder.ts
@@ -373,8 +373,25 @@ export const buildChartSpaceDoc = (spec: ChartSpec): XmlDocument => {
   chartChildren.push(
     valNode(c('autoTitleDeleted'), spec.title !== undefined ? '0' : '1'),
     plotArea,
+  );
+  // <c:legend> after plotArea but before plotVisOnly / dispBlanksAs.
+  // Skip entirely when `position` is explicitly null (author wants no
+  // legend at all).
+  if (spec.legend !== undefined && spec.legend.position !== null) {
+    const legendChildren: XmlElement[] = [valNode(c('legendPos'), spec.legend.position)];
+    for (const idx of spec.legend.hiddenIndices ?? []) {
+      legendChildren.push(
+        elem(c('legendEntry'), {
+          children: [valNode(c('idx'), idx), valNode(c('delete'), '1')],
+        }),
+      );
+    }
+    legendChildren.push(valNode(c('overlay'), spec.legend.overlay ? '1' : '0'));
+    chartChildren.push(elem(c('legend'), { children: legendChildren }));
+  }
+  chartChildren.push(
     valNode(c('plotVisOnly'), '1'),
-    valNode(c('dispBlanksAs'), 'gap'),
+    valNode(c('dispBlanksAs'), spec.dispBlanksAs ?? 'gap'),
   );
   const chart = elem(c('chart'), { children: chartChildren });
 

--- a/test/fn-chart-readback.test.ts
+++ b/test/fn-chart-readback.test.ts
@@ -137,6 +137,35 @@ describe('fn API: getSlideCharts', () => {
     expect(spec.dataLabels?.separator).toBe(', ');
   });
 
+  it('round-trips legend position + hiddenIndices + overlay + dispBlanksAs', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'column',
+        categories: ['A', 'B'],
+        series: [
+          { name: 'X', values: [1, 2] },
+          { name: 'Y', values: [3, 4] },
+          { name: 'Z', values: [5, 6] },
+        ],
+        legend: { position: 't', overlay: true, hiddenIndices: [1] },
+        dispBlanksAs: 'span',
+      },
+    });
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const spec = getSlideCharts(getSlides(reloaded)[0]!)[0]!.spec!;
+    expect(spec.legend?.position).toBe('t');
+    expect(spec.legend?.overlay).toBe(true);
+    expect(spec.legend?.hiddenIndices).toEqual([1]);
+    expect(spec.dispBlanksAs).toBe('span');
+  });
+
   it('distinguishes bar from column on the same barChart wire format', async () => {
     const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
     const slide = getSlides(pres)[0]!;


### PR DESCRIPTION
## Summary
- Emits `<c:legend>` with `legendPos` / `overlay` / `legendEntry` deletions; skips the element when `legend.position === null`.
- Threads `spec.dispBlanksAs` into `<c:dispBlanksAs>`.
- Round-trip test asserts all four survive.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (804 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)