### PR TITLE
feat: ChartSpec axis line colors

### DIFF
--- a/.changeset/chart-axis-line-color.md
+++ b/.changeset/chart-axis-line-color.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: `ChartSpec.categoryAxisLineColor` and `valueAxisLineColor` —
+authored stroke color on the axis line itself
+(`<c:catAx|valAx><c:spPr><a:ln><a:solidFill><a:srgbClr val=…/>`).
+`undefined` falls back to the renderer's default. Read by chart-reader,
+written by chart-builder in the correct CT_CatAx / CT_ValAx schema
+order (after the tick-mark elements, before `<c:txPr>`).

--- a/src/internal/chartml/chart-builder.ts
+++ b/src/internal/chartml/chart-builder.ts
@@ -329,6 +329,9 @@ const catAxis = (spec: ChartSpec): XmlElement => {
   if (spec.categoryAxisTickLabelPos !== undefined) {
     children.push(valNode(c('tickLblPos'), spec.categoryAxisTickLabelPos));
   }
+  if (spec.categoryAxisLineColor !== undefined) {
+    children.push(spPrChildren(undefined, spec.categoryAxisLineColor));
+  }
   const catTxPr = axisTxPrElement(spec.categoryAxisLabelStyle, spec.categoryAxisLabelRotationDeg);
   if (catTxPr) children.push(catTxPr);
   children.push(valNode(c('crossAx'), VAL_AX_ID));
@@ -408,6 +411,9 @@ const valAxis = (spec: ChartSpec): XmlElement => {
   }
   if (spec.valueAxisMinorTickMark !== undefined) {
     children.push(valNode(c('minorTickMark'), spec.valueAxisMinorTickMark));
+  }
+  if (spec.valueAxisLineColor !== undefined) {
+    children.push(spPrChildren(undefined, spec.valueAxisLineColor));
   }
   const valTxPr = axisTxPrElement(spec.valueAxisLabelStyle, spec.valueAxisLabelRotationDeg);
   if (valTxPr) children.push(valTxPr);

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -859,6 +859,21 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
   let categoryAxisLabelOffset: number | undefined;
   let categoryAxisLabelAlign: ChartSpec['categoryAxisLabelAlign'];
   let categoryAxisNumberFormat: string | undefined;
+  let categoryAxisLineColor: string | undefined;
+  let valueAxisLineColor: string | undefined;
+  // <c:catAx|valAx><c:spPr><a:ln><a:solidFill><a:srgbClr val=…/>.
+  const readAxisLineColor = (axis: XmlElement): string | undefined => {
+    const spPr = firstChildElement(axis, NAME_SP_PR_C);
+    if (!spPr) return undefined;
+    const ln = firstChildElement(spPr, qname('a', 'ln', NS_A));
+    if (!ln) return undefined;
+    const solid = firstChildElement(ln, NAME_SOLID_FILL);
+    if (!solid) return undefined;
+    const srgb = firstChildElement(solid, NAME_SRGB_CLR);
+    if (!srgb) return undefined;
+    const v = getAttrValue(srgb, ATTR_VAL);
+    return v !== null ? `#${v.toUpperCase()}` : undefined;
+  };
   const catAx = findFirst(plotArea, ['catAx', 'dateAx', 'serAx']);
   const isHidden = (axis: XmlElement): boolean | undefined => {
     const d = firstChildElement(axis, qname('c', 'delete', NS_C));
@@ -898,6 +913,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
       }
     }
     categoryAxisHidden = isHidden(catAx);
+    categoryAxisLineColor = readAxisLineColor(catAx);
     categoryAxisOrientation = readAxisOrientation(catAx);
     categoryAxisMajorTickMark = readTickMark(catAx);
     categoryAxisMinorTickMark = readTickMarkLocal(catAx, 'minorTickMark');
@@ -967,6 +983,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
       }
     }
     valueAxisHidden = isHidden(valAx);
+    valueAxisLineColor = readAxisLineColor(valAx);
     valueAxisOrientation = readAxisOrientation(valAx);
     valueAxisMajorTickMark = readTickMark(valAx);
     valueAxisMinorTickMark = readTickMarkLocal(valAx, 'minorTickMark');
@@ -1184,6 +1201,8 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     ...(categoryAxisLabelOffset !== undefined ? { categoryAxisLabelOffset } : {}),
     ...(categoryAxisLabelAlign !== undefined ? { categoryAxisLabelAlign } : {}),
     ...(categoryAxisNumberFormat !== undefined ? { categoryAxisNumberFormat } : {}),
+    ...(categoryAxisLineColor !== undefined ? { categoryAxisLineColor } : {}),
+    ...(valueAxisLineColor !== undefined ? { valueAxisLineColor } : {}),
     ...(categoryAxisOrientation !== undefined ? { categoryAxisOrientation } : {}),
     ...(valueAxisOrientation !== undefined ? { valueAxisOrientation } : {}),
     ...(valueAxisCrosses !== undefined ? { valueAxisCrosses } : {}),

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -353,6 +353,14 @@ export interface ChartSpec {
    * default (a light gray).
    */
   readonly valueAxisMajorGridlineColor?: string;
+  /**
+   * Authored color on the value-axis line itself — `<c:valAx><c:spPr>
+   * <a:ln><a:solidFill><a:srgbClr val="…"/>`. Returned as `#RRGGBB`.
+   * `undefined` falls back to the renderer's default axis stroke.
+   */
+  readonly valueAxisLineColor?: string;
+  /** Authored color on the category-axis line (same shape as `valueAxisLineColor`). */
+  readonly categoryAxisLineColor?: string;
   /** When the value-axis emits `<c:minorGridlines/>` — minor gridlines are visible. */
   readonly valueAxisMinorGridlines?: boolean;
   /**

--- a/test/fn-chart-readback.test.ts
+++ b/test/fn-chart-readback.test.ts
@@ -585,6 +585,29 @@ describe('fn API: getSlideCharts', () => {
     expect(spec.valueAxisOrientation).toBe('maxMin');
   });
 
+  it('round-trips axis line colors', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'column',
+        categories: ['A', 'B'],
+        series: [{ name: 'X', values: [1, 2] }],
+        categoryAxisLineColor: '#FF0000',
+        valueAxisLineColor: '#00AA00',
+      },
+    });
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const spec = getSlideCharts(getSlides(reloaded)[0]!)[0]!.spec!;
+    expect(spec.categoryAxisLineColor).toBe('#FF0000');
+    expect(spec.valueAxisLineColor).toBe('#00AA00');
+  });
+
   it('round-trips categoryAxisNumberFormat', async () => {
     const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
     const slide = getSlides(pres)[0]!;


### PR DESCRIPTION
## Summary
- Adds \`ChartSpec.categoryAxisLineColor\` and \`ChartSpec.valueAxisLineColor\` — authored stroke color on the axis line itself.
- Maps to \`<c:catAx|valAx><c:spPr><a:ln><a:solidFill><a:srgbClr val="…"/>\`.
- \`undefined\` falls back to the renderer's default.
- Read by chart-reader (via a new \`readAxisLineColor\` helper near the other axis helpers), written by chart-builder in the correct CT_CatAx / CT_ValAx schema order (after the tick-mark elements, before \`<c:txPr>\`).

## Test plan
- [x] New round-trip test in \`test/fn-chart-readback.test.ts\` covering both axes (\`#FF0000\` / \`#00AA00\`).
- [x] \`pnpm test\` — 863 passing (was 862), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)