### PR TITLE
fix(site): playground preview broke on opaque SlideCommentData + 1-arg media API

### DIFF
--- a/.changeset/fix-playground-broken-comment-media-api.md
+++ b/.changeset/fix-playground-broken-comment-media-api.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': patch
+---
+
+fix(site): playground stopped rendering after `SlideCommentData` was made
+opaque and `getSlideMediaPartNames` lost its `(pres, slide)` two-arg
+form. The playground was still doing `comment.text` and
+`getSlideMediaPartNames(pres, slide)`, both of which threw at runtime.
+Switched to the public `getCommentText(comment)` accessor and the
+single-arg `getSlideMediaPartNames(slide)` signature.

--- a/site/src/routes/playground/+page.svelte
+++ b/site/src/routes/playground/+page.svelte
@@ -6,6 +6,7 @@
   // exercises the real surface the same way the rest of the docs site
   // does — type errors here break the build.
   import {
+    getCommentText,
     getCoreProperties,
     getPresentationSummary,
     getSlideCharts,
@@ -110,13 +111,13 @@
           hidden: isSlideHidden(slide),
           commentCount: getSlideComments(slide).length,
           commentTexts: getSlideComments(slide)
-            .map((c) => c.text)
+            .map((c) => getCommentText(c))
             .filter((t) => t.length > 0)
             .join('\n'),
           layoutType,
           layoutName,
           chartCount: getSlideCharts(slide).length,
-          mediaCount: getSlideMediaPartNames(pres, slide).length,
+          mediaCount: getSlideMediaPartNames(slide).length,
         };
       });
 


### PR DESCRIPTION
## Summary
The playground stopped rendering slide previews after two recent API tightenings landed on `main`:

1. `SlideCommentData` was made opaque — fields are no longer accessible via `comment.text`; you have to go through `getCommentText(comment)`.
2. `getSlideMediaPartNames` settled on a single-arg `(slide)` signature; the playground was still passing `(pres, slide)`.

Both threw at runtime, so the whole \`slides\` array crashed and nothing rendered. The Svelte build still passed because the SlideCommentData fields were inferred as `any` at the consumer site.

This PR switches to the public `getCommentText(comment)` accessor and the single-arg `getSlideMediaPartNames(slide)` form.

## Test plan
- [x] `pnpm exec svelte-check` clean.
- [x] `pnpm exec vite build` succeeds.
- [ ] Drop a real .pptx on the playground preview — slides should render again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)