### PR TITLE
feat: chart builder writes back per-series <c:trendline>

### DIFF
--- a/.changeset/chart-builder-trendline.md
+++ b/.changeset/chart-builder-trendline.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: chart builder writes back per-series `<c:trendline>`. A new
+`trendlineElement(tl)` helper emits `<c:trendlineType>`,
+`<c:period>` (movingAvg), `<c:order>` (poly), `<c:forward>` /
+`<c:backward>`, and `<c:spPr><a:ln><a:solidFill>` color when
+authored. Closes the read/write gap for `ChartSeries.trendline`;
+round-trip test covers type / period / forward / backward / color.

--- a/src/internal/chartml/chart-builder.ts
+++ b/src/internal/chartml/chart-builder.ts
@@ -159,6 +159,35 @@ const markerElement = (
   return elem(c('marker'), { children });
 };
 
+// `<c:trendline>` for a series. Carries trendlineType + optional
+// period (movingAvg) / order (poly) / forward / backward / spPr color.
+const trendlineElement = (
+  tl: NonNullable<NonNullable<ChartSpec['series'][number]['trendline']>>,
+): XmlElement => {
+  const children: XmlElement[] = [];
+  if (tl.color !== undefined) {
+    const hex = tl.color.replace(/^#/, '').toUpperCase();
+    const ln = elem(a('ln'), {
+      children: [
+        elem(a('solidFill'), {
+          children: [elem(a('srgbClr'), { attrs: [attr(qname('', 'val', ''), hex)] })],
+        }),
+      ],
+    });
+    children.push(elem(c('spPr'), { children: [ln] }));
+  }
+  children.push(valNode(c('trendlineType'), tl.type));
+  if (tl.type === 'movingAvg' && tl.period !== undefined) {
+    children.push(valNode(c('period'), tl.period));
+  }
+  if (tl.type === 'poly' && tl.order !== undefined) {
+    children.push(valNode(c('order'), tl.order));
+  }
+  if (tl.forward !== undefined) children.push(valNode(c('forward'), tl.forward));
+  if (tl.backward !== undefined) children.push(valNode(c('backward'), tl.backward));
+  return elem(c('trendline'), { children });
+};
+
 const seriesElement = (spec: ChartSpec, seriesIdx: number, sheet: string): XmlElement => {
   const series = spec.series[seriesIdx];
   if (!series) throw new Error('seriesElement: out of range');
@@ -196,6 +225,7 @@ const seriesElement = (spec: ChartSpec, seriesIdx: number, sheet: string): XmlEl
   }
   const mk = markerElement(series.markerSymbol, series.markerSizePt);
   if (mk !== null) children.push(mk);
+  if (series.trendline) children.push(trendlineElement(series.trendline));
   children.push(elem(c('cat'), { children: [strRef(catRange, spec.categories)] }));
   children.push(elem(c('val'), { children: [numRef(valRange, paddedValues)] }));
   if (series.smooth === true) {

--- a/test/fn-chart-readback.test.ts
+++ b/test/fn-chart-readback.test.ts
@@ -383,6 +383,42 @@ describe('fn API: getSlideCharts', () => {
     expect(s2.invertIfNegative).toBe(true);
   });
 
+  it('round-trips series-level trendline (type / forward / backward / period / color)', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'line',
+        categories: ['A', 'B', 'C', 'D'],
+        series: [
+          {
+            name: 'Trend',
+            values: [1, 2, 3, 4],
+            trendline: {
+              type: 'movingAvg',
+              period: 2,
+              forward: 3,
+              backward: 1,
+              color: '#993366',
+            },
+          },
+        ],
+      },
+    });
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const tl = getSlideCharts(getSlides(reloaded)[0]!)[0]!.spec!.series[0]!.trendline!;
+    expect(tl.type).toBe('movingAvg');
+    expect(tl.period).toBe(2);
+    expect(tl.forward).toBe(3);
+    expect(tl.backward).toBe(1);
+    expect(tl.color).toBe('#993366');
+  });
+
   it('distinguishes bar from column on the same barChart wire format', async () => {
     const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
     const slide = getSlides(pres)[0]!;


### PR DESCRIPTION
## Summary
- `trendlineElement(tl)` emits `trendlineType`, optional `period` / `order` / `forward` / `backward`, and `spPr/ln/solidFill` color.
- Round-trip test asserts all five fields survive.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (811 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)