### PR TITLE
feat: hyperlink tooltip writer + reader/writer parity fix

### DIFF
--- a/.changeset/set-shape-hyperlink-tooltip.md
+++ b/.changeset/set-shape-hyperlink-tooltip.md
@@ -1,0 +1,14 @@
+---
+'pptx-kit': minor
+---
+
+feat: `setShapeHyperlink` and `setShapeRunHyperlink` now accept an
+optional `tooltip` argument that writes a `tooltip="…"` attribute on the
+emitted `<a:hlinkClick>`. Backwards compatible — calls that omit the new
+arg behave exactly as before.
+
+fix: `getShapeHyperlinkTooltip` previously only looked at the shape's
+`<p:cNvPr><a:hlinkClick>`, missing the run-level tooltip that
+`setShapeHyperlink` writes. It now scans run-level `<a:rPr>` first
+(mirroring `getShapeHyperlink`'s read path) and falls back to the
+shape-click hyperlink — so the reader / writer pair is consistent.

--- a/src/api/fn/shapes.ts
+++ b/src/api/fn/shapes.ts
@@ -2981,6 +2981,7 @@ export const setShapeRunHyperlink = (
   paragraphIndex: number,
   runIndex: number,
   url: string | null,
+  tooltip?: string,
 ): void => {
   const run = requireRun(shape, paragraphIndex, runIndex);
   let rPr = firstChildElement(run, qname('a', 'rPr', NS.dml));
@@ -3016,9 +3017,13 @@ export const setShapeRunHyperlink = (
       });
       pkg.setRels(slide[SLIDE_PART_NAME], rels);
     }
+    const hlinkAttrs = [attr(qname('r', 'id', NS.officeDocRels), rId)];
+    if (tooltip !== undefined) {
+      hlinkAttrs.push(attr(qname('', 'tooltip', ''), tooltip));
+    }
     rPr.children.push(
       elem(qname('a', 'hlinkClick', NS.dml), {
-        attrs: [attr(qname('r', 'id', NS.officeDocRels), rId)],
+        attrs: hlinkAttrs,
       }),
     );
   }
