### PR TITLE
feat: ChartSpec.language + ChartSpec.date1904 round-trip

### DIFF
--- a/.changeset/chart-lang-date1904.md
+++ b/.changeset/chart-lang-date1904.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: `ChartSpec.language` (`<c:chartSpace><c:lang val=…/>`) and
+`ChartSpec.date1904` (`<c:date1904 val=…/>`) — chartSpace-level Office
+metadata round-tripped for parity. `language` is the Office UI
+language code (e.g. `'en-US'`, `'ja-JP'`); `date1904` selects the
+1904 date epoch (default `false` = Excel 1900 epoch, surface only
+when explicitly true). pptx-kit's renderers don't act on either yet.

--- a/src/internal/chartml/chart-builder.ts
+++ b/src/internal/chartml/chart-builder.ts
@@ -756,8 +756,11 @@ export const buildChartSpaceDoc = (spec: ChartSpec): XmlDocument => {
   });
 
   // <c:chartSpace><c:spPr> sits at the root and styles the entire card.
-  // CT_ChartSpace schema order: roundedCorners → style → chart.
+  // CT_ChartSpace schema order: date1904 → lang → roundedCorners →
+  // style → chart.
   const rootChildren: XmlElement[] = [];
+  if (spec.date1904) rootChildren.push(valNode(c('date1904'), '1'));
+  if (spec.language !== undefined) rootChildren.push(valNode(c('lang'), spec.language));
   if (spec.roundedCorners) rootChildren.push(valNode(c('roundedCorners'), '1'));
   if (spec.chartStyle !== undefined) {
     rootChildren.push(valNode(c('style'), Math.round(spec.chartStyle)));

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -1155,6 +1155,20 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
       if (Number.isFinite(n) && n >= 1 && n <= 48) chartStyle = n;
     }
   }
+  // <c:chartSpace><c:lang val="…"/> + <c:date1904 val="…"/> — Office
+  // metadata. Surface for round-trip parity.
+  let language: string | undefined;
+  const langEl = firstChildElement(root, qname('c', 'lang', NS_C));
+  if (langEl) {
+    const v = getAttrValue(langEl, ATTR_VAL);
+    if (v !== null && v.length > 0) language = v;
+  }
+  let date1904: boolean | undefined;
+  const dateEl = firstChildElement(root, qname('c', 'date1904', NS_C));
+  if (dateEl) {
+    const v = getAttrValue(dateEl, ATTR_VAL);
+    if (v === '1' || v === 'true') date1904 = true;
+  }
 
   // <c:legend> sits on the chart element (not the plotArea). Read the
   // position; PowerPoint defaults to 'r' (right) when the element is
@@ -1263,6 +1277,8 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     ...(plotVisibleCellsOnly === false ? { plotVisibleCellsOnly: false } : {}),
     ...(roundedCorners === true ? { roundedCorners: true } : {}),
     ...(chartStyle !== undefined ? { chartStyle } : {}),
+    ...(language !== undefined ? { language } : {}),
+    ...(date1904 === true ? { date1904: true } : {}),
     ...(plotAreaFill !== undefined ? { plotAreaFill } : {}),
     ...(plotAreaStrokeColor !== undefined ? { plotAreaStrokeColor } : {}),
     ...(chartAreaFill !== undefined ? { chartAreaFill } : {}),

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -499,6 +499,19 @@ export interface ChartSpec {
    * pptx-kit don't (yet) interpret it.
    */
   readonly chartStyle?: number;
+  /**
+   * Language code for the chart's number / date formatters
+   * (`<c:chartSpace><c:lang val="…"/>`). PowerPoint emits the user's
+   * Office UI language (e.g. `'en-US'`, `'ja-JP'`). Carried for
+   * round-trip parity; renderers in pptx-kit don't act on it yet.
+   */
+  readonly language?: string;
+  /**
+   * `<c:chartSpace><c:date1904 val="…"/>` — the Excel date-system flag.
+   * `false` (the default) uses the 1900-epoch; `true` uses 1904.
+   * Surface for parity; renderers don't act on it yet.
+   */
+  readonly date1904?: boolean;
   /** Bar / column / area grouping mode. Absent for line / pie. */
   readonly grouping?: ChartGrouping;
   /**

--- a/test/fn-chart-readback.test.ts
+++ b/test/fn-chart-readback.test.ts
@@ -647,6 +647,29 @@ describe('fn API: getSlideCharts', () => {
     expect(tl.displayRSquared).toBe(true);
   });
 
+  it('round-trips chartSpace language + date1904', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'column',
+        categories: ['A', 'B'],
+        series: [{ name: 'X', values: [1, 2] }],
+        language: 'ja-JP',
+        date1904: true,
+      },
+    });
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const spec = getSlideCharts(getSlides(reloaded)[0]!)[0]!.spec!;
+    expect(spec.language).toBe('ja-JP');
+    expect(spec.date1904).toBe(true);
+  });
+
   it('round-trips chartStyle preset', async () => {
     const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
     const slide = getSlides(pres)[0]!;


### PR DESCRIPTION
## Summary
- Adds \`ChartSpec.language\` → \`<c:chartSpace><c:lang val=…/>\` (Office UI language code).
- Adds \`ChartSpec.date1904\` → \`<c:chartSpace><c:date1904 val=…/>\` (1904 date-epoch flag; surface only when explicitly true).
- pptx-kit's renderers don't act on either yet; surfaced for round-trip parity with PowerPoint-authored files.
- Emitted at the front of CT_ChartSpace per the schema (date1904 → lang → roundedCorners → style → chart).

## Test plan
- [x] New round-trip test in \`test/fn-chart-readback.test.ts\` covering \`language: 'ja-JP'\` + \`date1904: true\`.
- [x] \`pnpm test\` — 873 passing (was 872), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)