### PR TITLE
site(playground): honor ChartSpec.roundedCorners in chart-area rect

### DIFF
--- a/.changeset/site-chart-rounded-corners.md
+++ b/.changeset/site-chart-rounded-corners.md
@@ -1,0 +1,8 @@
+---
+'pptx-kit-site': patch
+---
+
+site(playground): honor `ChartSpec.roundedCorners` in the chart-area
+backdrop — adds `rx="6" ry="6"` to the chart-area `<rect>` only when
+the field is authored true. Mirrors PowerPoint's rounded-corner
+treatment without altering the default look of any existing chart.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -4046,7 +4046,7 @@ const renderChart = (
     // Chart-area backdrop honors <c:chartSpace><c:spPr><a:solidFill> /
     // <a:ln>. plot-area gets its own tinted rect + border when
     // <c:plotArea><c:spPr> authors them.
-    `<rect x="${px(f.x)}" y="${px(f.y)}" width="${px(f.w)}" height="${px(f.h)}" fill="${spec.chartAreaFill ?? '#FFFFFF'}" stroke="${spec.chartAreaStrokeColor ?? '#E5E7EB'}" stroke-width="0.6"/>`,
+    `<rect x="${px(f.x)}" y="${px(f.y)}" width="${px(f.w)}" height="${px(f.h)}" fill="${spec.chartAreaFill ?? '#FFFFFF'}" stroke="${spec.chartAreaStrokeColor ?? '#E5E7EB'}" stroke-width="0.6"${spec.roundedCorners ? ' rx="6" ry="6"' : ''}/>`,
     spec.plotAreaFill || spec.plotAreaStrokeColor
       ? `<rect x="${px(f.plotX)}" y="${px(f.plotY)}" width="${px(f.plotW)}" height="${px(f.plotH)}" fill="${spec.plotAreaFill ?? 'none'}" stroke="${spec.plotAreaStrokeColor ?? 'none'}" stroke-width="0.6"/>`
       : '',


### PR DESCRIPTION
## Summary
- Honors \`ChartSpec.roundedCorners\` in the playground's chart-area backdrop \`<rect>\` — adds \`rx="6" ry="6"\` only when the field is authored true.
- Default chart look unchanged.

## Test plan
- [x] \`pnpm test\` — 870 passing.
- [x] \`pnpm exec svelte-check\` clean.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)