### PR TITLE
feat: ChartSpec.plotVisibleCellsOnly round-trip

### DIFF
--- a/.changeset/chart-plot-visible-cells-only.md
+++ b/.changeset/chart-plot-visible-cells-only.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: `ChartSpec.plotVisibleCellsOnly` — toggle `<c:plotVisOnly val/>`.
+PowerPoint's default is `true` (only plot visible cells); the field
+exists to let authors opt into `false` (plot hidden rows / columns too).
+The reader surfaces `false` only when the wire is explicitly `0` so
+round-tripping the common default doesn't drag a redundant explicit
+`true` into the spec.

--- a/src/internal/chartml/chart-builder.ts
+++ b/src/internal/chartml/chart-builder.ts
@@ -737,7 +737,7 @@ export const buildChartSpaceDoc = (spec: ChartSpec): XmlDocument => {
     chartChildren.push(elem(c('legend'), { children: legendChildren }));
   }
   chartChildren.push(
-    valNode(c('plotVisOnly'), '1'),
+    valNode(c('plotVisOnly'), spec.plotVisibleCellsOnly === false ? '0' : '1'),
     valNode(c('dispBlanksAs'), spec.dispBlanksAs ?? 'gap'),
   );
   const chart = elem(c('chart'), { children: chartChildren });

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -1104,6 +1104,15 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     const v = getAttrValue(dbaEl, ATTR_VAL);
     if (v === 'gap' || v === 'zero' || v === 'span') dispBlanksAs = v;
   }
+  // <c:plotVisOnly val="0|1"/> — PowerPoint default is 1. Surface as
+  // `plotVisibleCellsOnly: false` only when explicitly 0 so the round-trip
+  // doesn't add a redundant `false` for every default-shaped chart.
+  let plotVisibleCellsOnly: boolean | undefined;
+  const pvoEl = firstChildElement(chart, qname('c', 'plotVisOnly', NS_C));
+  if (pvoEl) {
+    const v = getAttrValue(pvoEl, ATTR_VAL);
+    if (v === '0' || v === 'false') plotVisibleCellsOnly = false;
+  }
 
   // <c:legend> sits on the chart element (not the plotArea). Read the
   // position; PowerPoint defaults to 'r' (right) when the element is
@@ -1209,6 +1218,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     ...(titleOverlay !== undefined ? { titleOverlay } : {}),
     ...(varyColors !== undefined ? { varyColors } : {}),
     ...(dispBlanksAs !== undefined ? { dispBlanksAs } : {}),
+    ...(plotVisibleCellsOnly === false ? { plotVisibleCellsOnly: false } : {}),
     ...(plotAreaFill !== undefined ? { plotAreaFill } : {}),
     ...(plotAreaStrokeColor !== undefined ? { plotAreaStrokeColor } : {}),
     ...(chartAreaFill !== undefined ? { chartAreaFill } : {}),

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -460,6 +460,13 @@ export interface ChartSpec {
    * here so the round-trip preserves the authored intent.
    */
   readonly valueAxisCrossBetween?: 'between' | 'midCat';
+  /**
+   * When `false`, plot data from hidden cells in the embedded workbook
+   * — maps to `<c:plotVisOnly val="0"/>`. PowerPoint's default is
+   * `true` (only plot visible cells), so omitting this field emits
+   * `val="1"` to stay round-trip-safe with PowerPoint-authored files.
+   */
+  readonly plotVisibleCellsOnly?: boolean;
   /** Bar / column / area grouping mode. Absent for line / pie. */
   readonly grouping?: ChartGrouping;
   /**

--- a/test/fn-chart-readback.test.ts
+++ b/test/fn-chart-readback.test.ts
@@ -585,6 +585,47 @@ describe('fn API: getSlideCharts', () => {
     expect(spec.valueAxisOrientation).toBe('maxMin');
   });
 
+  it('round-trips plotVisibleCellsOnly=false', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'column',
+        categories: ['A', 'B'],
+        series: [{ name: 'X', values: [1, 2] }],
+        plotVisibleCellsOnly: false,
+      },
+    });
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const spec = getSlideCharts(getSlides(reloaded)[0]!)[0]!.spec!;
+    expect(spec.plotVisibleCellsOnly).toBe(false);
+  });
+
+  it('omits plotVisibleCellsOnly on read when the chart uses the default (true)', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'column',
+        categories: ['A', 'B'],
+        series: [{ name: 'X', values: [1, 2] }],
+      },
+    });
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const spec = getSlideCharts(getSlides(reloaded)[0]!)[0]!.spec!;
+    expect(spec.plotVisibleCellsOnly).toBeUndefined();
+  });
+
   it('round-trips axis title rotation', async () => {
     const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
     const slide = getSlides(pres)[0]!;


### PR DESCRIPTION
## Summary
- Adds \`ChartSpec.plotVisibleCellsOnly\` — toggle for \`<c:plotVisOnly val>\`.
- PowerPoint's default is \`true\` (only plot visible cells); the field lets authors opt into \`false\` so hidden rows / columns are also plotted.
- The reader surfaces \`false\` only when the wire is explicitly \`0\` — the common default doesn't drag a redundant explicit \`true\` into the spec.
- The builder still emits \`val="1"\` by default to stay round-trip-safe with PowerPoint-authored files.

## Test plan
- [x] 2 new tests in \`test/fn-chart-readback.test.ts\` covering both the \`false\` round-trip and the absence-on-default-true case.
- [x] \`pnpm test\` — 868 passing (was 866), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)