### PR TITLE
feat: ChartSpec axis title rotation round-trip

### DIFF
--- a/.changeset/chart-axis-title-rotation.md
+++ b/.changeset/chart-axis-title-rotation.md
@@ -1,0 +1,13 @@
+---
+'pptx-kit': minor
+---
+
+feat: `ChartSpec.categoryAxisTitleRotationDeg` and
+`ChartSpec.valueAxisTitleRotationDeg` — rotation in plain degrees
+(clockwise) on the per-axis title. Maps to
+`<c:catAx|valAx><c:title><c:tx><c:rich><a:bodyPr rot="N"/>` (60000ths
+of a degree on the wire). PowerPoint often emits `-90` on the value-
+axis title; the field now survives round-trip. Read by chart-reader
+via a new `readTitleRotationDeg` helper; written by chart-builder
+through an extended `titleElement(title, style?, rotationDeg?)`
+signature.

--- a/src/internal/chartml/chart-builder.ts
+++ b/src/internal/chartml/chart-builder.ts
@@ -333,7 +333,13 @@ const catAxis = (spec: ChartSpec): XmlElement => {
     children.push(gridlinesElement('minorGridlines', spec.categoryAxisMinorGridlineColor));
   }
   if (spec.categoryAxisTitle !== undefined) {
-    children.push(titleElement(spec.categoryAxisTitle, spec.categoryAxisTitleStyle));
+    children.push(
+      titleElement(
+        spec.categoryAxisTitle,
+        spec.categoryAxisTitleStyle,
+        spec.categoryAxisTitleRotationDeg,
+      ),
+    );
   }
   if (spec.categoryAxisNumberFormat !== undefined) {
     children.push(
@@ -402,7 +408,9 @@ const valAxis = (spec: ChartSpec): XmlElement => {
     children.push(gridlinesElement('minorGridlines', spec.valueAxisMinorGridlineColor));
   }
   if (spec.valueAxisTitle !== undefined) {
-    children.push(titleElement(spec.valueAxisTitle, spec.valueAxisTitleStyle));
+    children.push(
+      titleElement(spec.valueAxisTitle, spec.valueAxisTitleStyle, spec.valueAxisTitleRotationDeg),
+    );
   }
   if (spec.valueAxis?.numberFormat !== undefined) {
     children.push(
@@ -602,7 +610,7 @@ const rPrAttrsFromStyle = (
   return { attrs, children };
 };
 
-const titleElement = (title: string, style?: ChartTextStyle): XmlElement => {
+const titleElement = (title: string, style?: ChartTextStyle, rotationDeg?: number): XmlElement => {
   // defRPr stays 1400 (14pt) as the legacy default; the run-level
   // <a:rPr> carries authored overrides so renderers honor them.
   const rPr = elem(a('defRPr'), { attrs: [attr(qname('', 'sz', ''), '1400')] });
@@ -616,11 +624,13 @@ const titleElement = (title: string, style?: ChartTextStyle): XmlElement => {
     children: [runRPr, elem(a('t'), { children: [text(title)] })],
   });
   const para = elem(a('p'), { children: [pPr, tRun] });
+  const rotStr =
+    rotationDeg !== undefined && rotationDeg !== 0 ? String(Math.round(rotationDeg * 60000)) : '0';
   const rich = elem(c('rich'), {
     children: [
       elem(a('bodyPr'), {
         attrs: [
-          attr(qname('', 'rot', ''), '0'),
+          attr(qname('', 'rot', ''), rotStr),
           attr(qname('', 'spcFirstLastPara', ''), '1'),
           attr(qname('', 'vertOverflow', ''), 'ellipsis'),
           attr(qname('', 'vert', ''), 'horz'),

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -490,6 +490,23 @@ const readTitleStyle = (chart: XmlElement): ChartTextStyle | undefined => {
   return readTitleStyleOf(title);
 };
 
+// Reads `<c:title><c:tx><c:rich><a:bodyPr rot="N"/>` and converts from
+// the OOXML 60000ths-of-a-degree unit to plain degrees. Returns
+// `undefined` when the rotation is absent (the renderer's default
+// applies).
+const readTitleRotationDeg = (titleEl: XmlElement): number | undefined => {
+  const tx = firstChildElement(titleEl, NAME_TX);
+  if (!tx) return undefined;
+  const rich = firstChildElement(tx, NAME_RICH);
+  if (!rich) return undefined;
+  const bodyPr = firstChildElement(rich, qname('a', 'bodyPr', NS_A));
+  if (!bodyPr) return undefined;
+  const v = getAttrValue(bodyPr, qname('', 'rot', ''));
+  if (v === null) return undefined;
+  const n = Number.parseInt(v, 10);
+  return Number.isFinite(n) ? n / 60000 : undefined;
+};
+
 // `<c:dLbls><c:dLblPos val="…"/>` — the chart-kind-dependent enum that
 // names where labels sit relative to their data point. Returns
 // `undefined` for unknown tokens so callers fall back to their default.
@@ -829,6 +846,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
   // readTitle's projection.
   let categoryAxisTitle: string | undefined;
   let categoryAxisTitleStyle: ChartTextStyle | undefined;
+  let categoryAxisTitleRotationDeg: number | undefined;
   let categoryAxisLabelStyle: ChartTextStyle | undefined;
   let categoryAxisLabelRotationDeg: number | undefined;
   let valueAxisLabelRotationDeg: number | undefined;
@@ -850,6 +868,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     readTickMarkLocal(axis, 'majorTickMark');
   let valueAxisTitle: string | undefined;
   let valueAxisTitleStyle: ChartTextStyle | undefined;
+  let valueAxisTitleRotationDeg: number | undefined;
   let valueAxisLabelStyle: ChartTextStyle | undefined;
   let categoryAxisHidden: boolean | undefined;
   let valueAxisHidden: boolean | undefined;
@@ -916,7 +935,10 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     const t = readTitle(catAx);
     if (t !== undefined) categoryAxisTitle = t;
     const catTitleEl = firstChildElement(catAx, NAME_TITLE);
-    if (catTitleEl) categoryAxisTitleStyle = readTitleStyleOf(catTitleEl);
+    if (catTitleEl) {
+      categoryAxisTitleStyle = readTitleStyleOf(catTitleEl);
+      categoryAxisTitleRotationDeg = readTitleRotationDeg(catTitleEl);
+    }
     const catTxPr = firstChildElement(catAx, qname('c', 'txPr', NS_C));
     if (catTxPr) {
       categoryAxisLabelStyle = readLabelStyle(catTxPr);
@@ -993,7 +1015,10 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     const t = readTitle(valAx);
     if (t !== undefined) valueAxisTitle = t;
     const valTitleEl = firstChildElement(valAx, NAME_TITLE);
-    if (valTitleEl) valueAxisTitleStyle = readTitleStyleOf(valTitleEl);
+    if (valTitleEl) {
+      valueAxisTitleStyle = readTitleStyleOf(valTitleEl);
+      valueAxisTitleRotationDeg = readTitleRotationDeg(valTitleEl);
+    }
     const valTxPr = firstChildElement(valAx, qname('c', 'txPr', NS_C));
     if (valTxPr) {
       valueAxisLabelStyle = readLabelStyle(valTxPr);
@@ -1190,10 +1215,12 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     ...(chartAreaStrokeColor !== undefined ? { chartAreaStrokeColor } : {}),
     ...(categoryAxisTitle !== undefined ? { categoryAxisTitle } : {}),
     ...(categoryAxisTitleStyle !== undefined ? { categoryAxisTitleStyle } : {}),
+    ...(categoryAxisTitleRotationDeg !== undefined ? { categoryAxisTitleRotationDeg } : {}),
     ...(categoryAxisLabelStyle !== undefined ? { categoryAxisLabelStyle } : {}),
     ...(categoryAxisLabelRotationDeg !== undefined ? { categoryAxisLabelRotationDeg } : {}),
     ...(valueAxisTitle !== undefined ? { valueAxisTitle } : {}),
     ...(valueAxisTitleStyle !== undefined ? { valueAxisTitleStyle } : {}),
+    ...(valueAxisTitleRotationDeg !== undefined ? { valueAxisTitleRotationDeg } : {}),
     ...(valueAxisLabelStyle !== undefined ? { valueAxisLabelStyle } : {}),
     ...(categoryAxisHidden !== undefined ? { categoryAxisHidden } : {}),
     ...(valueAxisHidden !== undefined ? { valueAxisHidden } : {}),

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -305,6 +305,13 @@ export interface ChartSpec {
   readonly categoryAxisTitle?: string;
   /** Authored font / color on the category-axis title (same `<a:rPr>` shape as `titleStyle`). */
   readonly categoryAxisTitleStyle?: ChartTextStyle;
+  /**
+   * Rotation of the category-axis title, in degrees clockwise. Maps
+   * to `<c:catAx><c:title><c:tx><c:rich><a:bodyPr rot="N"/>` (the OOXML
+   * value is in 60000ths of a degree, but the API surface uses plain
+   * degrees). Omit to inherit the default (`0`).
+   */
+  readonly categoryAxisTitleRotationDeg?: number;
   /** Authored font / color on the category-axis *tick labels* — `<c:catAx><c:txPr>`. */
   readonly categoryAxisLabelStyle?: ChartTextStyle;
   /**
@@ -317,6 +324,13 @@ export interface ChartSpec {
   readonly valueAxisTitle?: string;
   /** Authored font / color on the value-axis title. */
   readonly valueAxisTitleStyle?: ChartTextStyle;
+  /**
+   * Rotation of the value-axis title, in degrees clockwise. PowerPoint
+   * often emits `-90` (or `vert270`) so the title reads bottom-to-top
+   * alongside the axis. Maps to `<c:valAx><c:title><c:tx><c:rich>
+   * <a:bodyPr rot="N"/>` (60000ths of a degree on the wire).
+   */
+  readonly valueAxisTitleRotationDeg?: number;
   /** Authored font / color on the value-axis *tick labels* — `<c:valAx><c:txPr>`. */
   readonly valueAxisLabelStyle?: ChartTextStyle;
   /**

--- a/test/fn-chart-readback.test.ts
+++ b/test/fn-chart-readback.test.ts
@@ -585,6 +585,31 @@ describe('fn API: getSlideCharts', () => {
     expect(spec.valueAxisOrientation).toBe('maxMin');
   });
 
+  it('round-trips axis title rotation', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'column',
+        categories: ['A', 'B'],
+        series: [{ name: 'X', values: [1, 2] }],
+        valueAxisTitle: 'Revenue',
+        valueAxisTitleRotationDeg: -90,
+        categoryAxisTitle: 'Quarter',
+        categoryAxisTitleRotationDeg: 45,
+      },
+    });
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const spec = getSlideCharts(getSlides(reloaded)[0]!)[0]!.spec!;
+    expect(spec.valueAxisTitleRotationDeg).toBe(-90);
+    expect(spec.categoryAxisTitleRotationDeg).toBe(45);
+  });
+
   it('round-trips all 4 gridline colors', async () => {
     const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
     const slide = getSlides(pres)[0]!;


### PR DESCRIPTION
## Summary
- Adds \`ChartSpec.categoryAxisTitleRotationDeg\` and \`ChartSpec.valueAxisTitleRotationDeg\` — rotation in plain degrees (clockwise) on the per-axis title.
- Maps to \`<c:catAx|valAx><c:title><c:tx><c:rich><a:bodyPr rot="N"/>\` (60000ths of a degree on the wire).
- PowerPoint often emits \`-90\` on the value-axis title; the field now survives round-trip.
- Read by chart-reader via a new \`readTitleRotationDeg\` helper; written by chart-builder through an extended \`titleElement(title, style?, rotationDeg?)\` signature.

## Test plan
- [x] New round-trip test in \`test/fn-chart-readback.test.ts\` covering both axes (\`-90\` on value, \`45\` on category).
- [x] \`pnpm test\` — 866 passing (was 865), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)