### PR TITLE
feat: chart builder writes back per-data-point <c:dPt> overrides

### DIFF
--- a/.changeset/chart-builder-dpt.md
+++ b/.changeset/chart-builder-dpt.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: chart builder writes back per-data-point `<c:dPt>` overrides.
+New `dPtElements(colors, explosions)` helper emits sparse
+`<c:dPt><c:idx><c:bubble3D val="0"/>[<c:explosion>]
+[<c:spPr><a:solidFill><a:srgbClr/>]</c:dPt>` entries from
+`ChartSeries.pointColors` and `ChartSeries.pointExplosions`.
+Round-trip test asserts both sparse arrays survive.

--- a/src/internal/chartml/chart-builder.ts
+++ b/src/internal/chartml/chart-builder.ts
@@ -159,6 +159,37 @@ const markerElement = (
   return elem(c('marker'), { children });
 };
 
+// Build the array of `<c:dPt>` overrides for a series — combines the
+// sparse pointColors and pointExplosions maps. Each authored index
+// emits a `<c:dPt>` with `<c:idx>` + `<c:bubble3D val="0"/>` (required
+// by PowerPoint) + optional explosion + optional spPr/solidFill color.
+const dPtElements = (
+  colors: ReadonlyArray<string | null> | undefined,
+  explosions: ReadonlyArray<number | null> | undefined,
+): XmlElement[] => {
+  const out: XmlElement[] = [];
+  const colorLen = colors?.length ?? 0;
+  const explLen = explosions?.length ?? 0;
+  const max = Math.max(colorLen, explLen);
+  for (let i = 0; i < max; i++) {
+    const color = colors?.[i] ?? null;
+    const expl = explosions?.[i] ?? null;
+    if (color === null && (expl === null || !Number.isFinite(expl))) continue;
+    const children: XmlElement[] = [
+      valNode(c('idx'), i),
+      // PowerPoint expects bubble3D=0 on every dPt outside bubble charts.
+      valNode(c('bubble3D'), '0'),
+    ];
+    if (expl !== null) children.push(valNode(c('explosion'), Math.round(expl)));
+    if (color !== null) {
+      const hex = color.replace(/^#/, '').toUpperCase();
+      children.push(solidFillSpPr(hex));
+    }
+    out.push(elem(c('dPt'), { children }));
+  }
+  return out;
+};
+
 // `<c:trendline>` for a series. Carries trendlineType + optional
 // period (movingAvg) / order (poly) / forward / backward / spPr color.
 const trendlineElement = (
@@ -225,6 +256,10 @@ const seriesElement = (spec: ChartSpec, seriesIdx: number, sheet: string): XmlEl
   }
   const mk = markerElement(series.markerSymbol, series.markerSizePt);
   if (mk !== null) children.push(mk);
+  // <c:dPt> overrides go after invertIfNegative / marker per schema.
+  for (const dPt of dPtElements(series.pointColors, series.pointExplosions)) {
+    children.push(dPt);
+  }
   const serDLbls = buildDLblsFromLabels(series.dataLabels);
   if (serDLbls !== null) children.push(serDLbls);
   if (series.trendline) children.push(trendlineElement(series.trendline));

--- a/test/fn-chart-readback.test.ts
+++ b/test/fn-chart-readback.test.ts
@@ -457,6 +457,35 @@ describe('fn API: getSlideCharts', () => {
     expect(spec.series[1]!.dataLabels).toBeUndefined();
   });
 
+  it('round-trips per-series dPt overrides (pointColors + pointExplosions)', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'pie',
+        categories: ['A', 'B', 'C'],
+        series: [
+          {
+            name: 'X',
+            values: [10, 20, 30],
+            pointColors: ['#FF0000', null, '#00FF00'],
+            pointExplosions: [null, 25, null],
+          },
+        ],
+      },
+    });
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const ser = getSlideCharts(getSlides(reloaded)[0]!)[0]!.spec!.series[0]!;
+    expect(ser.pointColors?.[0]).toBe('#FF0000');
+    expect(ser.pointColors?.[2]).toBe('#00FF00');
+    expect(ser.pointExplosions?.[1]).toBe(25);
+  });
+
   it('distinguishes bar from column on the same barChart wire format', async () => {
     const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
     const slide = getSlides(pres)[0]!;


### PR DESCRIPTION
## Summary
- New `dPtElements(colors, explosions)` helper builds sparse `<c:dPt>` entries from per-data-point fields.
- Round-trip test asserts both `pointColors` and `pointExplosions` survive.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (813 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)