### PR TITLE
feat: setTableCellTextDirection writer

### DIFF
--- a/.changeset/set-table-cell-text-direction.md
+++ b/.changeset/set-table-cell-text-direction.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: `setTableCellTextDirection(cell, direction | null)` — vertical-
+text writer for table cells, paired with the existing
+`getTableCellTextDirection` reader. Same six `ST_TextVerticalType`
+values as `setShapeTextDirection`. Passing `null` (or `'horz'`) clears
+the `<a:tcPr vert="…"/>` attribute so the cell uses the default
+horizontal direction. Creates `<a:tcPr>` if absent.

--- a/src/api/fn/tables.ts
+++ b/src/api/fn/tables.ts
@@ -490,6 +490,34 @@ export const getTableCellTextDirection = (
 };
 
 /**
+ * Sets the cell's text-direction via `<a:tcPr vert="…"/>`. Same six
+ * `ST_TextVerticalType` values as `setShapeTextDirection`. Passing
+ * `null` (or `'horz'`) clears the attribute so the cell uses the
+ * default horizontal direction. Creates `<a:tcPr>` if absent.
+ */
+export const setTableCellTextDirection = (
+  cell: TableCellData,
+  direction:
+    | 'horz'
+    | 'vert'
+    | 'vert270'
+    | 'wordArtVert'
+    | 'eaVert'
+    | 'mongolianVert'
+    | 'wordArtVertRtl'
+    | null,
+): void => {
+  const tcPr = ensureCellTcPr(cell);
+  tcPr.attrs = tcPr.attrs.filter(
+    (a) => !(a.name.namespaceURI === '' && a.name.localName === 'vert'),
+  );
+  if (direction !== null && direction !== 'horz') {
+    tcPr.attrs.push(attr(qname('', 'vert', ''), direction));
+  }
+  commitTableCell(cell);
+};
+
+/**
  * Reads the cell's vertical text anchor (`<a:tcPr anchor="t|ctr|b"/>`)
  * — `'top'`, `'center'`, `'bottom'`, or `null` for the default
  * (`ctr` / center per the schema).

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -466,6 +466,7 @@ export {
   setTableCellFill,
   setTableCellMargins,
   setTableCellText,
+  setTableCellTextDirection,
   setTableCellTextFormat,
   setTableColumnWidth,
   setTableRowHeight,

--- a/test/fn-set-table-cell-text-direction.test.ts
+++ b/test/fn-set-table-cell-text-direction.test.ts
@@ -1,0 +1,77 @@
+// `setTableCellTextDirection` — vertical-text writer for table cells.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  addSlideTable,
+  getSlides,
+  getSlideShapes,
+  getTableCell,
+  getTableCellTextDirection,
+  inches,
+  loadPresentation,
+  savePresentation,
+  setTableCellTextDirection,
+} from '../src/api/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+const DIRECTIONS = [
+  'vert',
+  'vert270',
+  'wordArtVert',
+  'eaVert',
+  'mongolianVert',
+  'wordArtVertRtl',
+] as const;
+
+const addDemo = async () => {
+  const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+  const slide = getSlides(pres)[0]!;
+  const table = addSlideTable(slide, {
+    x: inches(0),
+    y: inches(0),
+    w: inches(4),
+    h: inches(2),
+    rows: [
+      ['A', 'B'],
+      ['C', 'D'],
+    ],
+  });
+  return { pres, table };
+};
+
+describe('fn API: setTableCellTextDirection', () => {
+  it('round-trips every variant', async () => {
+    const { table } = await addDemo();
+    const cell = getTableCell(table, 0, 0);
+    for (const d of DIRECTIONS) {
+      setTableCellTextDirection(cell, d);
+      expect(getTableCellTextDirection(cell)).toBe(d);
+    }
+  });
+
+  it('survives save/reload', async () => {
+    const { pres, table } = await addDemo();
+    setTableCellTextDirection(getTableCell(table, 0, 1), 'eaVert');
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const reShapes = getSlideShapes(getSlides(reloaded)[0]!);
+    const tbl = reShapes[reShapes.length - 1]!;
+    expect(getTableCellTextDirection(getTableCell(tbl, 0, 1))).toBe('eaVert');
+  });
+
+  it('clears the attribute when set to null or horz', async () => {
+    const { table } = await addDemo();
+    const cell = getTableCell(table, 0, 0);
+    setTableCellTextDirection(cell, 'vert');
+    expect(getTableCellTextDirection(cell)).toBe('vert');
+    setTableCellTextDirection(cell, null);
+    expect(getTableCellTextDirection(cell)).toBeNull();
+    setTableCellTextDirection(cell, 'vert');
+    setTableCellTextDirection(cell, 'horz');
+    expect(getTableCellTextDirection(cell)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds \`setTableCellTextDirection(cell, direction | null)\` — vertical-text writer for table cells, paired with the existing reader.
- Same six \`ST_TextVerticalType\` values as \`setShapeTextDirection\` (\`vert\` / \`vert270\` / \`wordArtVert\` / \`eaVert\` / \`mongolianVert\` / \`wordArtVertRtl\`).
- Passing \`null\` or \`'horz'\` clears the \`<a:tcPr vert="…"/>\` attribute so the cell uses the default. Creates \`<a:tcPr>\` if absent.

## Test plan
- [x] 3 new tests in \`test/fn-set-table-cell-text-direction.test.ts\` covering every variant + save/reload + null/horz clear.
- [x] \`pnpm test\` — 849 passing (was 846), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)