### PR TITLE
feat: ChartSpec categoryAxisLabelOffset + categoryAxisLabelAlign

### DIFF
--- a/.changeset/chart-cat-axis-label-offset-align.md
+++ b/.changeset/chart-cat-axis-label-offset-align.md
@@ -1,0 +1,12 @@
+---
+'pptx-kit': minor
+---
+
+feat: `ChartSpec.categoryAxisLabelOffset` and
+`ChartSpec.categoryAxisLabelAlign` — two more category-axis tuning
+knobs from ECMA-376. `<c:catAx><c:lblOffset val="N"/>` (0..1000, default
+100) controls the distance from the axis line to the labels as a
+percent of text size; `<c:catAx><c:lblAlgn val="ctr|l|r"/>` controls
+how multi-line category labels align relative to their tick mark. Both
+are read by chart-reader and written by chart-builder in the correct
+CT_CatAx schema order.

--- a/src/internal/chartml/chart-builder.ts
+++ b/src/internal/chartml/chart-builder.ts
@@ -319,6 +319,13 @@ const catAxis = (spec: ChartSpec): XmlElement => {
   const catTxPr = axisTxPrElement(spec.categoryAxisLabelStyle, spec.categoryAxisLabelRotationDeg);
   if (catTxPr) children.push(catTxPr);
   children.push(valNode(c('crossAx'), VAL_AX_ID));
+  // CT_CatAx schema order: lblAlgn / lblOffset precede the skip pair.
+  if (spec.categoryAxisLabelAlign !== undefined) {
+    children.push(valNode(c('lblAlgn'), spec.categoryAxisLabelAlign));
+  }
+  if (spec.categoryAxisLabelOffset !== undefined) {
+    children.push(valNode(c('lblOffset'), spec.categoryAxisLabelOffset));
+  }
   if (spec.categoryAxisTickLabelSkip !== undefined) {
     children.push(valNode(c('tickLblSkip'), spec.categoryAxisTickLabelSkip));
   }

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -849,6 +849,8 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
   let categoryAxisTickLabelSkip: number | undefined;
   let categoryAxisTickMarkSkip: number | undefined;
   let categoryAxisTickLabelPos: ChartSpec['categoryAxisTickLabelPos'];
+  let categoryAxisLabelOffset: number | undefined;
+  let categoryAxisLabelAlign: ChartSpec['categoryAxisLabelAlign'];
   const catAx = findFirst(plotArea, ['catAx', 'dateAx', 'serAx']);
   const isHidden = (axis: XmlElement): boolean | undefined => {
     const d = firstChildElement(axis, qname('c', 'delete', NS_C));
@@ -910,6 +912,19 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
       if (v === 'none' || v === 'low' || v === 'high' || v === 'nextTo') {
         categoryAxisTickLabelPos = v;
       }
+    }
+    const lblOffsetEl = firstChildElement(catAx, qname('c', 'lblOffset', NS_C));
+    if (lblOffsetEl) {
+      const v = getAttrValue(lblOffsetEl, ATTR_VAL);
+      if (v !== null) {
+        const n = Number.parseInt(v, 10);
+        if (Number.isFinite(n) && n !== 100) categoryAxisLabelOffset = n;
+      }
+    }
+    const lblAlgnEl = firstChildElement(catAx, qname('c', 'lblAlgn', NS_C));
+    if (lblAlgnEl) {
+      const v = getAttrValue(lblAlgnEl, ATTR_VAL);
+      if (v === 'ctr' || v === 'l' || v === 'r') categoryAxisLabelAlign = v;
     }
   }
   // <c:majorGridlines> / <c:minorGridlines> presence governs visibility.
@@ -1125,6 +1140,8 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     ...(categoryAxisTickLabelSkip !== undefined ? { categoryAxisTickLabelSkip } : {}),
     ...(categoryAxisTickMarkSkip !== undefined ? { categoryAxisTickMarkSkip } : {}),
     ...(categoryAxisTickLabelPos !== undefined ? { categoryAxisTickLabelPos } : {}),
+    ...(categoryAxisLabelOffset !== undefined ? { categoryAxisLabelOffset } : {}),
+    ...(categoryAxisLabelAlign !== undefined ? { categoryAxisLabelAlign } : {}),
     ...(categoryAxisOrientation !== undefined ? { categoryAxisOrientation } : {}),
     ...(valueAxisOrientation !== undefined ? { valueAxisOrientation } : {}),
     ...(firstSliceAngleDeg !== undefined ? { firstSliceAngleDeg } : {}),

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -372,6 +372,19 @@ export interface ChartSpec {
    */
   readonly categoryAxisTickLabelPos?: 'none' | 'low' | 'high' | 'nextTo';
   /**
+   * Distance from the axis line to the labels, expressed as a percent of
+   * the chart text size — `<c:catAx><c:lblOffset val="N"/>` where N is
+   * 0..1000 (default 100). Larger values push category labels further
+   * from the axis. Per ECMA-376 §21.2.2.94.
+   */
+  readonly categoryAxisLabelOffset?: number;
+  /**
+   * Multi-line category-label alignment relative to the tick mark —
+   * `<c:catAx><c:lblAlgn val="ctr|l|r"/>`. PowerPoint defaults to
+   * `ctr` when omitted; the authored value wins.
+   */
+  readonly categoryAxisLabelAlign?: 'ctr' | 'l' | 'r';
+  /**
    * Category-axis order — `'minMax'` (the data's natural order) or
    * `'maxMin'` (reversed). For bar charts PowerPoint typically emits
    * `maxMin` so the first category sits at the top instead of the

--- a/test/fn-chart-readback.test.ts
+++ b/test/fn-chart-readback.test.ts
@@ -279,6 +279,8 @@ describe('fn API: getSlideCharts', () => {
         categoryAxisTickLabelSkip: 2,
         categoryAxisTickMarkSkip: 5,
         categoryAxisTickLabelPos: 'low',
+        categoryAxisLabelOffset: 150,
+        categoryAxisLabelAlign: 'l',
       },
     });
     const bytes = await savePresentation(pres);
@@ -292,6 +294,8 @@ describe('fn API: getSlideCharts', () => {
     expect(spec.categoryAxisTickLabelSkip).toBe(2);
     expect(spec.categoryAxisTickMarkSkip).toBe(5);
     expect(spec.categoryAxisTickLabelPos).toBe('low');
+    expect(spec.categoryAxisLabelOffset).toBe(150);
+    expect(spec.categoryAxisLabelAlign).toBe('l');
   });
 
   it('round-trips chart extras (varyColors / gapWidth / overlap / firstSliceAng / holeSize / dropLines / hiLowLines / titleOverlay / majorGridlines)', async () => {


### PR DESCRIPTION
## Summary
- Adds \`ChartSpec.categoryAxisLabelOffset\` → \`<c:catAx><c:lblOffset val="N"/>\` (0..1000, default 100 — percent of text size).
- Adds \`ChartSpec.categoryAxisLabelAlign\` → \`<c:catAx><c:lblAlgn val="ctr|l|r"/>\` (multi-line label alignment).
- Read by chart-reader, written by chart-builder in the correct CT_CatAx schema order.

## Test plan
- [x] Extended the existing axis-extras round-trip test in \`test/fn-chart-readback.test.ts\` to cover \`categoryAxisLabelOffset: 150\` and \`categoryAxisLabelAlign: 'l'\`.
- [x] \`pnpm test\` — 837 passing, 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)