### PR TITLE
feat: setShapeTextBodyRotationDeg writer

### DIFF
--- a/.changeset/set-shape-text-body-rotation.md
+++ b/.changeset/set-shape-text-body-rotation.md
@@ -1,0 +1,9 @@
+---
+'pptx-kit': minor
+---
+
+feat: `setShapeTextBodyRotationDeg(shape, rotationDeg | null)` — companion
+writer for the existing `getShapeTextBodyRotationDeg` reader. Sets
+`<a:bodyPr rot="N"/>` (in 60000ths of a degree, per OOXML) so the text
+body can rotate independently of the shape's own `<p:xfrm rot>`. Passing
+`null` or `0` clears the attribute so the shape inherits the default.

--- a/src/api/fn/shapes.ts
+++ b/src/api/fn/shapes.ts
@@ -2490,6 +2490,30 @@ export const getShapeTextBodyRotationDeg = (shape: SlideShapeData): number | nul
 };
 
 /**
+ * Sets the shape's text-body rotation (`<a:bodyPr rot="N"/>`), measured
+ * in degrees. Positive rotates clockwise per PowerPoint's convention.
+ * Passing `null` clears the attribute so the shape inherits the default
+ * (`0`). Throws for non-text-bearing shape kinds.
+ *
+ * Companion to `setShapeRotation`, which rotates the *whole* shape
+ * via `<p:xfrm rot>`. `bodyPr rot` rotates only the text inside.
+ */
+export const setShapeTextBodyRotationDeg = (
+  shape: SlideShapeData,
+  rotationDeg: number | null,
+): void => {
+  const bodyPr = requireBodyPr(shape);
+  // Strip any prior rot attribute.
+  bodyPr.attrs = bodyPr.attrs.filter(
+    (a) => !(a.name.namespaceURI === '' && a.name.localName === 'rot'),
+  );
+  if (rotationDeg !== null && rotationDeg !== 0) {
+    bodyPr.attrs.push(attr(qname('', 'rot', ''), String(Math.round(rotationDeg * 60000))));
+  }
+  commitAndRefresh(shape);
+};
+
+/**
  * Reads the shape's text-direction token from `<a:bodyPr vert="…"/>`.
  * Per ECMA-376 §17.18.93 `ST_TextVerticalType`:
  *

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -440,6 +440,7 @@ export {
   setShapeText,
   setShapeTextAnchor,
   setShapeTextAutoFit,
+  setShapeTextBodyRotationDeg,
   setShapeTextFormat,
   setShapeTextMargins,
   setShapeTextWrap,

--- a/test/fn-set-shape-text-body-rotation.test.ts
+++ b/test/fn-set-shape-text-body-rotation.test.ts
@@ -1,0 +1,75 @@
+// `setShapeTextBodyRotationDeg` — text-body rotation via `<a:bodyPr rot/>`.
+// Companion writer to `getShapeTextBodyRotationDeg`; rotates only the
+// text inside the shape, not the shape itself.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  addSlideTextBox,
+  getShapeTextBodyRotationDeg,
+  getSlideShapes,
+  getSlides,
+  inches,
+  loadPresentation,
+  savePresentation,
+  setShapeTextBodyRotationDeg,
+} from '../src/api/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+describe('fn API: setShapeTextBodyRotationDeg', () => {
+  it('round-trips a positive degree value through save/reload', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const tb = addSlideTextBox(slide, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(3),
+      h: inches(2),
+      text: 'rotated',
+    });
+    setShapeTextBodyRotationDeg(tb, 90);
+    expect(getShapeTextBodyRotationDeg(tb)).toBe(90);
+
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const reShapes = getSlideShapes(getSlides(reloaded)[0]!);
+    const rTb = reShapes[reShapes.length - 1]!;
+    expect(getShapeTextBodyRotationDeg(rTb)).toBe(90);
+  });
+
+  it('round-trips a negative degree value', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const tb = addSlideTextBox(slide, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(3),
+      h: inches(2),
+      text: 'r',
+    });
+    setShapeTextBodyRotationDeg(tb, -45);
+    expect(getShapeTextBodyRotationDeg(tb)).toBe(-45);
+  });
+
+  it('clears the attribute when set to null or 0', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const tb = addSlideTextBox(slide, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(3),
+      h: inches(2),
+      text: 'r',
+    });
+    setShapeTextBodyRotationDeg(tb, 180);
+    expect(getShapeTextBodyRotationDeg(tb)).toBe(180);
+    setShapeTextBodyRotationDeg(tb, null);
+    expect(getShapeTextBodyRotationDeg(tb)).toBeNull();
+    setShapeTextBodyRotationDeg(tb, 90);
+    setShapeTextBodyRotationDeg(tb, 0);
+    expect(getShapeTextBodyRotationDeg(tb)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `setShapeTextBodyRotationDeg(shape, rotationDeg | null)` — companion writer for the existing `getShapeTextBodyRotationDeg` reader.
- Writes `<a:bodyPr rot="N"/>` (60000ths of a degree, per OOXML). Passing `null` or `0` clears the attribute so the shape inherits the default rotation.
- Closes the read/write parity gap on shape text-body rotation.

## Test plan
- [x] 3 new tests in `test/fn-set-shape-text-body-rotation.test.ts` covering: round-trip through save/reload, negative degree, and clear-on-null/0.
- [x] `pnpm test` — 817 passing (was 814), 22 skipped.
- [x] `pnpm exec tsc --noEmit` clean.
- [x] `pnpm exec oxlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)