### PR TITLE
feat: chart builder writes back per-series <c:dLbls>

### DIFF
--- a/.changeset/chart-builder-per-series-dlbls.md
+++ b/.changeset/chart-builder-per-series-dlbls.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: chart builder writes back per-series `<c:dLbls>` overrides.
+`dLblsElement` is refactored to take the labels arg directly via
+`buildDLblsFromLabels(dl)`; `seriesElement` now emits per-series
+`<c:dLbls>` when authored, so charts with per-series label toggles /
+numberFormat / position survive round-trip. Round-trip test covers
+all four fields plus the no-override case.

--- a/src/internal/chartml/chart-builder.ts
+++ b/src/internal/chartml/chart-builder.ts
@@ -225,6 +225,8 @@ const seriesElement = (spec: ChartSpec, seriesIdx: number, sheet: string): XmlEl
   }
   const mk = markerElement(series.markerSymbol, series.markerSizePt);
   if (mk !== null) children.push(mk);
+  const serDLbls = buildDLblsFromLabels(series.dataLabels);
+  if (serDLbls !== null) children.push(serDLbls);
   if (series.trendline) children.push(trendlineElement(series.trendline));
   children.push(elem(c('cat'), { children: [strRef(catRange, spec.categories)] }));
   children.push(elem(c('val'), { children: [numRef(valRange, paddedValues)] }));
@@ -368,8 +370,7 @@ const valAxis = (spec: ChartSpec): XmlElement => {
 // showSerName / showPercent toggles plus optional numFmt, position,
 // separator). Returns `null` when no dataLabels were authored so
 // callers know to skip the element entirely.
-const dLblsElement = (spec: ChartSpec): XmlElement | null => {
-  const dl = spec.dataLabels;
+const buildDLblsFromLabels = (dl: ChartSpec['dataLabels'] | undefined): XmlElement | null => {
   if (!dl) return null;
   const children: XmlElement[] = [];
   if (dl.numberFormat !== undefined) {
@@ -396,6 +397,8 @@ const dLblsElement = (spec: ChartSpec): XmlElement | null => {
   }
   return elem(c('dLbls'), { children });
 };
+
+const dLblsElement = (spec: ChartSpec): XmlElement | null => buildDLblsFromLabels(spec.dataLabels);
 
 const buildBarChart = (spec: ChartSpec, sheet: string, direction: 'col' | 'bar'): XmlElement => {
   const ser = spec.series.map((_, i) => seriesElement(spec, i, sheet));

--- a/test/fn-chart-readback.test.ts
+++ b/test/fn-chart-readback.test.ts
@@ -419,6 +419,44 @@ describe('fn API: getSlideCharts', () => {
     expect(tl.color).toBe('#993366');
   });
 
+  it('round-trips per-series dataLabels (toggles + numFmt + position)', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'column',
+        categories: ['A', 'B'],
+        series: [
+          {
+            name: 'X',
+            values: [1, 2],
+            dataLabels: {
+              showValue: true,
+              showCategory: true,
+              showSeriesName: false,
+              showPercent: false,
+              numberFormat: '$#,##0',
+              position: 'inEnd',
+            },
+          },
+          { name: 'Y', values: [3, 4] }, // chart-level only, no per-series
+        ],
+      },
+    });
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const spec = getSlideCharts(getSlides(reloaded)[0]!)[0]!.spec!;
+    expect(spec.series[0]!.dataLabels?.showValue).toBe(true);
+    expect(spec.series[0]!.dataLabels?.showCategory).toBe(true);
+    expect(spec.series[0]!.dataLabels?.numberFormat).toBe('$#,##0');
+    expect(spec.series[0]!.dataLabels?.position).toBe('inEnd');
+    expect(spec.series[1]!.dataLabels).toBeUndefined();
+  });
+
   it('distinguishes bar from column on the same barChart wire format', async () => {
     const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
     const slide = getSlides(pres)[0]!;


### PR DESCRIPTION
## Summary
- Refactors `dLblsElement` into a reusable `buildDLblsFromLabels(dl)` helper.
- `seriesElement` now emits per-series `<c:dLbls>` when `series.dataLabels` is set.
- Round-trip test asserts per-series toggles + numFmt + position survive (and that unset series don't get a stray block).

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (812 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)