### PR TITLE
feat: ChartSpec category-axis major + minor gridlines

### DIFF
--- a/.changeset/chart-cat-axis-gridlines.md
+++ b/.changeset/chart-cat-axis-gridlines.md
@@ -1,0 +1,11 @@
+---
+'pptx-kit': minor
+---
+
+feat: `ChartSpec.categoryAxisMajorGridlines` and
+`ChartSpec.categoryAxisMinorGridlines` — companions to the existing
+`valueAxis*` pair. Bar charts (where the category axis sits on the
+vertical edge) actually use these as horizontal guide lines per
+category band. Mapped to `<c:catAx><c:majorGridlines/>` /
+`<c:minorGridlines/>`. Read by chart-reader, written by chart-builder
+in the correct CT_CatAx schema order (right after `<c:axPos>`).

--- a/src/internal/chartml/chart-builder.ts
+++ b/src/internal/chartml/chart-builder.ts
@@ -307,6 +307,8 @@ const catAxis = (spec: ChartSpec): XmlElement => {
     valNode(c('delete'), spec.categoryAxisHidden ? '1' : '0'),
     valNode(c('axPos'), 'b'),
   ];
+  if (spec.categoryAxisMajorGridlines) children.push(elem(c('majorGridlines')));
+  if (spec.categoryAxisMinorGridlines) children.push(elem(c('minorGridlines')));
   if (spec.categoryAxisTitle !== undefined) {
     children.push(titleElement(spec.categoryAxisTitle, spec.categoryAxisTitleStyle));
   }

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -861,6 +861,8 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
   let categoryAxisNumberFormat: string | undefined;
   let categoryAxisLineColor: string | undefined;
   let valueAxisLineColor: string | undefined;
+  let categoryAxisMajorGridlines: boolean | undefined;
+  let categoryAxisMinorGridlines: boolean | undefined;
   // <c:catAx|valAx><c:spPr><a:ln><a:solidFill><a:srgbClr val=…/>.
   const readAxisLineColor = (axis: XmlElement): string | undefined => {
     const spPr = firstChildElement(axis, NAME_SP_PR_C);
@@ -914,6 +916,10 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     }
     categoryAxisHidden = isHidden(catAx);
     categoryAxisLineColor = readAxisLineColor(catAx);
+    categoryAxisMajorGridlines =
+      firstChildElement(catAx, qname('c', 'majorGridlines', NS_C)) !== null;
+    categoryAxisMinorGridlines =
+      firstChildElement(catAx, qname('c', 'minorGridlines', NS_C)) !== null;
     categoryAxisOrientation = readAxisOrientation(catAx);
     categoryAxisMajorTickMark = readTickMark(catAx);
     categoryAxisMinorTickMark = readTickMarkLocal(catAx, 'minorTickMark');
@@ -1203,6 +1209,8 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     ...(categoryAxisNumberFormat !== undefined ? { categoryAxisNumberFormat } : {}),
     ...(categoryAxisLineColor !== undefined ? { categoryAxisLineColor } : {}),
     ...(valueAxisLineColor !== undefined ? { valueAxisLineColor } : {}),
+    ...(categoryAxisMajorGridlines === true ? { categoryAxisMajorGridlines: true } : {}),
+    ...(categoryAxisMinorGridlines === true ? { categoryAxisMinorGridlines: true } : {}),
     ...(categoryAxisOrientation !== undefined ? { categoryAxisOrientation } : {}),
     ...(valueAxisOrientation !== undefined ? { valueAxisOrientation } : {}),
     ...(valueAxisCrosses !== undefined ? { valueAxisCrosses } : {}),

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -364,6 +364,15 @@ export interface ChartSpec {
   /** When the value-axis emits `<c:minorGridlines/>` — minor gridlines are visible. */
   readonly valueAxisMinorGridlines?: boolean;
   /**
+   * Whether the category axis emits `<c:majorGridlines/>`. Sounds odd
+   * for column charts (where category gridlines are vertical, between
+   * categories) but bar charts put the cat axis on the vertical edge
+   * and use these as horizontal guide lines per category band.
+   */
+  readonly categoryAxisMajorGridlines?: boolean;
+  /** Companion `<c:minorGridlines/>` on the category axis. */
+  readonly categoryAxisMinorGridlines?: boolean;
+  /**
    * Category-axis tick label skip step (`<c:catAx><c:tickLblSkip val="N"/>`):
    * render every Nth category label. Commonly 2 / 5 / 10 on dense
    * time-series charts to keep labels from overlapping.

--- a/test/fn-chart-readback.test.ts
+++ b/test/fn-chart-readback.test.ts
@@ -585,6 +585,29 @@ describe('fn API: getSlideCharts', () => {
     expect(spec.valueAxisOrientation).toBe('maxMin');
   });
 
+  it('round-trips category-axis gridlines (major + minor)', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'bar',
+        categories: ['A', 'B'],
+        series: [{ name: 'X', values: [1, 2] }],
+        categoryAxisMajorGridlines: true,
+        categoryAxisMinorGridlines: true,
+      },
+    });
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const spec = getSlideCharts(getSlides(reloaded)[0]!)[0]!.spec!;
+    expect(spec.categoryAxisMajorGridlines).toBe(true);
+    expect(spec.categoryAxisMinorGridlines).toBe(true);
+  });
+
   it('round-trips axis line colors', async () => {
     const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
     const slide = getSlides(pres)[0]!;


### PR DESCRIPTION
## Summary
- Adds \`ChartSpec.categoryAxisMajorGridlines\` and \`ChartSpec.categoryAxisMinorGridlines\` — companions to the existing \`valueAxis*\` pair.
- Bar charts (where the cat axis sits on the vertical edge) actually use these as horizontal guide lines per category band.
- Maps to \`<c:catAx><c:majorGridlines/>\` / \`<c:minorGridlines/>\`.
- Read by chart-reader, written by chart-builder in the correct CT_CatAx schema order (right after \`<c:axPos>\`).

## Test plan
- [x] New round-trip test in \`test/fn-chart-readback.test.ts\` covering both flags on a bar chart.
- [x] \`pnpm test\` — 864 passing (was 863), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)