### PR TITLE
feat: chart builder writes back axis titles + hidden + tickLbl config

### DIFF
--- a/.changeset/chart-builder-axis-titles.md
+++ b/.changeset/chart-builder-axis-titles.md
@@ -1,0 +1,15 @@
+---
+'pptx-kit': minor
+---
+
+feat: chart builder writes back axis titles, hidden flags, and
+category-axis tick-label config. `<c:valAx>` / `<c:catAx>` now emit:
+
+- `<c:title>` with style (from `valueAxisTitleStyle` /
+  `categoryAxisTitleStyle`) when an axis title is authored
+- `<c:delete val="1"/>` when `valueAxisHidden` / `categoryAxisHidden`
+- `<c:tickLblPos>` and `<c:tickLblSkip>` when authored on the
+  category axis
+
+Closes the read/write gap for these `ChartSpec` fields. Round-trip
+test added.

--- a/src/internal/chartml/chart-builder.ts
+++ b/src/internal/chartml/chart-builder.ts
@@ -119,13 +119,22 @@ const catAxis = (spec: ChartSpec): XmlElement => {
   const children: XmlElement[] = [
     valNode(c('axId'), CAT_AX_ID),
     elem(c('scaling'), { children: [valNode(c('orientation'), 'minMax')] }),
-    valNode(c('delete'), '0'),
+    valNode(c('delete'), spec.categoryAxisHidden ? '1' : '0'),
     valNode(c('axPos'), 'b'),
   ];
+  if (spec.categoryAxisTitle !== undefined) {
+    children.push(titleElement(spec.categoryAxisTitle, spec.categoryAxisTitleStyle));
+  }
   if (spec.categoryAxisMajorTickMark !== undefined) {
     children.push(valNode(c('majorTickMark'), spec.categoryAxisMajorTickMark));
   }
+  if (spec.categoryAxisTickLabelPos !== undefined) {
+    children.push(valNode(c('tickLblPos'), spec.categoryAxisTickLabelPos));
+  }
   children.push(valNode(c('crossAx'), VAL_AX_ID));
+  if (spec.categoryAxisTickLabelSkip !== undefined) {
+    children.push(valNode(c('tickLblSkip'), spec.categoryAxisTickLabelSkip));
+  }
   return elem(c('catAx'), { children });
 };
 
@@ -145,9 +154,12 @@ const valAxis = (spec: ChartSpec): XmlElement => {
   const children: XmlElement[] = [
     valNode(c('axId'), VAL_AX_ID),
     elem(c('scaling'), { children: scalingChildren }),
-    valNode(c('delete'), '0'),
+    valNode(c('delete'), spec.valueAxisHidden ? '1' : '0'),
     valNode(c('axPos'), 'l'),
   ];
+  if (spec.valueAxisTitle !== undefined) {
+    children.push(titleElement(spec.valueAxisTitle, spec.valueAxisTitleStyle));
+  }
   if (spec.valueAxis?.numberFormat !== undefined) {
     children.push(
       elem(c('numFmt'), {

--- a/test/fn-chart-readback.test.ts
+++ b/test/fn-chart-readback.test.ts
@@ -197,6 +197,38 @@ describe('fn API: getSlideCharts', () => {
     expect(spec.valueAxis?.numberFormat).toBe('0.00%');
   });
 
+  it('round-trips axis titles + hidden / tickLblSkip / tickLblPos', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'column',
+        categories: ['A', 'B'],
+        series: [{ name: 'X', values: [1, 2] }],
+        valueAxisTitle: 'Revenue',
+        valueAxisTitleStyle: { sizePt: 12, bold: true },
+        categoryAxisTitle: 'Quarter',
+        categoryAxisHidden: true,
+        categoryAxisTickLabelSkip: 2,
+        categoryAxisTickLabelPos: 'low',
+      },
+    });
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const spec = getSlideCharts(getSlides(reloaded)[0]!)[0]!.spec!;
+    expect(spec.valueAxisTitle).toBe('Revenue');
+    expect(spec.valueAxisTitleStyle?.sizePt).toBe(12);
+    expect(spec.valueAxisTitleStyle?.bold).toBe(true);
+    expect(spec.categoryAxisTitle).toBe('Quarter');
+    expect(spec.categoryAxisHidden).toBe(true);
+    expect(spec.categoryAxisTickLabelSkip).toBe(2);
+    expect(spec.categoryAxisTickLabelPos).toBe('low');
+  });
+
   it('distinguishes bar from column on the same barChart wire format', async () => {
     const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
     const slide = getSlides(pres)[0]!;


### PR DESCRIPTION
## Summary
- valAxis/catAxis emit `<c:title>` (with style), `<c:delete>`, `<c:tickLblPos>`, `<c:tickLblSkip>` when authored.
- Round-trip test added.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (806 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)