### PR TITLE
feat: chart builder writes back plot-area + chart-area fill / stroke

### DIFF
--- a/.changeset/chart-builder-area-fill.md
+++ b/.changeset/chart-builder-area-fill.md
@@ -1,0 +1,11 @@
+---
+'pptx-kit': minor
+---
+
+feat: chart builder writes back plot-area / chart-area fill + stroke
+colors. A new `spPrChildren(fill, stroke)` helper emits
+`<c:spPr><a:solidFill><a:srgbClr/></a:solidFill><a:ln>…</a:ln>`. The
+builder appends it under `<c:plotArea>` when `plotAreaFill` or
+`plotAreaStrokeColor` is set, and under `<c:chartSpace>` (root) when
+`chartAreaFill` or `chartAreaStrokeColor` is set. Round-trip test
+verifies all four survive.

--- a/src/internal/chartml/chart-builder.ts
+++ b/src/internal/chartml/chart-builder.ts
@@ -69,6 +69,39 @@ const solidFillSpPr = (color: string): XmlElement => {
   return elem(c('spPr'), { children: [solidFill] });
 };
 
+// Generic <c:spPr> with optional fill color + line color. Used for the
+// chart-area / plot-area background, where authors set one or both.
+const spPrChildren = (fill: string | undefined, stroke: string | undefined): XmlElement => {
+  const out: XmlElement[] = [];
+  if (fill !== undefined) {
+    out.push(
+      elem(a('solidFill'), {
+        children: [
+          elem(a('srgbClr'), {
+            attrs: [attr(qname('', 'val', ''), fill.replace(/^#/, '').toUpperCase())],
+          }),
+        ],
+      }),
+    );
+  }
+  if (stroke !== undefined) {
+    out.push(
+      elem(a('ln'), {
+        children: [
+          elem(a('solidFill'), {
+            children: [
+              elem(a('srgbClr'), {
+                attrs: [attr(qname('', 'val', ''), stroke.replace(/^#/, '').toUpperCase())],
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+  }
+  return elem(c('spPr'), { children: out });
+};
+
 // Default theme accent palette (matches Office 2013+ default theme).
 const DEFAULT_ACCENT_COLORS = [
   '4472C4', // accent1
@@ -428,6 +461,10 @@ export const buildChartSpaceDoc = (spec: ChartSpec): XmlDocument => {
   if (!axisless) {
     plotAreaChildren.push(catAxis(spec), valAxis(spec));
   }
+  // <c:plotArea><c:spPr><a:solidFill> + optional <a:ln><a:solidFill>.
+  if (spec.plotAreaFill !== undefined || spec.plotAreaStrokeColor !== undefined) {
+    plotAreaChildren.push(spPrChildren(spec.plotAreaFill, spec.plotAreaStrokeColor));
+  }
   const plotArea = elem(c('plotArea'), { children: plotAreaChildren });
 
   const chartChildren: XmlElement[] = [];
@@ -479,13 +516,19 @@ export const buildChartSpaceDoc = (spec: ChartSpec): XmlDocument => {
     children: [valNode(c('autoUpdate'), '0')],
   });
 
+  // <c:chartSpace><c:spPr> sits at the root and styles the entire card.
+  const rootChildren: XmlElement[] = [chart];
+  if (spec.chartAreaFill !== undefined || spec.chartAreaStrokeColor !== undefined) {
+    rootChildren.push(spPrChildren(spec.chartAreaFill, spec.chartAreaStrokeColor));
+  }
+  rootChildren.push(externalData);
   const root = elem(c('chartSpace'), {
     prefixDecls: new Map([
       ['c', NS_C],
       ['a', NS_A],
       ['r', NS_R],
     ]),
-    children: [chart, externalData],
+    children: rootChildren,
   });
 
   return {

--- a/test/fn-chart-readback.test.ts
+++ b/test/fn-chart-readback.test.ts
@@ -278,6 +278,33 @@ describe('fn API: getSlideCharts', () => {
     expect(spec2.holeSizePct).toBe(70);
   });
 
+  it('round-trips plot-area / chart-area fill and stroke colors', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'column',
+        categories: ['A', 'B'],
+        series: [{ name: 'X', values: [1, 2] }],
+        plotAreaFill: '#F0F0F0',
+        plotAreaStrokeColor: '#102030',
+        chartAreaFill: '#FAFAFA',
+        chartAreaStrokeColor: '#888888',
+      },
+    });
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const spec = getSlideCharts(getSlides(reloaded)[0]!)[0]!.spec!;
+    expect(spec.plotAreaFill).toBe('#F0F0F0');
+    expect(spec.plotAreaStrokeColor).toBe('#102030');
+    expect(spec.chartAreaFill).toBe('#FAFAFA');
+    expect(spec.chartAreaStrokeColor).toBe('#888888');
+  });
+
   it('distinguishes bar from column on the same barChart wire format', async () => {
     const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
     const slide = getSlides(pres)[0]!;


### PR DESCRIPTION
## Summary
- New `spPrChildren(fill, stroke)` helper emits `<c:spPr><a:solidFill>` + optional `<a:ln><a:solidFill>`.
- Emits under `<c:plotArea>` when `plotAreaFill` / `plotAreaStrokeColor` set; under `<c:chartSpace>` when `chartAreaFill` / `chartAreaStrokeColor` set.
- Round-trip test asserts all four survive.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (808 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)