### PR TITLE
feat: ChartSpec.chartStyle round-trip

### DIFF
--- a/.changeset/chart-style-preset.md
+++ b/.changeset/chart-style-preset.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: `ChartSpec.chartStyle` — round-trip the chartSpace-level
+`<c:style val="N"/>` PowerPoint chart-style preset (1..48). Encodes a
+curated combo of theme accent colors, gradients, effects, and font
+sizes from the PowerPoint "Chart Styles" gallery. Read and written for
+round-trip parity; pptx-kit's renderers don't interpret the preset
+yet, but the field survives save/reload.

--- a/src/internal/chartml/chart-builder.ts
+++ b/src/internal/chartml/chart-builder.ts
@@ -752,9 +752,12 @@ export const buildChartSpaceDoc = (spec: ChartSpec): XmlDocument => {
   });
 
   // <c:chartSpace><c:spPr> sits at the root and styles the entire card.
-  // CT_ChartSpace schema order: roundedCorners comes BEFORE <c:chart>.
+  // CT_ChartSpace schema order: roundedCorners → style → chart.
   const rootChildren: XmlElement[] = [];
   if (spec.roundedCorners) rootChildren.push(valNode(c('roundedCorners'), '1'));
+  if (spec.chartStyle !== undefined) {
+    rootChildren.push(valNode(c('style'), Math.round(spec.chartStyle)));
+  }
   rootChildren.push(chart);
   if (spec.chartAreaFill !== undefined || spec.chartAreaStrokeColor !== undefined) {
     rootChildren.push(spPrChildren(spec.chartAreaFill, spec.chartAreaStrokeColor));

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -1133,6 +1133,17 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     const v = getAttrValue(rcEl, ATTR_VAL);
     if (v === '1' || v === 'true') roundedCorners = true;
   }
+  // <c:chartSpace><c:style val="N"/> — PowerPoint chart-style preset
+  // (1..48). Surface for round-trip parity; renderers don't act on it.
+  let chartStyle: number | undefined;
+  const styleEl = firstChildElement(root, qname('c', 'style', NS_C));
+  if (styleEl) {
+    const v = getAttrValue(styleEl, ATTR_VAL);
+    if (v !== null) {
+      const n = Number.parseInt(v, 10);
+      if (Number.isFinite(n) && n >= 1 && n <= 48) chartStyle = n;
+    }
+  }
 
   // <c:legend> sits on the chart element (not the plotArea). Read the
   // position; PowerPoint defaults to 'r' (right) when the element is
@@ -1240,6 +1251,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     ...(dispBlanksAs !== undefined ? { dispBlanksAs } : {}),
     ...(plotVisibleCellsOnly === false ? { plotVisibleCellsOnly: false } : {}),
     ...(roundedCorners === true ? { roundedCorners: true } : {}),
+    ...(chartStyle !== undefined ? { chartStyle } : {}),
     ...(plotAreaFill !== undefined ? { plotAreaFill } : {}),
     ...(plotAreaStrokeColor !== undefined ? { plotAreaStrokeColor } : {}),
     ...(chartAreaFill !== undefined ? { chartAreaFill } : {}),

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -484,6 +484,15 @@ export interface ChartSpec {
    * doesn't add a redundant `false`.
    */
   readonly roundedCorners?: boolean;
+  /**
+   * PowerPoint built-in chart-style preset
+   * (`<c:chartSpace><c:style val="N"/>`), 1–48. Encodes a curated combo
+   * of theme accent colors, gradients, effects, and font sizes that
+   * PowerPoint applies when the user picks a chart style from the
+   * "Chart Styles" gallery. Surface for round-trip parity; renderers in
+   * pptx-kit don't (yet) interpret it.
+   */
+  readonly chartStyle?: number;
   /** Bar / column / area grouping mode. Absent for line / pie. */
   readonly grouping?: ChartGrouping;
   /**

--- a/test/fn-chart-readback.test.ts
+++ b/test/fn-chart-readback.test.ts
@@ -617,6 +617,27 @@ describe('fn API: getSlideCharts', () => {
     expect(tl.displayRSquared).toBe(true);
   });
 
+  it('round-trips chartStyle preset', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'column',
+        categories: ['A', 'B'],
+        series: [{ name: 'X', values: [1, 2] }],
+        chartStyle: 42,
+      },
+    });
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const spec = getSlideCharts(getSlides(reloaded)[0]!)[0]!.spec!;
+    expect(spec.chartStyle).toBe(42);
+  });
+
   it('round-trips roundedCorners=true', async () => {
     const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
     const slide = getSlides(pres)[0]!;


### PR DESCRIPTION
## Summary
- Adds \`ChartSpec.chartStyle\` — round-trip the chartSpace-level \`<c:style val="N"/>\` PowerPoint chart-style preset (1..48).
- Encodes a curated combo of theme accent colors, gradients, effects, and font sizes from PowerPoint's "Chart Styles" gallery.
- pptx-kit's renderers don't interpret the preset yet, but the field survives save/reload.
- Schema position: between \`<c:roundedCorners>\` and \`<c:chart>\`.

## Test plan
- [x] New round-trip test in \`test/fn-chart-readback.test.ts\` covering style \`42\`.
- [x] \`pnpm test\` — 871 passing (was 870), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)