@@ -3056,8 +3061,33 @@ export const getShapeRunHyperlink = (
  * Returns `null` when no hyperlink is set or the link doesn't author
  * a tooltip. Tooltips show up in PowerPoint when the user hovers over
  * a linked shape in slide-show mode.
+ *
+ * Scans run-level `<a:rPr><a:hlinkClick>` first (where
+ * `setShapeHyperlink` writes) and falls back to the
+ * `<p:nvSpPr><p:cNvPr><a:hlinkClick>` shape-click hyperlink. Mirrors
+ * `getShapeHyperlink`'s read path so the writer / reader pair is
+ * consistent.
  */
 export const getShapeHyperlinkTooltip = (shape: SlideShapeData): string | null => {
+  if (shape[SHAPE_SNAPSHOT].kind === 'shape') {
+    const txBody = firstChildElement(shape[SHAPE_ELEMENT], NAME_TX_BODY);
+    if (txBody) {
+      for (const p of txBody.children) {
+        if (p.kind !== 'element' || p.name.namespaceURI !== NS.dml || p.name.localName !== 'p')
+          continue;
+        for (const r of p.children) {
+          if (r.kind !== 'element' || r.name.namespaceURI !== NS.dml || r.name.localName !== 'r')
+            continue;
+          const rPr = firstChildElement(r, qname('a', 'rPr', NS.dml));
+          if (!rPr) continue;
+          const hlink = firstChildElement(rPr, qname('a', 'hlinkClick', NS.dml));
+          if (!hlink) continue;
+          const tt = getAttrValue(hlink, qname('', 'tooltip', ''));
+          if (tt !== null) return tt;
+        }
+      }
+    }
+  }
   const cNvPr = findCNvPr(shape);
   if (!cNvPr) return null;
   const hlink = firstChildElement(cNvPr, NAME_HLINK_CLICK_FN);
@@ -4469,7 +4499,11 @@ export const getShapeHyperlink = (shape: SlideShapeData): string | null => {
  * (or reuses) a `hyperlink` relationship on the slide's `.rels`. Pass
  * `null` to clear.
  */
-export const setShapeHyperlink = (shape: SlideShapeData, url: string | null): void => {
+export const setShapeHyperlink = (
+  shape: SlideShapeData,
+  url: string | null,
+  tooltip?: string,
+): void => {
   const slide = shape[SHAPE_SLIDE];
   const txBody = requireTxBody(shape);
   if (url === null) {
@@ -4493,7 +4527,7 @@ export const setShapeHyperlink = (shape: SlideShapeData, url: string | null): vo
         pkg.setRels(slide[SLIDE_PART_NAME], rels);
         return nextId;
       })();
-    applyHyperlinkToAllRuns(txBody, rId);
+    applyHyperlinkToAllRuns(txBody, rId, tooltip);
   }
   commitAndRefresh(shape);
 };

--- a/src/internal/drawingml/hyperlink.ts
+++ b/src/internal/drawingml/hyperlink.ts
@@ -11,11 +11,17 @@ const NAME_HLINK_CLICK = qname('a', 'hlinkClick', NS.dml);
 const ATTR_R_ID = qname('r', 'id', NS.officeDocRels);
 
 /**
- * Sets `<a:hlinkClick r:id="rIdN"/>` inside the `<a:rPr>` of every run in
- * `txBody`. Pass `null` to remove an existing hyperlink. Creates `<a:rPr>`
+ * Sets `<a:hlinkClick r:id="rIdN" [tooltip="…"]/>` inside the `<a:rPr>`
+ * of every run in `txBody`. Pass `null` for `rId` to remove an existing
+ * hyperlink. When `tooltip` is `undefined` no `tooltip=` attribute is
+ * written; when it's a string the attribute is set. Creates `<a:rPr>`
  * if absent on a run.
  */
-export const applyHyperlinkToAllRuns = (txBody: XmlElement, rId: string | null): void => {
+export const applyHyperlinkToAllRuns = (
+  txBody: XmlElement,
+  rId: string | null,
+  tooltip?: string,
+): void => {
   for (const p of txBody.children) {
     if (p.kind !== 'element' || p.name.namespaceURI !== NS.dml || p.name.localName !== 'p') {
       continue;
@@ -39,9 +45,13 @@ export const applyHyperlinkToAllRuns = (txBody: XmlElement, rId: string | null):
           ),
       );
       if (rId !== null) {
+        const attrs = [attr(ATTR_R_ID, rId)];
+        if (tooltip !== undefined) {
+          attrs.push(attr(qname('', 'tooltip', ''), tooltip));
+        }
         // Per the schema, hlinkClick is one of the last children of rPr —
         // it follows the fill/typeface children. Append.
-        rPr.children.push(elem(NAME_HLINK_CLICK, { attrs: [attr(ATTR_R_ID, rId)] }));
+        rPr.children.push(elem(NAME_HLINK_CLICK, { attrs }));
       }
     }
   }

--- a/test/fn-set-shape-hyperlink-tooltip.test.ts
+++ b/test/fn-set-shape-hyperlink-tooltip.test.ts
@@ -1,0 +1,79 @@
+// `setShapeHyperlink` and `setShapeRunHyperlink` — optional `tooltip`
+// arg that drops a `tooltip="…"` attribute on the emitted
+// `<a:hlinkClick>`. Pairs the writers with the existing
+// `getShape{,Run}HyperlinkTooltip` readers.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  addSlideTextBox,
+  getShapeHyperlinkTooltip,
+  getShapeRunHyperlinkTooltip,
+  getSlideShapes,
+  getSlides,
+  inches,
+  loadPresentation,
+  savePresentation,
+  setShapeHyperlink,
+  setShapeRunHyperlink,
+} from '../src/api/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+describe('fn API: setShapeHyperlink tooltip', () => {
+  it('round-trips a shape-level tooltip through save/reload', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const tb = addSlideTextBox(slide, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(3),
+      h: inches(1),
+      text: 'click me',
+    });
+    setShapeHyperlink(tb, 'https://example.com', 'Visit example.com');
+    expect(getShapeHyperlinkTooltip(tb)).toBe('Visit example.com');
+
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const reShapes = getSlideShapes(getSlides(reloaded)[0]!);
+    expect(getShapeHyperlinkTooltip(reShapes[reShapes.length - 1]!)).toBe('Visit example.com');
+  });
+
+  it('omits the tooltip attribute when no tooltip arg is passed', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const tb = addSlideTextBox(slide, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(3),
+      h: inches(1),
+      text: 'no tip',
+    });
+    setShapeHyperlink(tb, 'https://example.com');
+    expect(getShapeHyperlinkTooltip(tb)).toBeNull();
+  });
+});
+
+describe('fn API: setShapeRunHyperlink tooltip', () => {
+  it('round-trips a per-run tooltip through save/reload', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const tb = addSlideTextBox(slide, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(3),
+      h: inches(1),
+      text: 'run',
+    });
+    setShapeRunHyperlink(tb, 0, 0, 'https://example.com', 'per-run tip');
+    expect(getShapeRunHyperlinkTooltip(tb, 0, 0)).toBe('per-run tip');
+
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const reShapes = getSlideShapes(getSlides(reloaded)[0]!);
+    expect(getShapeRunHyperlinkTooltip(reShapes[reShapes.length - 1]!, 0, 0)).toBe('per-run tip');
+  });
+});


### PR DESCRIPTION
## Summary
- \`setShapeHyperlink(shape, url, tooltip?)\` and \`setShapeRunHyperlink(shape, p, r, url, tooltip?)\` now accept an optional \`tooltip\` arg that writes \`<a:hlinkClick tooltip="…">\`. Backwards compatible — omitting the arg behaves exactly as before.
- **fix**: \`getShapeHyperlinkTooltip\` previously read from \`<p:cNvPr><a:hlinkClick>\` (the shape-click hyperlink), but \`setShapeHyperlink\` writes per-run on \`<a:rPr><a:hlinkClick>\`. The reader never saw what the writer set. Fixed by scanning run-level rPr first (mirroring \`getShapeHyperlink\`'s read path) with cNvPr as fallback.

## Test plan
- [x] 3 new tests in \`test/fn-set-shape-hyperlink-tooltip.test.ts\` covering shape-level + per-run tooltip round-trip and the no-tooltip case.
- [x] \`pnpm test\` — 825 passing (was 822), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)