### PR TITLE
feat: chart builder writes back series-level extras

### DIFF
--- a/.changeset/chart-builder-series-extras.md
+++ b/.changeset/chart-builder-series-extras.md
@@ -1,0 +1,15 @@
+---
+'pptx-kit': minor
+---
+
+feat: chart builder writes back series-level optional fields. Each
+`<c:ser>` now emits:
+
+- richer `<c:spPr>` with `<a:ln w="…"><a:prstDash/>` when
+  `series.lineWidthEmu` or `lineDash` is authored
+- `<c:invertIfNegative val="1"/>` when set
+- `<c:marker><c:symbol/><c:size/></c:marker>` from `markerSymbol` /
+  `markerSizePt`
+- `<c:smooth val="1"/>` when set
+
+Round-trip test covers all five fields.

--- a/src/internal/chartml/chart-builder.ts
+++ b/src/internal/chartml/chart-builder.ts
@@ -112,6 +112,53 @@ const DEFAULT_ACCENT_COLORS = [
   '70AD47', // accent6
 ];
 
+// Builds <c:spPr> for a series — solidFill + optional <a:ln> (line
+// width + dash). The reader extracts color from solidFill and width
+// /dash from the ln; this writer keeps them in lock-step.
+const seriesSpPr = (
+  color: string,
+  lineWidthEmu: number | undefined,
+  lineDash: string | undefined,
+): XmlElement => {
+  const lnChildren: XmlElement[] = [
+    elem(a('solidFill'), {
+      children: [elem(a('srgbClr'), { attrs: [attr(qname('', 'val', ''), color)] })],
+    }),
+  ];
+  if (lineDash !== undefined) {
+    lnChildren.push(elem(a('prstDash'), { attrs: [attr(qname('', 'val', ''), lineDash)] }));
+  }
+  const ln =
+    lineWidthEmu !== undefined
+      ? elem(a('ln'), {
+          attrs: [attr(qname('', 'w', ''), String(lineWidthEmu))],
+          children: lnChildren,
+        })
+      : elem(a('ln'), { children: lnChildren });
+  return elem(c('spPr'), {
+    children: [
+      elem(a('solidFill'), {
+        children: [elem(a('srgbClr'), { attrs: [attr(qname('', 'val', ''), color)] })],
+      }),
+      ln,
+    ],
+  });
+};
+
+// `<c:marker>` for a series. PowerPoint accepts symbol + size; the
+// inner <c:spPr> can carry per-marker fill/stroke but we leave that to
+// the existing series color.
+const markerElement = (
+  symbol: string | undefined,
+  sizePt: number | undefined,
+): XmlElement | null => {
+  if (symbol === undefined && sizePt === undefined) return null;
+  const children: XmlElement[] = [];
+  if (symbol !== undefined) children.push(valNode(c('symbol'), symbol));
+  if (sizePt !== undefined) children.push(valNode(c('size'), Math.round(sizePt)));
+  return elem(c('marker'), { children });
+};
+
 const seriesElement = (spec: ChartSpec, seriesIdx: number, sheet: string): XmlElement => {
   const series = spec.series[seriesIdx];
   if (!series) throw new Error('seriesElement: out of range');
@@ -131,16 +178,30 @@ const seriesElement = (spec: ChartSpec, seriesIdx: number, sheet: string): XmlEl
     paddedValues.push(i < series.values.length ? (series.values[i] ?? null) : null);
   }
 
-  return elem(c('ser'), {
-    children: [
-      valNode(c('idx'), seriesIdx),
-      valNode(c('order'), seriesIdx),
-      elem(c('tx'), { children: [strRef(headerCellFormula, [series.name])] }),
-      solidFillSpPr(color),
-      elem(c('cat'), { children: [strRef(catRange, spec.categories)] }),
-      elem(c('val'), { children: [numRef(valRange, paddedValues)] }),
-    ],
-  });
+  const children: XmlElement[] = [
+    valNode(c('idx'), seriesIdx),
+    valNode(c('order'), seriesIdx),
+    elem(c('tx'), { children: [strRef(headerCellFormula, [series.name])] }),
+  ];
+  // spPr — emit the richer version (with ln) only when authored fields
+  // would otherwise be lost; otherwise keep the legacy solid-fill-only
+  // shape for tight round-trip compatibility with the existing fixtures.
+  if (series.lineWidthEmu !== undefined || series.lineDash !== undefined) {
+    children.push(seriesSpPr(color, series.lineWidthEmu, series.lineDash));
+  } else {
+    children.push(solidFillSpPr(color));
+  }
+  if (series.invertIfNegative === true) {
+    children.push(valNode(c('invertIfNegative'), '1'));
+  }
+  const mk = markerElement(series.markerSymbol, series.markerSizePt);
+  if (mk !== null) children.push(mk);
+  children.push(elem(c('cat'), { children: [strRef(catRange, spec.categories)] }));
+  children.push(elem(c('val'), { children: [numRef(valRange, paddedValues)] }));
+  if (series.smooth === true) {
+    children.push(valNode(c('smooth'), '1'));
+  }
+  return elem(c('ser'), { children });
 };
 
 // Axis ids — arbitrary distinct positive 32-bit integers PowerPoint just

--- a/test/fn-chart-readback.test.ts
+++ b/test/fn-chart-readback.test.ts
@@ -335,6 +335,54 @@ describe('fn API: getSlideCharts', () => {
     expect(spec.valueAxisLabelRotationDeg).toBe(-30);
   });
 
+  it('round-trips series-level lineWidth / lineDash / marker / smooth / invertIfNegative', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'line',
+        categories: ['A', 'B'],
+        series: [
+          {
+            name: 'Trend',
+            values: [10, 20],
+            lineWidthEmu: 28575, // 2.25pt
+            lineDash: 'dash',
+            markerSymbol: 'diamond',
+            markerSizePt: 7,
+            smooth: true,
+          },
+        ],
+      },
+    });
+    const slide2 = getSlides(pres)[1]!;
+    addSlideChart(slide2, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'column',
+        categories: ['A', 'B'],
+        series: [{ name: 'X', values: [-1, 2], invertIfNegative: true }],
+      },
+    });
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const s1 = getSlideCharts(getSlides(reloaded)[0]!)[0]!.spec!.series[0]!;
+    expect(s1.lineWidthEmu).toBe(28575);
+    expect(s1.lineDash).toBe('dash');
+    expect(s1.markerSymbol).toBe('diamond');
+    expect(s1.markerSizePt).toBe(7);
+    expect(s1.smooth).toBe(true);
+    const s2 = getSlideCharts(getSlides(reloaded)[1]!)[0]!.spec!.series[0]!;
+    expect(s2.invertIfNegative).toBe(true);
+  });
+
   it('distinguishes bar from column on the same barChart wire format', async () => {
     const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
     const slide = getSlides(pres)[0]!;


### PR DESCRIPTION
## Summary
- per-series `<c:spPr>` with `<a:ln w/><a:prstDash/>` when authored.
- `<c:invertIfNegative>` toggle.
- `<c:marker><c:symbol/><c:size/></c:marker>` from `markerSymbol` / `markerSizePt`.
- `<c:smooth>` toggle.
- Round-trip test asserts all five survive.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (810 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)