### PR TITLE
feat: setTableStyleFlags writer

### DIFF
--- a/.changeset/set-table-style-flags.md
+++ b/.changeset/set-table-style-flags.md
@@ -1,0 +1,12 @@
+---
+'pptx-kit': minor
+---
+
+feat: `setTableStyleFlags(table, flags)` — partial-update writer for
+the six `<a:tblPr>` boolean style flags (`firstRow`, `lastRow`,
+`firstCol`, `lastCol`, `bandRow`, `bandCol`). Pairs the existing
+`getTableStyleFlags` reader. Only the keys present in `flags` are
+touched — omitted keys keep their current state. A flag set to `false`
+strips the attribute (matching how PowerPoint round-trips defaults).
+Creates `<a:tblPr>` if absent. Throws when the shape isn't a table
+graphic frame.

--- a/src/api/fn/tables.ts
+++ b/src/api/fn/tables.ts
@@ -196,6 +196,59 @@ export const getTableStyleFlags = (
   };
 };
 
+const ensureTblPr = (tbl: XmlElement): XmlElement => {
+  let tblPr = firstChildElement(tbl, qname('a', 'tblPr', NS.dml));
+  if (tblPr === null) {
+    tblPr = elem(qname('a', 'tblPr', NS.dml));
+    // <a:tblPr> is the FIRST child of <a:tbl> per the schema.
+    tbl.children.unshift(tblPr);
+  }
+  return tblPr;
+};
+
+const TABLE_STYLE_FLAG_KEYS = [
+  'firstRow',
+  'lastRow',
+  'firstCol',
+  'lastCol',
+  'bandRow',
+  'bandCol',
+] as const;
+
+/**
+ * Sets one or more boolean style flags on `<a:tblPr>`. Only the keys
+ * present in `flags` are touched — omitted keys are left at their
+ * current state. A flag set to `false` strips the attribute (rather
+ * than emitting `="0"`), matching how PowerPoint round-trips defaults.
+ *
+ * See `getTableStyleFlags` for the meaning of each flag.
+ */
+export const setTableStyleFlags = (
+  table: SlideShapeData,
+  flags: {
+    firstRow?: boolean;
+    lastRow?: boolean;
+    firstCol?: boolean;
+    lastCol?: boolean;
+    bandRow?: boolean;
+    bandCol?: boolean;
+  },
+): void => {
+  const tbl = findTblElement(table);
+  if (!tbl) throw new Error('setTableStyleFlags: shape is not a table graphic frame');
+  const tblPr = ensureTblPr(tbl);
+  for (const key of TABLE_STYLE_FLAG_KEYS) {
+    const v = flags[key];
+    if (v === undefined) continue;
+    tblPr.attrs = tblPr.attrs.filter(
+      (a) => !(a.name.namespaceURI === '' && a.name.localName === key),
+    );
+    if (v) tblPr.attrs.push(attr(qname('', key, ''), '1'));
+  }
+  commitSlideData(table[SHAPE_SLIDE]);
+  refreshSlideData(table[SHAPE_SLIDE]);
+};
+
 /**
  * Returns the table's row + column counts. Throws when the shape
  * isn't a table graphic frame.

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -471,6 +471,7 @@ export {
   setTableCellTextFormat,
   setTableColumnWidth,
   setTableRowHeight,
+  setTableStyleFlags,
   setThumbnail,
   pointInShape,
   shapesOverlap,

--- a/test/fn-set-table-style-flags.test.ts
+++ b/test/fn-set-table-style-flags.test.ts
@@ -1,0 +1,90 @@
+// `setTableStyleFlags` — partial-update writer for `<a:tblPr>` boolean
+// style flags (firstRow / lastRow / firstCol / lastCol / bandRow /
+// bandCol). Pairs the existing `getTableStyleFlags` reader.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  addSlideTable,
+  getSlides,
+  getSlideShapes,
+  getTableStyleFlags,
+  inches,
+  loadPresentation,
+  savePresentation,
+  setTableStyleFlags,
+} from '../src/api/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+const addDemo = async () => {
+  const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+  const slide = getSlides(pres)[0]!;
+  const table = addSlideTable(slide, {
+    x: inches(0),
+    y: inches(0),
+    w: inches(4),
+    h: inches(2),
+    rows: [
+      ['A', 'B'],
+      ['C', 'D'],
+    ],
+  });
+  return { pres, table };
+};
+
+describe('fn API: setTableStyleFlags', () => {
+  it('round-trips a single flag through save/reload', async () => {
+    const { pres, table } = await addDemo();
+    setTableStyleFlags(table, { firstRow: true, bandRow: true });
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const reShapes = getSlideShapes(getSlides(reloaded)[0]!);
+    const tbl = reShapes[reShapes.length - 1]!;
+    const flags = getTableStyleFlags(tbl);
+    expect(flags.firstRow).toBe(true);
+    expect(flags.bandRow).toBe(true);
+    expect(flags.lastRow).toBe(false);
+    expect(flags.bandCol).toBe(false);
+  });
+
+  it('omitted keys are left untouched; false strips the attribute', async () => {
+    const { table } = await addDemo();
+    setTableStyleFlags(table, { firstRow: true, lastRow: true });
+    setTableStyleFlags(table, { firstRow: false });
+    const flags = getTableStyleFlags(table);
+    expect(flags.firstRow).toBe(false);
+    expect(flags.lastRow).toBe(true);
+  });
+
+  it('all six flags can be set simultaneously', async () => {
+    const { table } = await addDemo();
+    setTableStyleFlags(table, {
+      firstRow: true,
+      lastRow: true,
+      firstCol: true,
+      lastCol: true,
+      bandRow: true,
+      bandCol: true,
+    });
+    expect(getTableStyleFlags(table)).toEqual({
+      firstRow: true,
+      lastRow: true,
+      firstCol: true,
+      lastCol: true,
+      bandRow: true,
+      bandCol: true,
+    });
+  });
+
+  it('throws on non-table shapes', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const nonTable = getSlideShapes(slide)[0]!;
+    expect(() => setTableStyleFlags(nonTable, { firstRow: true })).toThrow(
+      /shape is not a table graphic frame/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds \`setTableStyleFlags(table, flags)\` — partial-update writer for the six \`<a:tblPr>\` boolean style flags (\`firstRow\`, \`lastRow\`, \`firstCol\`, \`lastCol\`, \`bandRow\`, \`bandCol\`).
- Pairs the existing \`getTableStyleFlags\` reader.
- Only the keys present in \`flags\` are touched — omitted keys keep their current state. A flag set to \`false\` strips the attribute (matching how PowerPoint round-trips defaults).
- Creates \`<a:tblPr>\` if absent. Throws when the shape isn't a table graphic frame.

## Test plan
- [x] 4 new tests in \`test/fn-set-table-style-flags.test.ts\` covering save/reload, partial-update untouch, all-six set, and the non-table throw.
- [x] \`pnpm test\` — 858 passing (was 854), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)