### PR TITLE
feat: setTableCellBorders writer

### DIFF
--- a/.changeset/set-table-cell-borders.md
+++ b/.changeset/set-table-cell-borders.md
@@ -1,0 +1,13 @@
+---
+'pptx-kit': minor
+---
+
+feat: `setTableCellBorders(cell, sides | null)` — partial-update writer
+for all 6 cell-border slots (`left`, `right`, `top`, `bottom` + the
+`tlToBr` / `blToTr` diagonals). Pairs the existing
+`getTableCellBorders` reader. Sides listed with `null` are removed from
+`<a:tcPr>`; sides omitted are left untouched. Passing `null` as the
+whole `sides` arg clears every side. Creates `<a:tcPr>` if absent.
+
+The diagonals are independent of the four cardinal sides — a
+strikethrough cell can have only `tlToBr`.

--- a/src/api/fn/tables.ts
+++ b/src/api/fn/tables.ts
@@ -4,6 +4,7 @@ import { resolveChartPartName } from './charts.ts';
 import {
   applyAlignmentToAllParagraphs,
   applyFormatToAllRuns,
+  buildColorElement,
   clearFill as clearFillImpl,
   setSolidFill,
   setTextBody,
@@ -460,6 +461,81 @@ export const getTableCellBorders = (
     tlToBr: readLn('lnTlToBr'),
     blToTr: readLn('lnBlToTr'),
   };
+};
+
+const BORDER_SIDE_LOCALS = {
+  left: 'lnL',
+  right: 'lnR',
+  top: 'lnT',
+  bottom: 'lnB',
+  tlToBr: 'lnTlToBr',
+  blToTr: 'lnBlToTr',
+} as const;
+
+const writeBorderLn = (
+  tcPr: XmlElement,
+  local: 'lnL' | 'lnR' | 'lnT' | 'lnB' | 'lnTlToBr' | 'lnBlToTr',
+  border: TableCellBorder | null,
+): void => {
+  // Strip any prior side first.
+  tcPr.children = tcPr.children.filter(
+    (c) => !(c.kind === 'element' && c.name.namespaceURI === NS.dml && c.name.localName === local),
+  );
+  if (border === null) return;
+  const lnAttrs = [];
+  if (border.widthEmu !== null && border.widthEmu !== undefined) {
+    lnAttrs.push(attr(qname('', 'w', ''), String(Math.round(border.widthEmu))));
+  }
+  const children: XmlElement[] = [];
+  if (border.color !== null && border.color !== undefined) {
+    children.push(
+      elem(qname('a', 'solidFill', NS.dml), { children: [buildColorElement(border.color)] }),
+    );
+  }
+  if (border.dash !== null && border.dash !== undefined) {
+    children.push(
+      elem(qname('a', 'prstDash', NS.dml), { attrs: [attr(qname('', 'val', ''), border.dash)] }),
+    );
+  }
+  tcPr.children.push(elem(qname('a', local, NS.dml), { attrs: lnAttrs, children }));
+};
+
+/**
+ * Sets one or more side borders on a cell. Sides listed with `null` are
+ * removed from the `<a:tcPr>`; sides omitted from the partial are left
+ * untouched. Pass the whole `sides` arg as `null` to clear every side
+ * in one call. Creates `<a:tcPr>` if absent.
+ *
+ * The diagonal sides (`tlToBr` / `blToTr`) are independent of the
+ * cardinal four — a strikethrough cell can have only a diagonal.
+ */
+export const setTableCellBorders = (
+  cell: TableCellData,
+  sides: {
+    left?: TableCellBorder | null;
+    right?: TableCellBorder | null;
+    top?: TableCellBorder | null;
+    bottom?: TableCellBorder | null;
+    tlToBr?: TableCellBorder | null;
+    blToTr?: TableCellBorder | null;
+  } | null,
+): void => {
+  const tcPr = ensureCellTcPr(cell);
+  if (sides === null) {
+    for (const local of Object.values(BORDER_SIDE_LOCALS)) writeBorderLn(tcPr, local, null);
+  } else {
+    for (const [key, local] of Object.entries(BORDER_SIDE_LOCALS) as ReadonlyArray<
+      [
+        keyof typeof BORDER_SIDE_LOCALS,
+        (typeof BORDER_SIDE_LOCALS)[keyof typeof BORDER_SIDE_LOCALS],
+      ]
+    >) {
+      const v = sides[key];
+      if (v === undefined) continue;
+      writeBorderLn(tcPr, local, v);
+    }
+  }
+  commitTableCell(cell);
 };
 
 /**

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -463,6 +463,7 @@ export {
   setSlideTransition,
   setTableCellAlignment,
   setTableCellAnchor,
+  setTableCellBorders,
   setTableCellFill,
   setTableCellMargins,
   setTableCellText,

--- a/test/fn-set-table-cell-borders.test.ts
+++ b/test/fn-set-table-cell-borders.test.ts
@@ -1,0 +1,104 @@
+// `setTableCellBorders` — partial-update writer for all 6 sides
+// (left/right/top/bottom + tlToBr/blToTr diagonals). Pairs the existing
+// `getTableCellBorders` reader.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  addSlideTable,
+  getSlides,
+  getSlideShapes,
+  getTableCell,
+  getTableCellBorders,
+  inches,
+  loadPresentation,
+  savePresentation,
+  setTableCellBorders,
+} from '../src/api/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+const addDemo = async () => {
+  const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+  const slide = getSlides(pres)[0]!;
+  const table = addSlideTable(slide, {
+    x: inches(0),
+    y: inches(0),
+    w: inches(4),
+    h: inches(2),
+    rows: [
+      ['A', 'B'],
+      ['C', 'D'],
+    ],
+  });
+  return { pres, table };
+};
+
+describe('fn API: setTableCellBorders', () => {
+  it('writes one side and reads it back through save/reload', async () => {
+    const { pres, table } = await addDemo();
+    const cell = getTableCell(table, 0, 0);
+    setTableCellBorders(cell, {
+      bottom: { color: '#FF0000', widthEmu: 19050, dash: 'dash' },
+    });
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const reShapes = getSlideShapes(getSlides(reloaded)[0]!);
+    const tbl = reShapes[reShapes.length - 1]!;
+    const borders = getTableCellBorders(reloaded, getTableCell(tbl, 0, 0));
+    expect(borders.bottom).toEqual({ color: '#FF0000', widthEmu: 19050, dash: 'dash' });
+    expect(borders.left).toBeNull();
+    expect(borders.right).toBeNull();
+    expect(borders.top).toBeNull();
+  });
+
+  it('omitted sides are left untouched; null clears just that side', async () => {
+    const { pres, table } = await addDemo();
+    const cell = getTableCell(table, 0, 0);
+    setTableCellBorders(cell, {
+      left: { color: '#112233', widthEmu: 12700, dash: null },
+      right: { color: '#445566', widthEmu: 12700, dash: null },
+    });
+    // Partial update: clear `left` only, leave `right` intact.
+    setTableCellBorders(cell, { left: null });
+    const borders = getTableCellBorders(pres, cell);
+    expect(borders.left).toBeNull();
+    expect(borders.right).toEqual({ color: '#445566', widthEmu: 12700, dash: null });
+  });
+
+  it('null as the sides arg clears every side', async () => {
+    const { pres, table } = await addDemo();
+    const cell = getTableCell(table, 0, 0);
+    setTableCellBorders(cell, {
+      left: { color: '#000000', widthEmu: 6350, dash: null },
+      right: { color: '#000000', widthEmu: 6350, dash: null },
+      top: { color: '#000000', widthEmu: 6350, dash: null },
+      bottom: { color: '#000000', widthEmu: 6350, dash: null },
+    });
+    setTableCellBorders(cell, null);
+    const borders = getTableCellBorders(pres, cell);
+    expect(borders.left).toBeNull();
+    expect(borders.right).toBeNull();
+    expect(borders.top).toBeNull();
+    expect(borders.bottom).toBeNull();
+  });
+
+  it('round-trips diagonal borders', async () => {
+    const { pres, table } = await addDemo();
+    const cell = getTableCell(table, 0, 0);
+    setTableCellBorders(cell, {
+      tlToBr: { color: '#00AA00', widthEmu: 19050, dash: null },
+    });
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const reShapes = getSlideShapes(getSlides(reloaded)[0]!);
+    const tbl = reShapes[reShapes.length - 1]!;
+    expect(getTableCellBorders(reloaded, getTableCell(tbl, 0, 0)).tlToBr).toEqual({
+      color: '#00AA00',
+      widthEmu: 19050,
+      dash: null,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds \`setTableCellBorders(cell, sides | null)\` — partial-update writer for all 6 cell-border slots (\`left\`, \`right\`, \`top\`, \`bottom\` + the \`tlToBr\` / \`blToTr\` diagonals).
- Pairs the existing \`getTableCellBorders\` reader.
- Sides listed with \`null\` are removed from \`<a:tcPr>\`; omitted sides are left untouched. Passing the whole \`sides\` arg as \`null\` clears every side.
- Creates \`<a:tcPr>\` if absent.
- Diagonals are independent of the cardinal four — a strikethrough cell can have only \`tlToBr\`.

## Test plan
- [x] 4 new tests in \`test/fn-set-table-cell-borders.test.ts\` covering single-side write + save/reload, partial-update behavior, null full clear, and a diagonal round-trip.
- [x] \`pnpm test\` — 854 passing (was 850), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)