### PR TITLE
feat: chart builder writes back full value-axis scaling

### DIFF
--- a/.changeset/chart-builder-axis-scaling.md
+++ b/.changeset/chart-builder-axis-scaling.md
@@ -1,0 +1,8 @@
+---
+'pptx-kit': minor
+---
+
+feat: chart builder writes back full value-axis scaling. `<c:valAx>`
+now emits `<c:scaling><c:min/>/<c:max/>`, `<c:numFmt formatCode>`,
+`<c:majorUnit>`, and `<c:minorUnit>` when authored — completing the
+read/write parity for `ChartSpec.valueAxis`. Round-trip test added.

--- a/src/internal/chartml/chart-builder.ts
+++ b/src/internal/chartml/chart-builder.ts
@@ -130,9 +130,17 @@ const catAxis = (spec: ChartSpec): XmlElement => {
 };
 
 const valAxis = (spec: ChartSpec): XmlElement => {
-  const scalingChildren: XmlElement[] = [valNode(c('orientation'), 'minMax')];
+  // <c:scaling> ordering matters: logBase, orientation, min, max.
+  const scalingChildren: XmlElement[] = [];
   if (spec.valueAxis?.logBase !== undefined) {
     scalingChildren.push(valNode(c('logBase'), spec.valueAxis.logBase));
+  }
+  scalingChildren.push(valNode(c('orientation'), 'minMax'));
+  if (spec.valueAxis?.min !== undefined) {
+    scalingChildren.push(valNode(c('min'), spec.valueAxis.min));
+  }
+  if (spec.valueAxis?.max !== undefined) {
+    scalingChildren.push(valNode(c('max'), spec.valueAxis.max));
   }
   const children: XmlElement[] = [
     valNode(c('axId'), VAL_AX_ID),
@@ -140,10 +148,26 @@ const valAxis = (spec: ChartSpec): XmlElement => {
     valNode(c('delete'), '0'),
     valNode(c('axPos'), 'l'),
   ];
+  if (spec.valueAxis?.numberFormat !== undefined) {
+    children.push(
+      elem(c('numFmt'), {
+        attrs: [
+          attr(qname('', 'formatCode', ''), spec.valueAxis.numberFormat),
+          attr(qname('', 'sourceLinked', ''), '0'),
+        ],
+      }),
+    );
+  }
   if (spec.valueAxisMajorTickMark !== undefined) {
     children.push(valNode(c('majorTickMark'), spec.valueAxisMajorTickMark));
   }
   children.push(valNode(c('crossAx'), CAT_AX_ID));
+  if (spec.valueAxis?.majorUnit !== undefined) {
+    children.push(valNode(c('majorUnit'), spec.valueAxis.majorUnit));
+  }
+  if (spec.valueAxis?.minorUnit !== undefined) {
+    children.push(valNode(c('minorUnit'), spec.valueAxis.minorUnit));
+  }
   if (spec.valueAxis?.displayUnits !== undefined) {
     children.push(
       elem(c('dispUnits'), {

--- a/test/fn-chart-readback.test.ts
+++ b/test/fn-chart-readback.test.ts
@@ -166,6 +166,37 @@ describe('fn API: getSlideCharts', () => {
     expect(spec.dispBlanksAs).toBe('span');
   });
 
+  it('round-trips valueAxis scaling (min / max / majorUnit / minorUnit / numberFormat)', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'column',
+        categories: ['A', 'B'],
+        series: [{ name: 'X', values: [10, 50] }],
+        valueAxis: {
+          min: 0,
+          max: 100,
+          majorUnit: 20,
+          minorUnit: 5,
+          numberFormat: '0.00%',
+        },
+      },
+    });
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const spec = getSlideCharts(getSlides(reloaded)[0]!)[0]!.spec!;
+    expect(spec.valueAxis?.min).toBe(0);
+    expect(spec.valueAxis?.max).toBe(100);
+    expect(spec.valueAxis?.majorUnit).toBe(20);
+    expect(spec.valueAxis?.minorUnit).toBe(5);
+    expect(spec.valueAxis?.numberFormat).toBe('0.00%');
+  });
+
   it('distinguishes bar from column on the same barChart wire format', async () => {
     const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
     const slide = getSlides(pres)[0]!;


### PR DESCRIPTION
## Summary
- `<c:valAx>` emits `<c:scaling><c:min/>/<c:max/>`, `<c:numFmt formatCode>`, `<c:majorUnit>`, `<c:minorUnit>` when authored.
- Completes read/write parity for `ChartSpec.valueAxis`.
- Round-trip test added.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (805 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)