### PR TITLE
feat: chart builder writes back legend.textStyle + axis orientation

### DIFF
--- a/.changeset/chart-builder-legend-textstyle-orientation.md
+++ b/.changeset/chart-builder-legend-textstyle-orientation.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: chart builder writes back legend.textStyle + axis orientation
+reversals. `<c:legend><c:txPr>` now carries the authored font / color
+from `legend.textStyle` (via the existing `axisTxPrElement` helper);
+`<c:scaling><c:orientation>` honors `categoryAxisOrientation` and
+`valueAxisOrientation` (defaulting to `minMax`). Round-trip test
+asserts all four survive read → save → reload.

--- a/src/internal/chartml/chart-builder.ts
+++ b/src/internal/chartml/chart-builder.ts
@@ -300,9 +300,10 @@ const axisTxPrElement = (
 };
 
 const catAxis = (spec: ChartSpec): XmlElement => {
+  const catOrientation = spec.categoryAxisOrientation ?? 'minMax';
   const children: XmlElement[] = [
     valNode(c('axId'), CAT_AX_ID),
-    elem(c('scaling'), { children: [valNode(c('orientation'), 'minMax')] }),
+    elem(c('scaling'), { children: [valNode(c('orientation'), catOrientation)] }),
     valNode(c('delete'), spec.categoryAxisHidden ? '1' : '0'),
     valNode(c('axPos'), 'b'),
   ];
@@ -330,7 +331,7 @@ const valAxis = (spec: ChartSpec): XmlElement => {
   if (spec.valueAxis?.logBase !== undefined) {
     scalingChildren.push(valNode(c('logBase'), spec.valueAxis.logBase));
   }
-  scalingChildren.push(valNode(c('orientation'), 'minMax'));
+  scalingChildren.push(valNode(c('orientation'), spec.valueAxisOrientation ?? 'minMax'));
   if (spec.valueAxis?.min !== undefined) {
     scalingChildren.push(valNode(c('min'), spec.valueAxis.min));
   }
@@ -659,6 +660,11 @@ export const buildChartSpaceDoc = (spec: ChartSpec): XmlDocument => {
       );
     }
     legendChildren.push(valNode(c('overlay'), spec.legend.overlay ? '1' : '0'));
+    // <c:legend><c:txPr> carries authored legend font / color.
+    if (spec.legend.textStyle !== undefined) {
+      const txPr = axisTxPrElement(spec.legend.textStyle, undefined);
+      if (txPr !== null) legendChildren.push(txPr);
+    }
     chartChildren.push(elem(c('legend'), { children: legendChildren }));
   }
   chartChildren.push(

--- a/test/fn-chart-readback.test.ts
+++ b/test/fn-chart-readback.test.ts
@@ -486,6 +486,36 @@ describe('fn API: getSlideCharts', () => {
     expect(ser.pointExplosions?.[1]).toBe(25);
   });
 
+  it('round-trips legend.textStyle + axis orientation reversals', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'column',
+        categories: ['A', 'B'],
+        series: [{ name: 'X', values: [1, 2] }],
+        legend: {
+          position: 'b',
+          textStyle: { sizePt: 11, bold: true, color: '#102030' },
+        },
+        categoryAxisOrientation: 'maxMin',
+        valueAxisOrientation: 'maxMin',
+      },
+    });
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const spec = getSlideCharts(getSlides(reloaded)[0]!)[0]!.spec!;
+    expect(spec.legend?.textStyle?.sizePt).toBe(11);
+    expect(spec.legend?.textStyle?.bold).toBe(true);
+    expect(spec.legend?.textStyle?.color).toBe('#102030');
+    expect(spec.categoryAxisOrientation).toBe('maxMin');
+    expect(spec.valueAxisOrientation).toBe('maxMin');
+  });
+
   it('distinguishes bar from column on the same barChart wire format', async () => {
     const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
     const slide = getSlides(pres)[0]!;


### PR DESCRIPTION
## Summary
- `<c:legend><c:txPr>` carries authored `legend.textStyle` (via existing `axisTxPrElement`).
- `<c:scaling><c:orientation>` honors `categoryAxisOrientation` / `valueAxisOrientation`.
- Round-trip test asserts all four survive.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test (814 passing, 22 skipped)
- [x] pnpm format
- [x] pnpm lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)