### PR TITLE
feat: ChartDataLabels.textStyle round-trip

### DIFF
--- a/.changeset/chart-dlbls-text-style.md
+++ b/.changeset/chart-dlbls-text-style.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: `ChartDataLabels.textStyle` — the default-run text style for chart
+data labels is now read and written. `<c:dLbls><c:txPr><a:defRPr/>`
+is parsed into `ChartTextStyle` (sizePt / bold / italic / color) and
+emitted in CT_DLbls schema order (after `<c:numFmt>`, before
+`<c:dLblPos>`). Both the chart-level `dataLabels` and per-series
+`series[i].dataLabels` honor the field.

--- a/src/internal/chartml/chart-builder.ts
+++ b/src/internal/chartml/chart-builder.ts
@@ -419,6 +419,12 @@ const buildDLblsFromLabels = (dl: ChartSpec['dataLabels'] | undefined): XmlEleme
       }),
     );
   }
+  if (dl.textStyle !== undefined) {
+    // CT_DLbls schema order places <c:txPr> before <c:dLblPos>; reusing
+    // `axisTxPrElement` keeps the formatting parity with axis / legend.
+    const txPr = axisTxPrElement(dl.textStyle, undefined);
+    if (txPr !== null) children.push(txPr);
+  }
   if (dl.position !== undefined) children.push(valNode(c('dLblPos'), dl.position));
   children.push(
     valNode(c('showLegendKey'), '0'),

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -623,6 +623,8 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
       }
       const position = readDataLabelPosition(serDLblsEl);
       const separator = readDataLabelSeparator(serDLblsEl);
+      const txPrEl = firstChildElement(serDLblsEl, qname('c', 'txPr', NS_C));
+      const textStyle = txPrEl ? readLabelStyle(txPrEl) : undefined;
       serDataLabels = {
         showValue: readToggle('showVal'),
         showCategory: readToggle('showCatName'),
@@ -631,6 +633,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
         ...(numberFormat !== undefined ? { numberFormat } : {}),
         ...(position !== undefined ? { position } : {}),
         ...(separator !== undefined ? { separator } : {}),
+        ...(textStyle !== undefined ? { textStyle } : {}),
       };
     }
     series.push({
@@ -676,6 +679,8 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     }
     const position = readDataLabelPosition(dLbls);
     const separator = readDataLabelSeparator(dLbls);
+    const txPrEl = firstChildElement(dLbls, qname('c', 'txPr', NS_C));
+    const textStyle = txPrEl ? readLabelStyle(txPrEl) : undefined;
     dataLabels = {
       showValue: readToggle('showVal'),
       showCategory: readToggle('showCatName'),
@@ -684,6 +689,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
       ...(numberFormat !== undefined ? { numberFormat } : {}),
       ...(position !== undefined ? { position } : {}),
       ...(separator !== undefined ? { separator } : {}),
+      ...(textStyle !== undefined ? { textStyle } : {}),
     };
   }
 

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -178,6 +178,13 @@ export interface ChartDataLabels {
    * `"\n"`, `"; "`.
    */
   readonly separator?: string;
+  /**
+   * Default-run text style for the labels — projected from
+   * `<c:dLbls><c:txPr>…<a:defRPr/>…</c:txPr>`. Applies to whichever
+   * label parts are turned on by the `show*` toggles. Independent of
+   * the chart-title style and the axis-label style.
+   */
+  readonly textStyle?: ChartTextStyle;
 }
 
 /**

--- a/test/fn-chart-readback.test.ts
+++ b/test/fn-chart-readback.test.ts
@@ -137,6 +137,69 @@ describe('fn API: getSlideCharts', () => {
     expect(spec.dataLabels?.separator).toBe(', ');
   });
 
+  it('round-trips chart-level dataLabels.textStyle (sz / bold / color)', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'column',
+        categories: ['A', 'B'],
+        series: [{ name: 'X', values: [1, 2] }],
+        dataLabels: {
+          showValue: true,
+          showCategory: false,
+          showSeriesName: false,
+          showPercent: false,
+          textStyle: { sizePt: 14, bold: true, color: '#FF8800' },
+        },
+      },
+    });
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const spec = getSlideCharts(getSlides(reloaded)[0]!)[0]!.spec!;
+    expect(spec.dataLabels?.textStyle?.sizePt).toBe(14);
+    expect(spec.dataLabels?.textStyle?.bold).toBe(true);
+    expect(spec.dataLabels?.textStyle?.color).toBe('#FF8800');
+  });
+
+  it('round-trips per-series dataLabels.textStyle', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'column',
+        categories: ['A', 'B'],
+        series: [
+          {
+            name: 'X',
+            values: [1, 2],
+            dataLabels: {
+              showValue: true,
+              showCategory: false,
+              showSeriesName: false,
+              showPercent: false,
+              textStyle: { sizePt: 9, italic: true, color: '#003366' },
+            },
+          },
+        ],
+      },
+    });
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const spec = getSlideCharts(getSlides(reloaded)[0]!)[0]!.spec!;
+    expect(spec.series[0]!.dataLabels?.textStyle?.sizePt).toBe(9);
+    expect(spec.series[0]!.dataLabels?.textStyle?.italic).toBe(true);
+    expect(spec.series[0]!.dataLabels?.textStyle?.color).toBe('#003366');
+  });
+
   it('round-trips legend position + hiddenIndices + overlay + dispBlanksAs', async () => {
     const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
     const slide = getSlides(pres)[0]!;


### PR DESCRIPTION
## Summary
- Adds `ChartDataLabels.textStyle` — the default-run text style for chart data labels.
- chart-reader: parses `<c:dLbls><c:txPr><a:defRPr/>` into `ChartTextStyle` (sizePt / bold / italic / color); applies to both chart-level `dataLabels` and per-series `series[i].dataLabels`.
- chart-builder: emits `<c:txPr>` in CT_DLbls schema order (after `<c:numFmt>`, before `<c:dLblPos>`); reuses `axisTxPrElement` for formatting parity with axis / legend.

## Test plan
- [x] 2 new round-trip tests in `test/fn-chart-readback.test.ts` covering chart-level + per-series `textStyle` (sz / bold / italic / color).
- [x] `pnpm test` — 819 passing (was 817), 22 skipped.
- [x] `pnpm exec tsc --noEmit` clean.
- [x] `pnpm exec oxlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)