### PR TITLE
feat: ChartSpec.roundedCorners round-trip

### DIFF
--- a/.changeset/chart-rounded-corners.md
+++ b/.changeset/chart-rounded-corners.md
@@ -1,0 +1,9 @@
+---
+'pptx-kit': minor
+---
+
+feat: `ChartSpec.roundedCorners` — round-trip the chartSpace-level
+`<c:roundedCorners val>` toggle. PowerPoint's default is `false`; the
+reader surfaces `true` only when the wire is explicitly `1` and the
+builder emits the element only when authored, so common defaults stay
+clean. Schema position is BEFORE `<c:chart>` (per CT_ChartSpace).

--- a/src/internal/chartml/chart-builder.ts
+++ b/src/internal/chartml/chart-builder.ts
@@ -752,7 +752,10 @@ export const buildChartSpaceDoc = (spec: ChartSpec): XmlDocument => {
   });
 
   // <c:chartSpace><c:spPr> sits at the root and styles the entire card.
-  const rootChildren: XmlElement[] = [chart];
+  // CT_ChartSpace schema order: roundedCorners comes BEFORE <c:chart>.
+  const rootChildren: XmlElement[] = [];
+  if (spec.roundedCorners) rootChildren.push(valNode(c('roundedCorners'), '1'));
+  rootChildren.push(chart);
   if (spec.chartAreaFill !== undefined || spec.chartAreaStrokeColor !== undefined) {
     rootChildren.push(spPrChildren(spec.chartAreaFill, spec.chartAreaStrokeColor));
   }

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -1125,6 +1125,14 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     const v = getAttrValue(pvoEl, ATTR_VAL);
     if (v === '0' || v === 'false') plotVisibleCellsOnly = false;
   }
+  // <c:chartSpace><c:roundedCorners val="1"/> — surface only when
+  // explicitly true so the round-trip doesn't carry a redundant false.
+  let roundedCorners: boolean | undefined;
+  const rcEl = firstChildElement(root, qname('c', 'roundedCorners', NS_C));
+  if (rcEl) {
+    const v = getAttrValue(rcEl, ATTR_VAL);
+    if (v === '1' || v === 'true') roundedCorners = true;
+  }
 
   // <c:legend> sits on the chart element (not the plotArea). Read the
   // position; PowerPoint defaults to 'r' (right) when the element is
@@ -1231,6 +1239,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     ...(varyColors !== undefined ? { varyColors } : {}),
     ...(dispBlanksAs !== undefined ? { dispBlanksAs } : {}),
     ...(plotVisibleCellsOnly === false ? { plotVisibleCellsOnly: false } : {}),
+    ...(roundedCorners === true ? { roundedCorners: true } : {}),
     ...(plotAreaFill !== undefined ? { plotAreaFill } : {}),
     ...(plotAreaStrokeColor !== undefined ? { plotAreaStrokeColor } : {}),
     ...(chartAreaFill !== undefined ? { chartAreaFill } : {}),

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -477,6 +477,13 @@ export interface ChartSpec {
    * `val="1"` to stay round-trip-safe with PowerPoint-authored files.
    */
   readonly plotVisibleCellsOnly?: boolean;
+  /**
+   * Renders the chart area with rounded corners
+   * (`<c:chartSpace><c:roundedCorners val="1"/>`). PowerPoint's default
+   * is `false`; surface only when explicitly `true` so the round-trip
+   * doesn't add a redundant `false`.
+   */
+  readonly roundedCorners?: boolean;
   /** Bar / column / area grouping mode. Absent for line / pie. */
   readonly grouping?: ChartGrouping;
   /**

--- a/test/fn-chart-readback.test.ts
+++ b/test/fn-chart-readback.test.ts
@@ -617,6 +617,27 @@ describe('fn API: getSlideCharts', () => {
     expect(tl.displayRSquared).toBe(true);
   });
 
+  it('round-trips roundedCorners=true', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'column',
+        categories: ['A', 'B'],
+        series: [{ name: 'X', values: [1, 2] }],
+        roundedCorners: true,
+      },
+    });
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const spec = getSlideCharts(getSlides(reloaded)[0]!)[0]!.spec!;
+    expect(spec.roundedCorners).toBe(true);
+  });
+
   it('round-trips plotVisibleCellsOnly=false', async () => {
     const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
     const slide = getSlides(pres)[0]!;


### PR DESCRIPTION
## Summary
- Adds \`ChartSpec.roundedCorners\` — toggle for \`<c:chartSpace><c:roundedCorners val>\`.
- PowerPoint's default is \`false\`; the reader surfaces \`true\` only when the wire is explicitly \`1\` and the builder only emits the element when authored, so common defaults stay clean.
- Schema position is BEFORE \`<c:chart>\` per CT_ChartSpace.

## Test plan
- [x] New round-trip test in \`test/fn-chart-readback.test.ts\` covering \`true\`.
- [x] \`pnpm test\` — 870 passing (was 869), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)