### PR TITLE
feat: ChartTrendline.name round-trip

### DIFF
--- a/.changeset/chart-trendline-name.md
+++ b/.changeset/chart-trendline-name.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: `ChartTrendline.name` — round-trip a custom trendline label
+(`<c:trendline><c:name>…`). PowerPoint auto-generates a label like
+"Linear (X)" or "MA(5) (X)" when this element is omitted; authors who
+want a different label (or who imported one from another tool) now
+have the field. Read by chart-reader; written by chart-builder at the
+CT_Trendline schema-required first position (before `<c:spPr>`).

--- a/src/internal/chartml/chart-builder.ts
+++ b/src/internal/chartml/chart-builder.ts
@@ -215,6 +215,10 @@ const trendlineElement = (
   tl: NonNullable<NonNullable<ChartSpec['series'][number]['trendline']>>,
 ): XmlElement => {
   const children: XmlElement[] = [];
+  // CT_Trendline schema order: <c:name> first, before <c:spPr>.
+  if (tl.name !== undefined) {
+    children.push(elem(c('name'), { children: [text(tl.name)] }));
+  }
   if (tl.color !== undefined) {
     const hex = tl.color.replace(/^#/, '').toUpperCase();
     const ln = elem(a('ln'), {

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -232,6 +232,16 @@ const readDataPointOverrides = (
 const readTrendline = (ser: XmlElement): ChartTrendline | undefined => {
   const tl = firstChildElement(ser, qname('c', 'trendline', NS_C));
   if (!tl) return undefined;
+  // <c:trendline><c:name>…</c:name> — optional custom label.
+  let name: string | undefined;
+  const nameEl = firstChildElement(tl, qname('c', 'name', NS_C));
+  if (nameEl) {
+    let acc = '';
+    for (const child of nameEl.children) {
+      if (child.kind === 'text' || child.kind === 'cdata') acc += child.data;
+    }
+    if (acc.length > 0) name = acc;
+  }
   const typeEl = firstChildElement(tl, qname('c', 'trendlineType', NS_C));
   const tToken = typeEl ? getAttrValue(typeEl, ATTR_VAL) : null;
   let type: ChartTrendline['type'];
@@ -308,6 +318,7 @@ const readTrendline = (ser: XmlElement): ChartTrendline | undefined => {
   const displayEquation = readDispBool('dispEq');
   const displayRSquared = readDispBool('dispRSqr');
   return {
+    ...(name !== undefined ? { name } : {}),
     type,
     ...(period !== undefined ? { period } : {}),
     ...(order !== undefined ? { order } : {}),

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -100,6 +100,12 @@ export interface ChartSeries {
 
 /** A single trendline overlay for a series. */
 export interface ChartTrendline {
+  /**
+   * Optional custom label for the trendline (`<c:trendline><c:name>…`).
+   * Defaults to PowerPoint's auto-generated label
+   * (e.g. "Linear (X)" / "MA(5) (X)") when omitted.
+   */
+  readonly name?: string;
   /** Regression type — linear / exp / log / poly / power / movingAvg. */
   readonly type: 'linear' | 'exp' | 'log' | 'poly' | 'power' | 'movingAvg';
   /**

--- a/test/fn-chart-readback.test.ts
+++ b/test/fn-chart-readback.test.ts
@@ -585,6 +585,36 @@ describe('fn API: getSlideCharts', () => {
     expect(spec.valueAxisOrientation).toBe('maxMin');
   });
 
+  it('round-trips trendline custom name', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'line',
+        categories: ['A', 'B', 'C'],
+        series: [
+          {
+            name: 'X',
+            values: [1, 2, 4],
+            trendline: {
+              type: 'movingAvg',
+              period: 2,
+              name: 'MA(2) — smoothed',
+            },
+          },
+        ],
+      },
+    });
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const spec = getSlideCharts(getSlides(reloaded)[0]!)[0]!.spec!;
+    expect(spec.series[0]!.trendline!.name).toBe('MA(2) — smoothed');
+  });
+
   it('round-trips trendline displayEquation + displayRSquared', async () => {
     const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
     const slide = getSlides(pres)[0]!;


### PR DESCRIPTION
## Summary
- Adds \`ChartTrendline.name\` — optional custom trendline label.
- Maps to \`<c:trendline><c:name>…</c:name>\`. Omitted → PowerPoint auto-generates a label (e.g. "Linear (X)" / "MA(5) (X)").
- Read by chart-reader; written by chart-builder at the CT_Trendline schema-required first position (before \`<c:spPr>\`).

## Test plan
- [x] New round-trip test in \`test/fn-chart-readback.test.ts\` covering a movingAvg trendline with a custom \`"MA(2) — smoothed"\` name.
- [x] \`pnpm test\` — 872 passing (was 871), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)