### PR TITLE
feat: round out gridline color round-trip

### DIFF
--- a/.changeset/chart-all-gridline-colors.md
+++ b/.changeset/chart-all-gridline-colors.md
@@ -1,0 +1,12 @@
+---
+'pptx-kit': minor
+---
+
+feat: round out gridline color round-trip with 3 more fields —
+`valueAxisMinorGridlineColor`, `categoryAxisMajorGridlineColor`, and
+`categoryAxisMinorGridlineColor`. Previously only the value-axis major
+color was carried. All four now share a new chart-builder
+`gridlinesElement(local, color?)` helper and a chart-reader
+`readGridlineColor(gl)` helper; the existing major-gridline color
+inline parse was replaced with a call to the shared reader for
+consistency.

--- a/src/internal/chartml/chart-builder.ts
+++ b/src/internal/chartml/chart-builder.ts
@@ -69,6 +69,25 @@ const solidFillSpPr = (color: string): XmlElement => {
   return elem(c('spPr'), { children: [solidFill] });
 };
 
+// <c:majorGridlines|minorGridlines> with optional spPr/ln/solidFill/srgbClr
+// for the gridline color. Centralizes the per-gridline color emit so all
+// four axis-gridline slots share the same shape.
+const gridlinesElement = (
+  local: 'majorGridlines' | 'minorGridlines',
+  color: string | undefined,
+): XmlElement => {
+  if (color === undefined) return elem(c(local));
+  const hex = color.replace(/^#/, '').toUpperCase();
+  const ln = elem(a('ln'), {
+    children: [
+      elem(a('solidFill'), {
+        children: [elem(a('srgbClr'), { attrs: [attr(qname('', 'val', ''), hex)] })],
+      }),
+    ],
+  });
+  return elem(c(local), { children: [elem(c('spPr'), { children: [ln] })] });
+};
+
 // Generic <c:spPr> with optional fill color + line color. Used for the
 // chart-area / plot-area background, where authors set one or both.
 const spPrChildren = (fill: string | undefined, stroke: string | undefined): XmlElement => {
@@ -307,8 +326,12 @@ const catAxis = (spec: ChartSpec): XmlElement => {
     valNode(c('delete'), spec.categoryAxisHidden ? '1' : '0'),
     valNode(c('axPos'), 'b'),
   ];
-  if (spec.categoryAxisMajorGridlines) children.push(elem(c('majorGridlines')));
-  if (spec.categoryAxisMinorGridlines) children.push(elem(c('minorGridlines')));
+  if (spec.categoryAxisMajorGridlines) {
+    children.push(gridlinesElement('majorGridlines', spec.categoryAxisMajorGridlineColor));
+  }
+  if (spec.categoryAxisMinorGridlines) {
+    children.push(gridlinesElement('minorGridlines', spec.categoryAxisMinorGridlineColor));
+  }
   if (spec.categoryAxisTitle !== undefined) {
     children.push(titleElement(spec.categoryAxisTitle, spec.categoryAxisTitleStyle));
   }
@@ -372,29 +395,12 @@ const valAxis = (spec: ChartSpec): XmlElement => {
     valNode(c('delete'), spec.valueAxisHidden ? '1' : '0'),
     valNode(c('axPos'), 'l'),
   ];
-  // <c:majorGridlines> with optional spPr/ln/solidFill/srgbClr.
   if (spec.valueAxisMajorGridlines) {
-    const glChildren: XmlElement[] = [];
-    if (spec.valueAxisMajorGridlineColor !== undefined) {
-      const hex = spec.valueAxisMajorGridlineColor.startsWith('#')
-        ? spec.valueAxisMajorGridlineColor.slice(1)
-        : spec.valueAxisMajorGridlineColor;
-      const ln = elem(a('ln'), {
-        children: [
-          elem(a('solidFill'), {
-            children: [
-              elem(a('srgbClr'), {
-                attrs: [attr(qname('', 'val', ''), hex.toUpperCase())],
-              }),
-            ],
-          }),
-        ],
-      });
-      glChildren.push(elem(c('spPr'), { children: [ln] }));
-    }
-    children.push(elem(c('majorGridlines'), { children: glChildren }));
+    children.push(gridlinesElement('majorGridlines', spec.valueAxisMajorGridlineColor));
   }
-  if (spec.valueAxisMinorGridlines) children.push(elem(c('minorGridlines')));
+  if (spec.valueAxisMinorGridlines) {
+    children.push(gridlinesElement('minorGridlines', spec.valueAxisMinorGridlineColor));
+  }
   if (spec.valueAxisTitle !== undefined) {
     children.push(titleElement(spec.valueAxisTitle, spec.valueAxisTitleStyle));
   }

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -863,6 +863,22 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
   let valueAxisLineColor: string | undefined;
   let categoryAxisMajorGridlines: boolean | undefined;
   let categoryAxisMinorGridlines: boolean | undefined;
+  let categoryAxisMajorGridlineColor: string | undefined;
+  let categoryAxisMinorGridlineColor: string | undefined;
+  let valueAxisMinorGridlineColor: string | undefined;
+  // <c:majorGridlines|minorGridlines><c:spPr><a:ln><a:solidFill><a:srgbClr val=…/>.
+  const readGridlineColor = (gl: XmlElement): string | undefined => {
+    const spPr = firstChildElement(gl, NAME_SP_PR_C);
+    if (!spPr) return undefined;
+    const ln = firstChildElement(spPr, qname('a', 'ln', NS_A));
+    if (!ln) return undefined;
+    const solid = firstChildElement(ln, NAME_SOLID_FILL);
+    if (!solid) return undefined;
+    const srgb = firstChildElement(solid, NAME_SRGB_CLR);
+    if (!srgb) return undefined;
+    const v = getAttrValue(srgb, ATTR_VAL);
+    return v !== null ? `#${v.toUpperCase()}` : undefined;
+  };
   // <c:catAx|valAx><c:spPr><a:ln><a:solidFill><a:srgbClr val=…/>.
   const readAxisLineColor = (axis: XmlElement): string | undefined => {
     const spPr = firstChildElement(axis, NAME_SP_PR_C);
@@ -916,10 +932,12 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     }
     categoryAxisHidden = isHidden(catAx);
     categoryAxisLineColor = readAxisLineColor(catAx);
-    categoryAxisMajorGridlines =
-      firstChildElement(catAx, qname('c', 'majorGridlines', NS_C)) !== null;
-    categoryAxisMinorGridlines =
-      firstChildElement(catAx, qname('c', 'minorGridlines', NS_C)) !== null;
+    const catMajorGl = firstChildElement(catAx, qname('c', 'majorGridlines', NS_C));
+    categoryAxisMajorGridlines = catMajorGl !== null;
+    if (catMajorGl) categoryAxisMajorGridlineColor = readGridlineColor(catMajorGl);
+    const catMinorGl = firstChildElement(catAx, qname('c', 'minorGridlines', NS_C));
+    categoryAxisMinorGridlines = catMinorGl !== null;
+    if (catMinorGl) categoryAxisMinorGridlineColor = readGridlineColor(catMinorGl);
     categoryAxisOrientation = readAxisOrientation(catAx);
     categoryAxisMajorTickMark = readTickMark(catAx);
     categoryAxisMinorTickMark = readTickMarkLocal(catAx, 'minorTickMark');
@@ -1017,24 +1035,10 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     }
     const majorGl = firstChildElement(valAx, qname('c', 'majorGridlines', NS_C));
     valueAxisMajorGridlines = majorGl !== null;
-    if (majorGl) {
-      // <c:majorGridlines><c:spPr><a:ln><a:solidFill><a:srgbClr val="…"/>
-      const spPr = firstChildElement(majorGl, NAME_SP_PR_C);
-      if (spPr) {
-        const ln = firstChildElement(spPr, qname('a', 'ln', NS_A));
-        if (ln) {
-          const solid = firstChildElement(ln, NAME_SOLID_FILL);
-          if (solid) {
-            const srgb = firstChildElement(solid, NAME_SRGB_CLR);
-            if (srgb) {
-              const v = getAttrValue(srgb, ATTR_VAL);
-              if (v !== null) valueAxisMajorGridlineColor = `#${v.toUpperCase()}`;
-            }
-          }
-        }
-      }
-    }
-    valueAxisMinorGridlines = firstChildElement(valAx, qname('c', 'minorGridlines', NS_C)) !== null;
+    if (majorGl) valueAxisMajorGridlineColor = readGridlineColor(majorGl);
+    const minorGl = firstChildElement(valAx, qname('c', 'minorGridlines', NS_C));
+    valueAxisMinorGridlines = minorGl !== null;
+    if (minorGl) valueAxisMinorGridlineColor = readGridlineColor(minorGl);
   }
 
   // Plot area + chart area fills (`<c:spPr><a:solidFill><a:srgbClr/>`).
