### PR TITLE
site(playground): project categoryAxisLabelAlign into horizontal cat-axis labels

### DIFF
--- a/.changeset/site-cat-axis-label-align.md
+++ b/.changeset/site-cat-axis-label-align.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit-site': patch
+---
+
+site(playground): project `ChartSpec.categoryAxisLabelAlign` into the
+horizontal category-axis tick labels. Authored `<c:catAx><c:lblAlgn
+val="ctr|l|r"/>` now overrides the rotation-derived default
+text-anchor (useful for multi-line labels that the author wants flush-
+left under each column). Vertical bar-chart layout keeps its existing
+right-edge alignment, which is the only sensible default there.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -2810,6 +2810,7 @@ const renderCategoryAxis = (
   skip = 1,
   labelStyle?: ChartTextStyle,
   labelRotationDeg?: number,
+  labelAlign?: 'ctr' | 'l' | 'r',
 ): string => {
   const labels: string[] = [];
   for (let i = 0; i < pointCount; i++) {
@@ -2840,12 +2841,21 @@ const renderCategoryAxis = (
           : '';
       // When rotated, right-align to the pivot so the label leans
       // toward its data point rather than overflowing the next column.
+      // Authored <c:lblAlgn val=…> overrides the rotation-derived
+      // default — useful for multi-line cat labels that the author
+      // wants flush-left under each column.
       const anchor =
-        labelRotationDeg && labelRotationDeg > 0
-          ? 'end'
-          : labelRotationDeg && labelRotationDeg < 0
-            ? 'start'
-            : 'middle';
+        labelAlign === 'l'
+          ? 'start'
+          : labelAlign === 'r'
+            ? 'end'
+            : labelAlign === 'ctr'
+              ? 'middle'
+              : labelRotationDeg && labelRotationDeg > 0
+                ? 'end'
+                : labelRotationDeg && labelRotationDeg < 0
+                  ? 'start'
+                  : 'middle';
       out.push(
         `<text x="${px(cx)}" y="${px(cy)}" text-anchor="${anchor}" dominant-baseline="middle" ${axisTickAttrs(labelStyle)}${transform}>${escapeXml(truncated)}</text>`,
       );
@@ -3934,6 +3944,7 @@ const renderChart = (
         spec.categoryAxisTickLabelSkip ?? 1,
         spec.categoryAxisLabelStyle,
         spec.categoryAxisLabelRotationDeg,
+        spec.categoryAxisLabelAlign,
       );
     }
   }


### PR DESCRIPTION
## Summary
- Projects the new \`ChartSpec.categoryAxisLabelAlign\` (\`'ctr' | 'l' | 'r'\`) into the playground's horizontal category-axis tick labels.
- Authored \`<c:catAx><c:lblAlgn val>\` now overrides the rotation-derived text-anchor default.
- Vertical bar-chart layout keeps its existing right-edge alignment, which is the only sensible default there.

## Test plan
- [x] \`pnpm test\` — 849 passing.
- [x] \`pnpm exec svelte-check\` clean.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)