### PR TITLE
feat: ChartSpec.categoryAxisTickMarkSkip round-trip

### DIFF
--- a/.changeset/chart-tick-mark-skip.md
+++ b/.changeset/chart-tick-mark-skip.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: `ChartSpec.categoryAxisTickMarkSkip` — the second half of the
+ECMA-376 `<c:catAx>` skip pair. `<c:tickLblSkip>` (already supported)
+controls label-skip stride; `<c:tickMarkSkip val="N"/>` independently
+draws every Nth tick mark. Useful when you want fewer label collisions
+but the same dense tick lattice. Read by chart-reader and written by
+chart-builder.

--- a/src/internal/chartml/chart-builder.ts
+++ b/src/internal/chartml/chart-builder.ts
@@ -322,6 +322,9 @@ const catAxis = (spec: ChartSpec): XmlElement => {
   if (spec.categoryAxisTickLabelSkip !== undefined) {
     children.push(valNode(c('tickLblSkip'), spec.categoryAxisTickLabelSkip));
   }
+  if (spec.categoryAxisTickMarkSkip !== undefined) {
+    children.push(valNode(c('tickMarkSkip'), spec.categoryAxisTickMarkSkip));
+  }
   return elem(c('catAx'), { children });
 };
 

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -847,6 +847,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
   let categoryAxisHidden: boolean | undefined;
   let valueAxisHidden: boolean | undefined;
   let categoryAxisTickLabelSkip: number | undefined;
+  let categoryAxisTickMarkSkip: number | undefined;
   let categoryAxisTickLabelPos: ChartSpec['categoryAxisTickLabelPos'];
   const catAx = findFirst(plotArea, ['catAx', 'dateAx', 'serAx']);
   const isHidden = (axis: XmlElement): boolean | undefined => {
@@ -893,6 +894,14 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
       if (v !== null) {
         const n = Number.parseInt(v, 10);
         if (Number.isFinite(n) && n > 1) categoryAxisTickLabelSkip = n;
+      }
+    }
+    const markSkipEl = firstChildElement(catAx, qname('c', 'tickMarkSkip', NS_C));
+    if (markSkipEl) {
+      const v = getAttrValue(markSkipEl, ATTR_VAL);
+      if (v !== null) {
+        const n = Number.parseInt(v, 10);
+        if (Number.isFinite(n) && n > 1) categoryAxisTickMarkSkip = n;
       }
     }
     const posEl = firstChildElement(catAx, qname('c', 'tickLblPos', NS_C));
@@ -1114,6 +1123,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     ...(categoryAxisMajorTickMark !== undefined ? { categoryAxisMajorTickMark } : {}),
     ...(valueAxisMinorGridlines !== undefined ? { valueAxisMinorGridlines } : {}),
     ...(categoryAxisTickLabelSkip !== undefined ? { categoryAxisTickLabelSkip } : {}),
+    ...(categoryAxisTickMarkSkip !== undefined ? { categoryAxisTickMarkSkip } : {}),
     ...(categoryAxisTickLabelPos !== undefined ? { categoryAxisTickLabelPos } : {}),
     ...(categoryAxisOrientation !== undefined ? { categoryAxisOrientation } : {}),
     ...(valueAxisOrientation !== undefined ? { valueAxisOrientation } : {}),

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -358,6 +358,13 @@ export interface ChartSpec {
    */
   readonly categoryAxisTickLabelSkip?: number;
   /**
+   * Category-axis tick *mark* skip (`<c:catAx><c:tickMarkSkip val="N"/>`):
+   * draw every Nth tick mark independently of the label-skip stride.
+   * Useful when you want fewer label collisions but the same dense
+   * tick lattice; defaults to 1 (every tick).
+   */
+  readonly categoryAxisTickMarkSkip?: number;
+  /**
    * Category-axis tick label position (`<c:catAx><c:tickLblPos val="…"/>`):
    *   - `none` hides labels but keeps the axis line
    *   - `low` / `high` puts them at the start / end (rare)

--- a/test/fn-chart-readback.test.ts
+++ b/test/fn-chart-readback.test.ts
@@ -277,6 +277,7 @@ describe('fn API: getSlideCharts', () => {
         categoryAxisTitle: 'Quarter',
         categoryAxisHidden: true,
         categoryAxisTickLabelSkip: 2,
+        categoryAxisTickMarkSkip: 5,
         categoryAxisTickLabelPos: 'low',
       },
     });
@@ -289,6 +290,7 @@ describe('fn API: getSlideCharts', () => {
     expect(spec.categoryAxisTitle).toBe('Quarter');
     expect(spec.categoryAxisHidden).toBe(true);
     expect(spec.categoryAxisTickLabelSkip).toBe(2);
+    expect(spec.categoryAxisTickMarkSkip).toBe(5);
     expect(spec.categoryAxisTickLabelPos).toBe('low');
   });
 


### PR DESCRIPTION
## Summary
- Adds \`ChartSpec.categoryAxisTickMarkSkip\` — pairs with the existing \`categoryAxisTickLabelSkip\`.
- Maps to \`<c:catAx><c:tickMarkSkip val="N"/>\`. Label-skip and tick-skip are independent strides per ECMA-376.
- Read by chart-reader, written by chart-builder.

## Test plan
- [x] Extended the existing axis-extras round-trip test in \`test/fn-chart-readback.test.ts\` to cover \`categoryAxisTickMarkSkip: 5\` alongside \`categoryAxisTickLabelSkip: 2\`.
- [x] \`pnpm test\` — 837 passing, 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)