### PR TITLE
feat: ChartSpec minor tick mark on both axes

### DIFF
--- a/.changeset/chart-minor-tick-mark.md
+++ b/.changeset/chart-minor-tick-mark.md
@@ -1,0 +1,9 @@
+---
+'pptx-kit': minor
+---
+
+feat: `ChartSpec.valueAxisMinorTickMark` and `categoryAxisMinorTickMark`
+— minor-tick-mark mode siblings of the existing `*MajorTickMark` pair.
+Maps to `<c:catAx><c:minorTickMark val="in|out|cross|none"/>` and the
+value-axis equivalent. Read by chart-reader, written by chart-builder
+in the correct schema order (right after `<c:majorTickMark>`).

--- a/src/internal/chartml/chart-builder.ts
+++ b/src/internal/chartml/chart-builder.ts
@@ -313,6 +313,9 @@ const catAxis = (spec: ChartSpec): XmlElement => {
   if (spec.categoryAxisMajorTickMark !== undefined) {
     children.push(valNode(c('majorTickMark'), spec.categoryAxisMajorTickMark));
   }
+  if (spec.categoryAxisMinorTickMark !== undefined) {
+    children.push(valNode(c('minorTickMark'), spec.categoryAxisMinorTickMark));
+  }
   if (spec.categoryAxisTickLabelPos !== undefined) {
     children.push(valNode(c('tickLblPos'), spec.categoryAxisTickLabelPos));
   }
@@ -392,6 +395,9 @@ const valAxis = (spec: ChartSpec): XmlElement => {
   }
   if (spec.valueAxisMajorTickMark !== undefined) {
     children.push(valNode(c('majorTickMark'), spec.valueAxisMajorTickMark));
+  }
+  if (spec.valueAxisMinorTickMark !== undefined) {
+    children.push(valNode(c('minorTickMark'), spec.valueAxisMinorTickMark));
   }
   const valTxPr = axisTxPrElement(spec.valueAxisLabelStyle, spec.valueAxisLabelRotationDeg);
   if (valTxPr) children.push(valTxPr);

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -834,13 +834,20 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
   let valueAxisLabelRotationDeg: number | undefined;
   let valueAxisMajorTickMark: ChartSpec['valueAxisMajorTickMark'];
   let categoryAxisMajorTickMark: ChartSpec['categoryAxisMajorTickMark'];
-  const readTickMark = (axis: XmlElement): 'in' | 'out' | 'cross' | 'none' | undefined => {
-    const el = firstChildElement(axis, qname('c', 'majorTickMark', NS_C));
+  let valueAxisMinorTickMark: ChartSpec['valueAxisMinorTickMark'];
+  let categoryAxisMinorTickMark: ChartSpec['categoryAxisMinorTickMark'];
+  const readTickMarkLocal = (
+    axis: XmlElement,
+    local: 'majorTickMark' | 'minorTickMark',
+  ): 'in' | 'out' | 'cross' | 'none' | undefined => {
+    const el = firstChildElement(axis, qname('c', local, NS_C));
     if (!el) return undefined;
     const v = getAttrValue(el, ATTR_VAL);
     if (v === 'in' || v === 'out' || v === 'cross' || v === 'none') return v;
     return undefined;
   };
+  const readTickMark = (axis: XmlElement): 'in' | 'out' | 'cross' | 'none' | undefined =>
+    readTickMarkLocal(axis, 'majorTickMark');
   let valueAxisTitle: string | undefined;
   let valueAxisTitleStyle: ChartTextStyle | undefined;
   let valueAxisLabelStyle: ChartTextStyle | undefined;
@@ -892,6 +899,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     categoryAxisHidden = isHidden(catAx);
     categoryAxisOrientation = readAxisOrientation(catAx);
     categoryAxisMajorTickMark = readTickMark(catAx);
+    categoryAxisMinorTickMark = readTickMarkLocal(catAx, 'minorTickMark');
     const skipEl = firstChildElement(catAx, qname('c', 'tickLblSkip', NS_C));
     if (skipEl) {
       const v = getAttrValue(skipEl, ATTR_VAL);
@@ -955,6 +963,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     valueAxisHidden = isHidden(valAx);
     valueAxisOrientation = readAxisOrientation(valAx);
     valueAxisMajorTickMark = readTickMark(valAx);
+    valueAxisMinorTickMark = readTickMarkLocal(valAx, 'minorTickMark');
     // <c:crosses val> and <c:crossesAt val> are mutually exclusive per
     // the schema; crossesAt wins when both are emitted (matches the
     // PowerPoint priority).
@@ -1158,8 +1167,10 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     ...(valueAxisMajorGridlines !== undefined ? { valueAxisMajorGridlines } : {}),
     ...(valueAxisMajorGridlineColor !== undefined ? { valueAxisMajorGridlineColor } : {}),
     ...(valueAxisMajorTickMark !== undefined ? { valueAxisMajorTickMark } : {}),
+    ...(valueAxisMinorTickMark !== undefined ? { valueAxisMinorTickMark } : {}),
     ...(valueAxisLabelRotationDeg !== undefined ? { valueAxisLabelRotationDeg } : {}),
     ...(categoryAxisMajorTickMark !== undefined ? { categoryAxisMajorTickMark } : {}),
+    ...(categoryAxisMinorTickMark !== undefined ? { categoryAxisMinorTickMark } : {}),
     ...(valueAxisMinorGridlines !== undefined ? { valueAxisMinorGridlines } : {}),
     ...(categoryAxisTickLabelSkip !== undefined ? { categoryAxisTickLabelSkip } : {}),
     ...(categoryAxisTickMarkSkip !== undefined ? { categoryAxisTickMarkSkip } : {}),

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -342,6 +342,10 @@ export interface ChartSpec {
   readonly valueAxisMajorTickMark?: 'in' | 'out' | 'cross' | 'none';
   /** Major-tick mark mode on the category axis (`<c:catAx><c:majorTickMark>`). */
   readonly categoryAxisMajorTickMark?: 'in' | 'out' | 'cross' | 'none';
+  /** Minor-tick mark mode on the value axis (`<c:valAx><c:minorTickMark>`). */
+  readonly valueAxisMinorTickMark?: 'in' | 'out' | 'cross' | 'none';
+  /** Minor-tick mark mode on the category axis (`<c:catAx><c:minorTickMark>`). */
+  readonly categoryAxisMinorTickMark?: 'in' | 'out' | 'cross' | 'none';
   /**
    * Authored color on the value-axis major gridlines — `<c:valAx>
    * <c:majorGridlines><c:spPr><a:ln><a:solidFill><a:srgbClr val="…"/>`.

--- a/test/fn-chart-readback.test.ts
+++ b/test/fn-chart-readback.test.ts
@@ -585,6 +585,29 @@ describe('fn API: getSlideCharts', () => {
     expect(spec.valueAxisOrientation).toBe('maxMin');
   });
 
+  it('round-trips minor tick mark on both axes', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'column',
+        categories: ['A', 'B'],
+        series: [{ name: 'X', values: [1, 2] }],
+        categoryAxisMinorTickMark: 'out',
+        valueAxisMinorTickMark: 'cross',
+      },
+    });
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const spec = getSlideCharts(getSlides(reloaded)[0]!)[0]!.spec!;
+    expect(spec.categoryAxisMinorTickMark).toBe('out');
+    expect(spec.valueAxisMinorTickMark).toBe('cross');
+  });
+
   it('round-trips valueAxisCrossBetween', async () => {
     const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
     const slide = getSlides(pres)[0]!;


### PR DESCRIPTION
## Summary
- Adds \`ChartSpec.valueAxisMinorTickMark\` and \`ChartSpec.categoryAxisMinorTickMark\` — \`'in' | 'out' | 'cross' | 'none'\`.
- Map to \`<c:catAx>/<c:valAx><c:minorTickMark val="…"/>\`.
- Read by chart-reader (via a refactored \`readTickMarkLocal(axis, local)\` helper that the existing major-tick reader now wraps), written by chart-builder in the correct schema order (right after \`<c:majorTickMark>\`).

## Test plan
- [x] New round-trip test in \`test/fn-chart-readback.test.ts\` covering both axes (\`'out'\` on category, \`'cross'\` on value).
- [x] \`pnpm test\` — 840 passing (was 839), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)