### PR TITLE
feat: chart builder writes back axis tick-label style + rotation

### DIFF
--- a/.changeset/chart-builder-txpr.md
+++ b/.changeset/chart-builder-txpr.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: chart builder writes back axis tick-label style + rotation via
+`<c:txPr>`. New `axisTxPrElement(style, rotationDeg)` helper emits the
+`<c:txPr><a:bodyPr rot/><a:lstStyle/><a:p><a:pPr><a:defRPr…/></a:pPr></a:p></c:txPr>`
+payload from `categoryAxisLabelStyle` / `categoryAxisLabelRotationDeg`
+and the value-axis counterparts. Closes the read/write gap for these
+fields; round-trip test added.

--- a/src/internal/chartml/chart-builder.ts
+++ b/src/internal/chartml/chart-builder.ts
@@ -148,6 +148,29 @@ const seriesElement = (spec: ChartSpec, seriesIdx: number, sheet: string): XmlEl
 const CAT_AX_ID = 111111111;
 const VAL_AX_ID = 222222222;
 
+// Build a `<c:txPr>` block carrying axis tick-label font / color and an
+// optional `<a:bodyPr rot="N"/>` rotation. Returns null when neither
+// labelStyle nor rotation are set.
+const axisTxPrElement = (
+  style: ChartTextStyle | undefined,
+  rotationDeg: number | undefined,
+): XmlElement | null => {
+  if (style === undefined && rotationDeg === undefined) return null;
+  const bodyAttrs: ReturnType<typeof attr>[] = [];
+  if (rotationDeg !== undefined) {
+    bodyAttrs.push(attr(qname('', 'rot', ''), String(Math.round(rotationDeg * 60000))));
+  }
+  bodyAttrs.push(attr(qname('', 'vert', ''), 'horz'));
+  const bodyPr = elem(a('bodyPr'), { attrs: bodyAttrs });
+  const { attrs: defAttrs, children: defChildren } = rPrAttrsFromStyle(style);
+  const defRPr = elem(a('defRPr'), { attrs: defAttrs, children: defChildren });
+  const pPr = elem(a('pPr'), { children: [defRPr] });
+  // An empty <a:p> with just pPr is the canonical "defaults only" shape.
+  return elem(c('txPr'), {
+    children: [bodyPr, elem(a('lstStyle')), elem(a('p'), { children: [pPr] })],
+  });
+};
+
 const catAxis = (spec: ChartSpec): XmlElement => {
   const children: XmlElement[] = [
     valNode(c('axId'), CAT_AX_ID),
@@ -164,6 +187,8 @@ const catAxis = (spec: ChartSpec): XmlElement => {
   if (spec.categoryAxisTickLabelPos !== undefined) {
     children.push(valNode(c('tickLblPos'), spec.categoryAxisTickLabelPos));
   }
+  const catTxPr = axisTxPrElement(spec.categoryAxisLabelStyle, spec.categoryAxisLabelRotationDeg);
+  if (catTxPr) children.push(catTxPr);
   children.push(valNode(c('crossAx'), VAL_AX_ID));
   if (spec.categoryAxisTickLabelSkip !== undefined) {
     children.push(valNode(c('tickLblSkip'), spec.categoryAxisTickLabelSkip));
@@ -229,6 +254,8 @@ const valAxis = (spec: ChartSpec): XmlElement => {
   if (spec.valueAxisMajorTickMark !== undefined) {
     children.push(valNode(c('majorTickMark'), spec.valueAxisMajorTickMark));
   }
+  const valTxPr = axisTxPrElement(spec.valueAxisLabelStyle, spec.valueAxisLabelRotationDeg);
+  if (valTxPr) children.push(valTxPr);
   children.push(valNode(c('crossAx'), CAT_AX_ID));
   if (spec.valueAxis?.majorUnit !== undefined) {
     children.push(valNode(c('majorUnit'), spec.valueAxis.majorUnit));

--- a/test/fn-chart-readback.test.ts
+++ b/test/fn-chart-readback.test.ts
@@ -305,6 +305,36 @@ describe('fn API: getSlideCharts', () => {
     expect(spec.chartAreaStrokeColor).toBe('#888888');
   });
 
+  it('round-trips axis tick-label style + rotation via <c:txPr>', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'column',
+        categories: ['A', 'B'],
+        series: [{ name: 'X', values: [1, 2] }],
+        categoryAxisLabelStyle: { sizePt: 9, bold: true, color: '#112233' },
+        categoryAxisLabelRotationDeg: 45,
+        valueAxisLabelStyle: { sizePt: 10, italic: true },
+        valueAxisLabelRotationDeg: -30,
+      },
+    });
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const spec = getSlideCharts(getSlides(reloaded)[0]!)[0]!.spec!;
+    expect(spec.categoryAxisLabelStyle?.sizePt).toBe(9);
+    expect(spec.categoryAxisLabelStyle?.bold).toBe(true);
+    expect(spec.categoryAxisLabelStyle?.color).toBe('#112233');
+    expect(spec.categoryAxisLabelRotationDeg).toBe(45);
+    expect(spec.valueAxisLabelStyle?.sizePt).toBe(10);
+    expect(spec.valueAxisLabelStyle?.italic).toBe(true);
+    expect(spec.valueAxisLabelRotationDeg).toBe(-30);
+  });
+
   it('distinguishes bar from column on the same barChart wire format', async () => {
     const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
     const slide = getSlides(pres)[0]!;


### PR DESCRIPTION
## Summary
- New `axisTxPrElement` helper emits `<c:txPr>` with `<a:bodyPr rot>` + `<a:defRPr>` from style.
- Wired into both `catAxis` and `valAxis`.
- Round-trip test asserts style + rotation survive on both axes.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (809 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)