### PR TITLE
feat: setTableStyleId writer

### DIFF
--- a/.changeset/set-table-style-id.md
+++ b/.changeset/set-table-style-id.md
@@ -1,0 +1,11 @@
+---
+'pptx-kit': minor
+---
+
+feat: `setTableStyleId(table, styleId | null)` — writer for
+`<a:tbl><a:tblPr><a:tableStyleId>`. Pairs the existing `getTableStyleId`
+reader. Pass the curly-braced GUID (e.g.
+`'{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}'` for PowerPoint's "Medium
+Style 2 - Accent 1") or `null` to remove the reference so the table
+uses the slide's default style. Creates `<a:tblPr>` if absent. Throws
+when the shape isn't a table graphic frame.

--- a/src/api/fn/tables.ts
+++ b/src/api/fn/tables.ts
@@ -22,6 +22,7 @@ import {
   firstChildElement,
   getAttrValue,
   qname,
+  text,
 } from '../../internal/xml/index.ts';
 import {
   CELL_COL,
@@ -141,6 +142,34 @@ export const getTableStyleId = (table: SlideShapeData): string | null => {
     if (c.kind === 'text' || c.kind === 'cdata') acc += c.data;
   }
   return acc.trim() || null;
+};
+
+/**
+ * Writes `<a:tbl><a:tblPr><a:tableStyleId>` to the given GUID. Pass
+ * `null` to remove the element so the table falls back to the slide's
+ * default style. The GUID must include its curly braces — e.g.
+ * `'{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}'` (PowerPoint's "Medium
+ * Style 2 - Accent 1"). Creates `<a:tblPr>` if absent. Throws when the
+ * shape isn't a table graphic frame.
+ */
+export const setTableStyleId = (table: SlideShapeData, styleId: string | null): void => {
+  const tbl = findTblElement(table);
+  if (!tbl) throw new Error('setTableStyleId: shape is not a table graphic frame');
+  const tblPr = ensureTblPr(tbl);
+  // tableStyleId is the LAST child of <a:tblPr> per CT_TableProperties.
+  tblPr.children = tblPr.children.filter(
+    (c) =>
+      !(
+        c.kind === 'element' &&
+        c.name.namespaceURI === NS.dml &&
+        c.name.localName === 'tableStyleId'
+      ),
+  );
+  if (styleId !== null) {
+    tblPr.children.push(elem(qname('a', 'tableStyleId', NS.dml), { children: [text(styleId)] }));
+  }
+  commitSlideData(table[SHAPE_SLIDE]);
+  refreshSlideData(table[SHAPE_SLIDE]);
 };
 
 /**

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -472,6 +472,7 @@ export {
   setTableColumnWidth,
   setTableRowHeight,
   setTableStyleFlags,
+  setTableStyleId,
   setThumbnail,
   pointInShape,
   shapesOverlap,

--- a/test/fn-set-table-style-id.test.ts
+++ b/test/fn-set-table-style-id.test.ts
@@ -1,0 +1,73 @@
+// `setTableStyleId` — writer for `<a:tblPr><a:tableStyleId>`. Pairs the
+// existing `getTableStyleId` reader.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  addSlideTable,
+  getSlides,
+  getSlideShapes,
+  getTableStyleId,
+  inches,
+  loadPresentation,
+  savePresentation,
+  setTableStyleId,
+} from '../src/api/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+const STYLE_GUID = '{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}';
+
+const addDemo = async () => {
+  const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+  const slide = getSlides(pres)[0]!;
+  const table = addSlideTable(slide, {
+    x: inches(0),
+    y: inches(0),
+    w: inches(4),
+    h: inches(2),
+    rows: [
+      ['A', 'B'],
+      ['C', 'D'],
+    ],
+  });
+  return { pres, table };
+};
+
+describe('fn API: setTableStyleId', () => {
+  it('round-trips a style GUID through save/reload', async () => {
+    const { pres, table } = await addDemo();
+    setTableStyleId(table, STYLE_GUID);
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const reShapes = getSlideShapes(getSlides(reloaded)[0]!);
+    const tbl = reShapes[reShapes.length - 1]!;
+    expect(getTableStyleId(tbl)).toBe(STYLE_GUID);
+  });
+
+  it('null removes the element', async () => {
+    const { table } = await addDemo();
+    setTableStyleId(table, STYLE_GUID);
+    expect(getTableStyleId(table)).toBe(STYLE_GUID);
+    setTableStyleId(table, null);
+    expect(getTableStyleId(table)).toBeNull();
+  });
+
+  it('replaces a prior id on subsequent calls', async () => {
+    const { table } = await addDemo();
+    setTableStyleId(table, STYLE_GUID);
+    setTableStyleId(table, '{00000000-0000-0000-0000-000000000000}');
+    expect(getTableStyleId(table)).toBe('{00000000-0000-0000-0000-000000000000}');
+  });
+
+  it('throws on non-table shapes', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const nonTable = getSlideShapes(slide)[0]!;
+    expect(() => setTableStyleId(nonTable, STYLE_GUID)).toThrow(
+      /shape is not a table graphic frame/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds \`setTableStyleId(table, styleId | null)\` — writer for \`<a:tbl><a:tblPr><a:tableStyleId>\`.
- Pairs the existing \`getTableStyleId\` reader.
- Pass the curly-braced GUID (e.g. \`'{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}'\` for "Medium Style 2 - Accent 1") or \`null\` to remove the reference.
- Creates \`<a:tblPr>\` if absent. Throws when the shape isn't a table graphic frame.

## Test plan
- [x] 4 new tests in \`test/fn-set-table-style-id.test.ts\` covering save/reload, null clear, replacement-on-subsequent-call, and the non-table throw.
- [x] \`pnpm test\` — 862 passing (was 858), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)