### PR TITLE
feat: setShapeTextDirection writer

### DIFF
--- a/.changeset/set-shape-text-direction.md
+++ b/.changeset/set-shape-text-direction.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: `setShapeTextDirection(shape, direction | null)` — companion
+writer for the existing `getShapeTextDirection` reader. Sets
+`<a:bodyPr vert="…"/>` with any of the six `ST_TextVerticalType`
+values (`vert`, `vert270`, `wordArtVert`, `eaVert`, `mongolianVert`,
+`wordArtVertRtl`); passing `null` or `'horz'` clears the attribute so
+the shape uses the default horizontal direction.

--- a/src/api/fn/shapes.ts
+++ b/src/api/fn/shapes.ts
@@ -2548,6 +2548,34 @@ export const getShapeTextDirection = (
   return null;
 };
 
+/**
+ * Sets the shape's text-direction via `<a:bodyPr vert="…"/>`. See
+ * `getShapeTextDirection` for the meaning of each value. Passing `null`
+ * (or `'horz'`) clears the attribute so the shape uses the default
+ * horizontal direction. Throws for non-text-bearing shape kinds.
+ */
+export const setShapeTextDirection = (
+  shape: SlideShapeData,
+  direction:
+    | 'horz'
+    | 'vert'
+    | 'vert270'
+    | 'wordArtVert'
+    | 'eaVert'
+    | 'mongolianVert'
+    | 'wordArtVertRtl'
+    | null,
+): void => {
+  const bodyPr = requireBodyPr(shape);
+  bodyPr.attrs = bodyPr.attrs.filter(
+    (a) => !(a.name.namespaceURI === '' && a.name.localName === 'vert'),
+  );
+  if (direction !== null && direction !== 'horz') {
+    bodyPr.attrs.push(attr(qname('', 'vert', ''), direction));
+  }
+  commitAndRefresh(shape);
+};
+
 export const getShapeTextMargins = (
   shape: SlideShapeData,
 ): {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -441,6 +441,7 @@ export {
   setShapeTextAnchor,
   setShapeTextAutoFit,
   setShapeTextBodyRotationDeg,
+  setShapeTextDirection,
   setShapeTextFormat,
   setShapeTextMargins,
   setShapeTextWrap,

--- a/test/fn-set-shape-text-direction.test.ts
+++ b/test/fn-set-shape-text-direction.test.ts
@@ -1,0 +1,84 @@
+// `setShapeTextDirection` — vertical-text writer that pairs with
+// `getShapeTextDirection`. Asserts all six `ST_TextVerticalType`
+// values round-trip and that null / `'horz'` clears the attribute.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  addSlideTextBox,
+  getShapeTextDirection,
+  getSlideShapes,
+  getSlides,
+  inches,
+  loadPresentation,
+  savePresentation,
+  setShapeTextDirection,
+} from '../src/api/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+const DIRECTIONS = [
+  'vert',
+  'vert270',
+  'wordArtVert',
+  'eaVert',
+  'mongolianVert',
+  'wordArtVertRtl',
+] as const;
+
+describe('fn API: setShapeTextDirection', () => {
+  it('round-trips every non-default direction in-memory', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const tb = addSlideTextBox(slide, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(3),
+      h: inches(2),
+      text: 'v',
+    });
+    for (const dir of DIRECTIONS) {
+      setShapeTextDirection(tb, dir);
+      expect(getShapeTextDirection(tb)).toBe(dir);
+    }
+  });
+
+  it('round-trips through save/reload', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const tb = addSlideTextBox(slide, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(3),
+      h: inches(2),
+      text: 'v',
+    });
+    setShapeTextDirection(tb, 'eaVert');
+
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const reShapes = getSlideShapes(getSlides(reloaded)[0]!);
+    expect(getShapeTextDirection(reShapes[reShapes.length - 1]!)).toBe('eaVert');
+  });
+
+  it('clears the attribute when set to null or horz', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const tb = addSlideTextBox(slide, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(3),
+      h: inches(2),
+      text: 'v',
+    });
+    setShapeTextDirection(tb, 'vert');
+    expect(getShapeTextDirection(tb)).toBe('vert');
+    setShapeTextDirection(tb, null);
+    expect(getShapeTextDirection(tb)).toBeNull();
+    setShapeTextDirection(tb, 'vert');
+    setShapeTextDirection(tb, 'horz');
+    expect(getShapeTextDirection(tb)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `setShapeTextDirection(shape, direction | null)` — companion writer for the existing `getShapeTextDirection` reader.
- Sets `<a:bodyPr vert="…"/>` with any of the six `ST_TextVerticalType` values (`vert`, `vert270`, `wordArtVert`, `eaVert`, `mongolianVert`, `wordArtVertRtl`).
- Passing `null` or `'horz'` clears the attribute so the shape uses the default horizontal direction.

## Test plan
- [x] 3 new tests in `test/fn-set-shape-text-direction.test.ts` covering all six directions, save/reload round-trip, and the null/`'horz'` clear path.
- [x] `pnpm test` — 820 passing (was 817), 22 skipped.
- [x] `pnpm exec tsc --noEmit` clean.
- [x] `pnpm exec oxlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)