### PR TITLE
feat: ChartSpec.categoryAxisNumberFormat round-trip

### DIFF
--- a/.changeset/chart-cat-axis-number-format.md
+++ b/.changeset/chart-cat-axis-number-format.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: `ChartSpec.categoryAxisNumberFormat` — number-format code for the
+category-axis tick labels (`<c:catAx><c:numFmt formatCode="…"/>`). Most
+useful on date-style categories (`"mm/dd/yyyy"`, `"mmm-yyyy"`) but
+accepts any Excel format string. Independent of `valueAxis.numberFormat`.
+Read by chart-reader, written by chart-builder in the correct CT_CatAx
+schema order (after `<c:title>`, before `<c:majorTickMark>`).

--- a/src/internal/chartml/chart-builder.ts
+++ b/src/internal/chartml/chart-builder.ts
@@ -310,6 +310,16 @@ const catAxis = (spec: ChartSpec): XmlElement => {
   if (spec.categoryAxisTitle !== undefined) {
     children.push(titleElement(spec.categoryAxisTitle, spec.categoryAxisTitleStyle));
   }
+  if (spec.categoryAxisNumberFormat !== undefined) {
+    children.push(
+      elem(c('numFmt'), {
+        attrs: [
+          attr(qname('', 'formatCode', ''), spec.categoryAxisNumberFormat),
+          attr(qname('', 'sourceLinked', ''), '0'),
+        ],
+      }),
+    );
+  }
   if (spec.categoryAxisMajorTickMark !== undefined) {
     children.push(valNode(c('majorTickMark'), spec.categoryAxisMajorTickMark));
   }

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -858,6 +858,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
   let categoryAxisTickLabelPos: ChartSpec['categoryAxisTickLabelPos'];
   let categoryAxisLabelOffset: number | undefined;
   let categoryAxisLabelAlign: ChartSpec['categoryAxisLabelAlign'];
+  let categoryAxisNumberFormat: string | undefined;
   const catAx = findFirst(plotArea, ['catAx', 'dateAx', 'serAx']);
   const isHidden = (axis: XmlElement): boolean | undefined => {
     const d = firstChildElement(axis, qname('c', 'delete', NS_C));
@@ -935,6 +936,11 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     if (lblAlgnEl) {
       const v = getAttrValue(lblAlgnEl, ATTR_VAL);
       if (v === 'ctr' || v === 'l' || v === 'r') categoryAxisLabelAlign = v;
+    }
+    const catNumFmtEl = firstChildElement(catAx, qname('c', 'numFmt', NS_C));
+    if (catNumFmtEl) {
+      const fc = getAttrValue(catNumFmtEl, qname('', 'formatCode', ''));
+      if (fc !== null && fc.length > 0 && fc !== 'General') categoryAxisNumberFormat = fc;
     }
   }
   // <c:majorGridlines> / <c:minorGridlines> presence governs visibility.
@@ -1177,6 +1183,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     ...(categoryAxisTickLabelPos !== undefined ? { categoryAxisTickLabelPos } : {}),
     ...(categoryAxisLabelOffset !== undefined ? { categoryAxisLabelOffset } : {}),
     ...(categoryAxisLabelAlign !== undefined ? { categoryAxisLabelAlign } : {}),
+    ...(categoryAxisNumberFormat !== undefined ? { categoryAxisNumberFormat } : {}),
     ...(categoryAxisOrientation !== undefined ? { categoryAxisOrientation } : {}),
     ...(valueAxisOrientation !== undefined ? { valueAxisOrientation } : {}),
     ...(valueAxisCrosses !== undefined ? { valueAxisCrosses } : {}),

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -389,6 +389,14 @@ export interface ChartSpec {
    */
   readonly categoryAxisLabelAlign?: 'ctr' | 'l' | 'r';
   /**
+   * Number-format code for the category-axis tick labels —
+   * `<c:catAx><c:numFmt formatCode="…"/>`. Most useful on date-style
+   * categories (`"mm/dd/yyyy"`, `"mmm"`, etc.) but accepts any Excel
+   * format string. Independent of `valueAxis.numberFormat` (which
+   * targets the value axis).
+   */
+  readonly categoryAxisNumberFormat?: string;
+  /**
    * Category-axis order — `'minMax'` (the data's natural order) or
    * `'maxMin'` (reversed). For bar charts PowerPoint typically emits
    * `maxMin` so the first category sits at the top instead of the

--- a/test/fn-chart-readback.test.ts
+++ b/test/fn-chart-readback.test.ts
@@ -585,6 +585,27 @@ describe('fn API: getSlideCharts', () => {
     expect(spec.valueAxisOrientation).toBe('maxMin');
   });
 
+  it('round-trips categoryAxisNumberFormat', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'column',
+        categories: ['2024-01', '2024-02', '2024-03'],
+        series: [{ name: 'X', values: [1, 2, 3] }],
+        categoryAxisNumberFormat: 'mmm-yyyy',
+      },
+    });
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const spec = getSlideCharts(getSlides(reloaded)[0]!)[0]!.spec!;
+    expect(spec.categoryAxisNumberFormat).toBe('mmm-yyyy');
+  });
+
   it('round-trips minor tick mark on both axes', async () => {
     const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
     const slide = getSlides(pres)[0]!;


### PR DESCRIPTION
## Summary
- Adds \`ChartSpec.categoryAxisNumberFormat\` — number-format code for the category-axis tick labels.
- Maps to \`<c:catAx><c:numFmt formatCode="…" sourceLinked="0"/>\`.
- Most useful on date-style categories (e.g. \`'mmm-yyyy'\`) but accepts any Excel format string.
- Independent of \`valueAxis.numberFormat\` (which targets the value axis).
- Read by chart-reader, written by chart-builder in the correct CT_CatAx schema order (after \`<c:title>\`, before \`<c:majorTickMark>\`).

## Test plan
- [x] New round-trip test in \`test/fn-chart-readback.test.ts\` covering \`'mmm-yyyy'\`.
- [x] \`pnpm test\` — 850 passing (was 849), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)