### PR TITLE
feat: setShapeTextColumns writer

### DIFF
--- a/.changeset/set-shape-text-columns.md
+++ b/.changeset/set-shape-text-columns.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: `setShapeTextColumns(shape, { count, gapEmu? } | null)` — multi-
+column writer pairing the existing `getShapeTextColumns` reader. Writes
+`<a:bodyPr numCol="N" [spcCol="EMU"]/>`. Passing `null` clears both
+attributes so the text body falls back to PowerPoint's default single
+column. `count` must be `>= 2` (single column is the default — pass
+`null` instead); the function throws otherwise.

--- a/src/api/fn/shapes.ts
+++ b/src/api/fn/shapes.ts
@@ -2522,6 +2522,40 @@ export const getShapeTextColumns = (
 };
 
 /**
+ * Sets the multi-column layout on the shape's text body — writes
+ * `<a:bodyPr numCol="N" [spcCol="EMU"]/>`. Pass `null` to clear both
+ * attributes so the text body falls back to PowerPoint's default
+ * single column. `count` must be `>= 2` (PowerPoint clamps higher
+ * values silently; OOXML allows up to 16). `gapEmu`, when omitted,
+ * removes any prior `spcCol`. Throws for non-text-bearing shape kinds.
+ */
+export const setShapeTextColumns = (
+  shape: SlideShapeData,
+  columns: { count: number; gapEmu?: number } | null,
+): void => {
+  const bodyPr = requireBodyPr(shape);
+  bodyPr.attrs = bodyPr.attrs.filter(
+    (a) =>
+      !(
+        a.name.namespaceURI === '' &&
+        (a.name.localName === 'numCol' || a.name.localName === 'spcCol')
+      ),
+  );
+  if (columns !== null) {
+    if (columns.count < 2) {
+      throw new Error(
+        `setShapeTextColumns: count must be >= 2 (single column is the default — pass null instead). Got ${columns.count}.`,
+      );
+    }
+    bodyPr.attrs.push(attr(qname('', 'numCol', ''), String(columns.count)));
+    if (columns.gapEmu !== undefined) {
+      bodyPr.attrs.push(attr(qname('', 'spcCol', ''), String(Math.round(columns.gapEmu))));
+    }
+  }
+  commitAndRefresh(shape);
+};
+
+/**
  * Reads the shape's text-body rotation from `<a:bodyPr rot="N"/>`.
  * `rot` is stored in 60000ths of a degree (OOXML angle units); the
  * returned value is in degrees. Positive values rotate clockwise per

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -444,6 +444,7 @@ export {
   setShapeTextAnchor,
   setShapeTextAutoFit,
   setShapeTextBodyRotationDeg,
+  setShapeTextColumns,
   setShapeTextDirection,
   setShapeTextFormat,
   setShapeTextMargins,

--- a/test/fn-set-shape-text-columns.test.ts
+++ b/test/fn-set-shape-text-columns.test.ts
@@ -1,0 +1,85 @@
+// `setShapeTextColumns` — multi-column writer pairing the existing
+// `getShapeTextColumns` reader.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  addSlideTextBox,
+  getShapeTextColumns,
+  getSlideShapes,
+  getSlides,
+  inches,
+  loadPresentation,
+  savePresentation,
+  setShapeTextColumns,
+} from '../src/api/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+describe('fn API: setShapeTextColumns', () => {
+  it('round-trips count + gap through save/reload', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const tb = addSlideTextBox(slide, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(6),
+      h: inches(2),
+      text: 'col text',
+    });
+    setShapeTextColumns(tb, { count: 3, gapEmu: 228600 }); // 0.25in
+    expect(getShapeTextColumns(tb)).toEqual({ count: 3, gapEmu: 228600 });
+
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const reShapes = getSlideShapes(getSlides(reloaded)[0]!);
+    expect(getShapeTextColumns(reShapes[reShapes.length - 1]!)).toEqual({
+      count: 3,
+      gapEmu: 228600,
+    });
+  });
+
+  it('omits spcCol when gapEmu is not passed', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const tb = addSlideTextBox(slide, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(6),
+      h: inches(2),
+      text: 'c',
+    });
+    setShapeTextColumns(tb, { count: 2 });
+    expect(getShapeTextColumns(tb)).toEqual({ count: 2 });
+  });
+
+  it('clears both attributes when set to null', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const tb = addSlideTextBox(slide, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(6),
+      h: inches(2),
+      text: 'c',
+    });
+    setShapeTextColumns(tb, { count: 4, gapEmu: 114300 });
+    setShapeTextColumns(tb, null);
+    expect(getShapeTextColumns(tb)).toBeNull();
+  });
+
+  it('throws when count < 2', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const tb = addSlideTextBox(slide, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(6),
+      h: inches(2),
+      text: 'c',
+    });
+    expect(() => setShapeTextColumns(tb, { count: 1 })).toThrow(/count must be >= 2/);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds \`setShapeTextColumns(shape, { count, gapEmu? } | null)\` — multi-column writer paired with the existing \`getShapeTextColumns\` reader.
- Writes \`<a:bodyPr numCol="N" [spcCol="EMU"]/>\`. \`gapEmu\` omitted → no \`spcCol\` attribute.
- \`null\` clears both attributes so the body falls back to PowerPoint's single-column default.
- \`count < 2\` throws (single column is the default — \`null\` is the right way to express that).

## Test plan
- [x] 4 new tests in \`test/fn-set-shape-text-columns.test.ts\` covering count + gap round-trip, save/reload, no-gap, null clear, and the count<2 throw.
- [x] \`pnpm test\` — 837 passing (was 833), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)