### PR TITLE
feat: ChartSpec.valueAxisCrossBetween round-trip

### DIFF
--- a/.changeset/chart-value-axis-cross-between.md
+++ b/.changeset/chart-value-axis-cross-between.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: `ChartSpec.valueAxisCrossBetween` — controls whether the value
+axis crosses the category axis *between* tick marks (the default for
+bar/column/area) or *at* each tick mark (the default for line/scatter).
+Maps to `<c:valAx><c:crossBetween val="between|midCat"/>`. Read by
+chart-reader, written by chart-builder in the correct CT_ValAx schema
+order (after `<c:crossesAt>`).

--- a/src/internal/chartml/chart-builder.ts
+++ b/src/internal/chartml/chart-builder.ts
@@ -406,6 +406,9 @@ const valAxis = (spec: ChartSpec): XmlElement => {
       children.push(valNode(c('crossesAt'), String(xross.at)));
     }
   }
+  if (spec.valueAxisCrossBetween !== undefined) {
+    children.push(valNode(c('crossBetween'), spec.valueAxisCrossBetween));
+  }
   if (spec.valueAxis?.majorUnit !== undefined) {
     children.push(valNode(c('majorUnit'), spec.valueAxis.majorUnit));
   }

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -861,6 +861,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
   let categoryAxisOrientation: 'minMax' | 'maxMin' | undefined;
   let valueAxisOrientation: 'minMax' | 'maxMin' | undefined;
   let valueAxisCrosses: ChartSpec['valueAxisCrosses'];
+  let valueAxisCrossBetween: ChartSpec['valueAxisCrossBetween'];
   const readAxisOrientation = (axis: XmlElement): 'minMax' | 'maxMin' | undefined => {
     const scaling = firstChildElement(axis, qname('c', 'scaling', NS_C));
     if (!scaling) return undefined;
@@ -970,6 +971,11 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
         const v = getAttrValue(crossesEl, ATTR_VAL);
         if (v === 'autoZero' || v === 'min' || v === 'max') valueAxisCrosses = v;
       }
+    }
+    const crossBetweenEl = firstChildElement(valAx, qname('c', 'crossBetween', NS_C));
+    if (crossBetweenEl) {
+      const v = getAttrValue(crossBetweenEl, ATTR_VAL);
+      if (v === 'between' || v === 'midCat') valueAxisCrossBetween = v;
     }
     const majorGl = firstChildElement(valAx, qname('c', 'majorGridlines', NS_C));
     valueAxisMajorGridlines = majorGl !== null;
@@ -1163,6 +1169,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     ...(categoryAxisOrientation !== undefined ? { categoryAxisOrientation } : {}),
     ...(valueAxisOrientation !== undefined ? { valueAxisOrientation } : {}),
     ...(valueAxisCrosses !== undefined ? { valueAxisCrosses } : {}),
+    ...(valueAxisCrossBetween !== undefined ? { valueAxisCrossBetween } : {}),
     ...(firstSliceAngleDeg !== undefined ? { firstSliceAngleDeg } : {}),
     ...(holeSizePct !== undefined ? { holeSizePct } : {}),
   };

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -402,6 +402,15 @@ export interface ChartSpec {
    * range straddles zero, otherwise at the closer extreme).
    */
   readonly valueAxisCrosses?: 'autoZero' | 'min' | 'max' | { at: number };
+  /**
+   * Whether the value axis crosses the category axis *between* tick
+   * marks (the default for bar / column / area) or *at* each tick mark
+   * (the default for line / scatter). Maps to `<c:valAx>
+   * <c:crossBetween val="between|midCat"/>`. PowerPoint emits this when
+   * the chart kind makes the default value non-obvious — surface it
+   * here so the round-trip preserves the authored intent.
+   */
+  readonly valueAxisCrossBetween?: 'between' | 'midCat';
   /** Bar / column / area grouping mode. Absent for line / pie. */
   readonly grouping?: ChartGrouping;
   /**

--- a/test/fn-chart-readback.test.ts
+++ b/test/fn-chart-readback.test.ts
@@ -585,6 +585,27 @@ describe('fn API: getSlideCharts', () => {
     expect(spec.valueAxisOrientation).toBe('maxMin');
   });
 
+  it('round-trips valueAxisCrossBetween', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'column',
+        categories: ['A', 'B'],
+        series: [{ name: 'X', values: [1, 2] }],
+        valueAxisCrossBetween: 'midCat',
+      },
+    });
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const spec = getSlideCharts(getSlides(reloaded)[0]!)[0]!.spec!;
+    expect(spec.valueAxisCrossBetween).toBe('midCat');
+  });
+
   it('round-trips valueAxisCrosses enum + numeric forms', async () => {
     const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
     const slide = getSlides(pres)[0]!;


### PR DESCRIPTION
## Summary
- Adds \`ChartSpec.valueAxisCrossBetween\` — \`'between' | 'midCat'\`.
- Maps to \`<c:valAx><c:crossBetween val="…"/>\`. \`between\` is the bar/column/area default; \`midCat\` is the line/scatter default.
- Read by chart-reader, written by chart-builder in the correct CT_ValAx schema order (after \`<c:crossesAt>\`, before \`<c:majorUnit>\`).

## Test plan
- [x] New round-trip test in \`test/fn-chart-readback.test.ts\` covering \`'midCat'\`.
- [x] \`pnpm test\` — 839 passing (was 838), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)