### PR TITLE
feat: ChartSpec.valueAxisCrosses (enum + numeric forms)

### DIFF
--- a/.changeset/chart-value-axis-crosses.md
+++ b/.changeset/chart-value-axis-crosses.md
@@ -1,0 +1,11 @@
+---
+'pptx-kit': minor
+---
+
+feat: `ChartSpec.valueAxisCrosses` — controls where the category axis
+crosses the value axis. Accepts either an enum keyword
+(`'autoZero' | 'min' | 'max'` → `<c:valAx><c:crosses val=…/>`) or a
+numeric tagged form (`{ at: N }` → `<c:valAx><c:crossesAt val=N/>`).
+The two forms are mutually exclusive per the schema; `crossesAt` wins
+when both are present on read. Read by chart-reader, written by
+chart-builder in the correct CT_ValAx schema order (after `<c:crossAx>`).

--- a/src/internal/chartml/chart-builder.ts
+++ b/src/internal/chartml/chart-builder.ts
@@ -396,6 +396,16 @@ const valAxis = (spec: ChartSpec): XmlElement => {
   const valTxPr = axisTxPrElement(spec.valueAxisLabelStyle, spec.valueAxisLabelRotationDeg);
   if (valTxPr) children.push(valTxPr);
   children.push(valNode(c('crossAx'), CAT_AX_ID));
+  // <c:crosses val>/`crossesAt val>` — mutually exclusive per the
+  // schema. Object form `{ at: N }` → crossesAt; string form → crosses.
+  const xross = spec.valueAxisCrosses;
+  if (xross !== undefined) {
+    if (typeof xross === 'string') {
+      children.push(valNode(c('crosses'), xross));
+    } else {
+      children.push(valNode(c('crossesAt'), String(xross.at)));
+    }
+  }
   if (spec.valueAxis?.majorUnit !== undefined) {
     children.push(valNode(c('majorUnit'), spec.valueAxis.majorUnit));
   }

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -860,6 +860,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
   };
   let categoryAxisOrientation: 'minMax' | 'maxMin' | undefined;
   let valueAxisOrientation: 'minMax' | 'maxMin' | undefined;
+  let valueAxisCrosses: ChartSpec['valueAxisCrosses'];
   const readAxisOrientation = (axis: XmlElement): 'minMax' | 'maxMin' | undefined => {
     const scaling = firstChildElement(axis, qname('c', 'scaling', NS_C));
     if (!scaling) return undefined;
@@ -953,6 +954,23 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     valueAxisHidden = isHidden(valAx);
     valueAxisOrientation = readAxisOrientation(valAx);
     valueAxisMajorTickMark = readTickMark(valAx);
+    // <c:crosses val> and <c:crossesAt val> are mutually exclusive per
+    // the schema; crossesAt wins when both are emitted (matches the
+    // PowerPoint priority).
+    const crossesAtEl = firstChildElement(valAx, qname('c', 'crossesAt', NS_C));
+    if (crossesAtEl) {
+      const v = getAttrValue(crossesAtEl, ATTR_VAL);
+      if (v !== null) {
+        const n = Number.parseFloat(v);
+        if (Number.isFinite(n)) valueAxisCrosses = { at: n };
+      }
+    } else {
+      const crossesEl = firstChildElement(valAx, qname('c', 'crosses', NS_C));
+      if (crossesEl) {
+        const v = getAttrValue(crossesEl, ATTR_VAL);
+        if (v === 'autoZero' || v === 'min' || v === 'max') valueAxisCrosses = v;
+      }
+    }
     const majorGl = firstChildElement(valAx, qname('c', 'majorGridlines', NS_C));
     valueAxisMajorGridlines = majorGl !== null;
     if (majorGl) {
@@ -1144,6 +1162,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     ...(categoryAxisLabelAlign !== undefined ? { categoryAxisLabelAlign } : {}),
     ...(categoryAxisOrientation !== undefined ? { categoryAxisOrientation } : {}),
     ...(valueAxisOrientation !== undefined ? { valueAxisOrientation } : {}),
+    ...(valueAxisCrosses !== undefined ? { valueAxisCrosses } : {}),
     ...(firstSliceAngleDeg !== undefined ? { firstSliceAngleDeg } : {}),
     ...(holeSizePct !== undefined ? { holeSizePct } : {}),
   };

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -393,6 +393,15 @@ export interface ChartSpec {
   readonly categoryAxisOrientation?: 'minMax' | 'maxMin';
   /** Same for the value axis. */
   readonly valueAxisOrientation?: 'minMax' | 'maxMin';
+  /**
+   * Where the category axis crosses the value axis. Either an enum
+   * keyword (`<c:valAx><c:crosses val="autoZero|min|max"/>`) or a
+   * specific numeric value (`<c:valAx><c:crossesAt val="N"/>`). The two
+   * forms are mutually exclusive — PowerPoint emits one or the other.
+   * Default is `autoZero` (the category axis sits at value 0 if the
+   * range straddles zero, otherwise at the closer extreme).
+   */
+  readonly valueAxisCrosses?: 'autoZero' | 'min' | 'max' | { at: number };
   /** Bar / column / area grouping mode. Absent for line / pie. */
   readonly grouping?: ChartGrouping;
   /**

--- a/test/fn-chart-readback.test.ts
+++ b/test/fn-chart-readback.test.ts
@@ -585,6 +585,46 @@ describe('fn API: getSlideCharts', () => {
     expect(spec.valueAxisOrientation).toBe('maxMin');
   });
 
+  it('round-trips valueAxisCrosses enum + numeric forms', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'column',
+        categories: ['A', 'B'],
+        series: [{ name: 'X', values: [1, 2] }],
+        valueAxisCrosses: 'max',
+      },
+    });
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const spec = getSlideCharts(getSlides(reloaded)[0]!)[0]!.spec!;
+    expect(spec.valueAxisCrosses).toBe('max');
+
+    // Now the numeric form on a second chart.
+    const pres2 = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    addSlideChart(getSlides(pres2)[0]!, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'column',
+        categories: ['A', 'B'],
+        series: [{ name: 'X', values: [-5, 5] }],
+        valueAxisCrosses: { at: -3 },
+      },
+    });
+    const b2 = await savePresentation(pres2);
+    const r2 = await loadPresentation(b2);
+    const s2 = getSlideCharts(getSlides(r2)[0]!)[0]!.spec!;
+    expect(s2.valueAxisCrosses).toEqual({ at: -3 });
+  });
+
   it('distinguishes bar from column on the same barChart wire format', async () => {
     const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
     const slide = getSlides(pres)[0]!;


### PR DESCRIPTION
## Summary
- Adds \`ChartSpec.valueAxisCrosses\` — \`'autoZero' | 'min' | 'max' | { at: N }\`.
- Enum string → \`<c:valAx><c:crosses val="…"/>\`.
- Numeric tagged form \`{ at: N }\` → \`<c:valAx><c:crossesAt val="N"/>\`.
- The two are mutually exclusive per the schema; \`crossesAt\` wins on read (matches PowerPoint priority).

## Test plan
- [x] New round-trip test in \`test/fn-chart-readback.test.ts\` covering both forms (enum 'max' and numeric \`{ at: -3 }\`).
- [x] \`pnpm test\` — 838 passing (was 837), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)