### PR TITLE
feat: ChartTrendline displayEquation + displayRSquared

### DIFF
--- a/.changeset/chart-trendline-display-eq-rsqr.md
+++ b/.changeset/chart-trendline-display-eq-rsqr.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: `ChartTrendline.displayEquation` and `ChartTrendline.displayRSquared`
+— two booleans that toggle the regression-equation label and R²
+coefficient overlay next to a trendline. Map to
+`<c:trendline><c:dispEq val="1"/>` and `<c:dispRSqr val="1"/>`. Read by
+chart-reader; written by chart-builder in the correct CT_Trendline
+schema order (after `<c:backward>`, before any `<c:trendlineLbl>`).

--- a/src/internal/chartml/chart-builder.ts
+++ b/src/internal/chartml/chart-builder.ts
@@ -235,6 +235,10 @@ const trendlineElement = (
   }
   if (tl.forward !== undefined) children.push(valNode(c('forward'), tl.forward));
   if (tl.backward !== undefined) children.push(valNode(c('backward'), tl.backward));
+  // CT_Trendline schema order: dispRSqr before dispEq, both after
+  // forward/backward and before trendlineLbl/extLst.
+  if (tl.displayRSquared) children.push(valNode(c('dispRSqr'), '1'));
+  if (tl.displayEquation) children.push(valNode(c('dispEq'), '1'));
   return elem(c('trendline'), { children });
 };
 

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -297,6 +297,16 @@ const readTrendline = (ser: XmlElement): ChartTrendline | undefined => {
   };
   const forward = readExtension('forward');
   const backward = readExtension('backward');
+  // <c:dispEq val="1"/> and <c:dispRSqr val="1"/> show the regression
+  // equation / R² coefficient next to the line. Default false.
+  const readDispBool = (local: string): boolean | undefined => {
+    const el = firstChildElement(tl, qname('c', local, NS_C));
+    if (!el) return undefined;
+    const v = getAttrValue(el, ATTR_VAL);
+    return v === null || v === '1' || v === 'true' ? true : undefined;
+  };
+  const displayEquation = readDispBool('dispEq');
+  const displayRSquared = readDispBool('dispRSqr');
   return {
     type,
     ...(period !== undefined ? { period } : {}),
@@ -304,6 +314,8 @@ const readTrendline = (ser: XmlElement): ChartTrendline | undefined => {
     ...(color !== undefined ? { color } : {}),
     ...(forward !== undefined ? { forward } : {}),
     ...(backward !== undefined ? { backward } : {}),
+    ...(displayEquation === true ? { displayEquation: true } : {}),
+    ...(displayRSquared === true ? { displayRSquared: true } : {}),
   };
 };
 

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -119,6 +119,16 @@ export interface ChartTrendline {
   readonly order?: number;
   /** Override stroke color; defaults to the series color. */
   readonly color?: string;
+  /**
+   * Show the regression equation next to the trendline
+   * (`<c:dispEq val="1"/>`). Defaults to `false`.
+   */
+  readonly displayEquation?: boolean;
+  /**
+   * Show the R² coefficient next to the trendline
+   * (`<c:dispRSqr val="1"/>`). Defaults to `false`.
+   */
+  readonly displayRSquared?: boolean;
 }
 
 /**

--- a/test/fn-chart-readback.test.ts
+++ b/test/fn-chart-readback.test.ts
@@ -585,6 +585,38 @@ describe('fn API: getSlideCharts', () => {
     expect(spec.valueAxisOrientation).toBe('maxMin');
   });
 
+  it('round-trips trendline displayEquation + displayRSquared', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'line',
+        categories: ['A', 'B', 'C'],
+        series: [
+          {
+            name: 'X',
+            values: [1, 2, 4],
+            trendline: {
+              type: 'linear',
+              displayEquation: true,
+              displayRSquared: true,
+            },
+          },
+        ],
+      },
+    });
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const spec = getSlideCharts(getSlides(reloaded)[0]!)[0]!.spec!;
+    const tl = spec.series[0]!.trendline!;
+    expect(tl.displayEquation).toBe(true);
+    expect(tl.displayRSquared).toBe(true);
+  });
+
   it('round-trips plotVisibleCellsOnly=false', async () => {
     const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
     const slide = getSlides(pres)[0]!;


### PR DESCRIPTION
## Summary
- Adds \`ChartTrendline.displayEquation\` and \`ChartTrendline.displayRSquared\` — two booleans that toggle the regression-equation label and R² coefficient overlay next to a trendline.
- Map to \`<c:trendline><c:dispEq val="1"/>\` and \`<c:dispRSqr val="1"/>\`.
- Read by chart-reader (both default to absence on read so common defaults stay clean), written by chart-builder in the correct CT_Trendline schema order (after \`<c:backward>\`, before any \`<c:trendlineLbl>\`).

## Test plan
- [x] New round-trip test in \`test/fn-chart-readback.test.ts\` covering both flags on a linear trendline.
- [x] \`pnpm test\` — 869 passing (was 868), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)