@@ -1211,6 +1215,9 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     ...(valueAxisLineColor !== undefined ? { valueAxisLineColor } : {}),
     ...(categoryAxisMajorGridlines === true ? { categoryAxisMajorGridlines: true } : {}),
     ...(categoryAxisMinorGridlines === true ? { categoryAxisMinorGridlines: true } : {}),
+    ...(categoryAxisMajorGridlineColor !== undefined ? { categoryAxisMajorGridlineColor } : {}),
+    ...(categoryAxisMinorGridlineColor !== undefined ? { categoryAxisMinorGridlineColor } : {}),
+    ...(valueAxisMinorGridlineColor !== undefined ? { valueAxisMinorGridlineColor } : {}),
     ...(categoryAxisOrientation !== undefined ? { categoryAxisOrientation } : {}),
     ...(valueAxisOrientation !== undefined ? { valueAxisOrientation } : {}),
     ...(valueAxisCrosses !== undefined ? { valueAxisCrosses } : {}),

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -353,6 +353,12 @@ export interface ChartSpec {
    * default (a light gray).
    */
   readonly valueAxisMajorGridlineColor?: string;
+  /** Companion authored color on the value-axis minor gridlines. */
+  readonly valueAxisMinorGridlineColor?: string;
+  /** Authored color on the category-axis major gridlines (same shape as `valueAxisMajorGridlineColor`). */
+  readonly categoryAxisMajorGridlineColor?: string;
+  /** Authored color on the category-axis minor gridlines. */
+  readonly categoryAxisMinorGridlineColor?: string;
   /**
    * Authored color on the value-axis line itself — `<c:valAx><c:spPr>
    * <a:ln><a:solidFill><a:srgbClr val="…"/>`. Returned as `#RRGGBB`.

--- a/test/fn-chart-readback.test.ts
+++ b/test/fn-chart-readback.test.ts
@@ -585,6 +585,37 @@ describe('fn API: getSlideCharts', () => {
     expect(spec.valueAxisOrientation).toBe('maxMin');
   });
 
+  it('round-trips all 4 gridline colors', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'bar',
+        categories: ['A', 'B'],
+        series: [{ name: 'X', values: [1, 2] }],
+        categoryAxisMajorGridlines: true,
+        categoryAxisMinorGridlines: true,
+        valueAxisMajorGridlines: true,
+        valueAxisMinorGridlines: true,
+        categoryAxisMajorGridlineColor: '#111111',
+        categoryAxisMinorGridlineColor: '#222222',
+        valueAxisMajorGridlineColor: '#333333',
+        valueAxisMinorGridlineColor: '#444444',
+      },
+    });
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const spec = getSlideCharts(getSlides(reloaded)[0]!)[0]!.spec!;
+    expect(spec.categoryAxisMajorGridlineColor).toBe('#111111');
+    expect(spec.categoryAxisMinorGridlineColor).toBe('#222222');
+    expect(spec.valueAxisMajorGridlineColor).toBe('#333333');
+    expect(spec.valueAxisMinorGridlineColor).toBe('#444444');
+  });
+
   it('round-trips category-axis gridlines (major + minor)', async () => {
     const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
     const slide = getSlides(pres)[0]!;


### PR DESCRIPTION
## Summary
- Adds 3 new fields to complete the 2×2 (axis × major/minor) gridline color matrix that previously only carried \`valueAxisMajorGridlineColor\`:
  - \`valueAxisMinorGridlineColor\`
  - \`categoryAxisMajorGridlineColor\`
  - \`categoryAxisMinorGridlineColor\`
- New chart-builder \`gridlinesElement(local, color?)\` helper and chart-reader \`readGridlineColor(gl)\` helper centralize the emit / parse so all 4 sites share the shape.
- The existing major-gridline-color inline parse was replaced with a call to the shared reader for consistency.

## Test plan
- [x] New round-trip test in \`test/fn-chart-readback.test.ts\` covering all 4 colors (\`#111111\` / \`#222222\` / \`#333333\` / \`#444444\`).
- [x] \`pnpm test\` — 865 passing (was 864), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)