### PR TITLE
fix(validator): flag duplicate cNvPr id within a slide

### DIFF
--- a/.changeset/validator-duplicate-shape-ids.md
+++ b/.changeset/validator-duplicate-shape-ids.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': patch
+---
+
+fix(validator): `validatePresentation` now flags duplicate
+`<p:cNvPr id="N">` values inside a single slide's `<p:spTree>` as
+errors. PowerPoint requires every shape's non-visual ID to be unique
+within its slide; duplicates often appear after pasting shapes from
+another slide without re-allocating IDs. The walk recurses into
+`<p:grpSp>` so duplicates nested in groups are also caught.

--- a/src/internal/validator/validate-presentation.ts
+++ b/src/internal/validator/validate-presentation.ts
@@ -245,6 +245,61 @@ export const validatePresentationPackage = (pkg: OpcPackage): ValidationIssue[] 
     }
   }
 
+  // Per-slide: duplicate `<p:cNvPr id="N">` collisions inside
+  // `<p:spTree>`. PowerPoint requires every shape's non-visual ID to be
+  // unique within the slide; duplicates often appear when callers paste
+  // shapes from another slide without re-allocating IDs.
+  for (const slideName of slidePartNames) {
+    const slidePart = pkg.getPart(slideName);
+    if (!slidePart) continue;
+    let slideRoot: ReturnType<typeof parseXml>['root'];
+    try {
+      slideRoot = parseXml(decode(slidePart.data)).root;
+    } catch {
+      // Parse failure on the slide itself is surfaced by other checks
+      // upstream; skip here.
+      continue;
+    }
+    const cSld = firstChildElement(slideRoot, qname('p', 'cSld', NS.pml));
+    if (!cSld) continue;
+    const spTree = firstChildElement(cSld, qname('p', 'spTree', NS.pml));
+    if (!spTree) continue;
+    const seenShapeIds = new Map<string, number>();
+    const walk = (host: ReturnType<typeof parseXml>['root']): void => {
+      for (const child of host.children) {
+        if (child.kind !== 'element') continue;
+        if (child.name.namespaceURI === NS.pml && child.name.localName === 'grpSp') {
+          // Group shapes nest <p:sp> children; recurse so duplicates
+          // inside groups don't slip past the check.
+          walk(child);
+          continue;
+        }
+        const nvHost =
+          firstChildElement(child, qname('p', 'nvSpPr', NS.pml)) ??
+          firstChildElement(child, qname('p', 'nvPicPr', NS.pml)) ??
+          firstChildElement(child, qname('p', 'nvCxnSpPr', NS.pml)) ??
+          firstChildElement(child, qname('p', 'nvGrpSpPr', NS.pml)) ??
+          firstChildElement(child, qname('p', 'nvGraphicFramePr', NS.pml));
+        if (!nvHost) continue;
+        const cNvPr = firstChildElement(nvHost, qname('p', 'cNvPr', NS.pml));
+        if (!cNvPr) continue;
+        const id = getAttrValue(cNvPr, ATTR_ID);
+        if (id === null) continue;
+        seenShapeIds.set(id, (seenShapeIds.get(id) ?? 0) + 1);
+      }
+    };
+    walk(spTree);
+    for (const [id, count] of seenShapeIds) {
+      if (count > 1) {
+        issues.push({
+          severity: 'error',
+          message: `duplicate shape id="${id}" appears ${count}× in slide ${slideName}`,
+          partName: slideName,
+        });
+      }
+    }
+  }
+
   // Chart parts must resolve to their embedded xlsx workbooks.
   for (const part of pkg.parts) {
     if (part.contentType !== 'application/vnd.openxmlformats-officedocument.drawingml.chart+xml') {

--- a/test/fn-validator.test.ts
+++ b/test/fn-validator.test.ts
@@ -62,6 +62,30 @@ describe('fn API: validatePresentation', () => {
     expect(validatePresentation(after)).toEqual([]);
   });
 
+  it('flags duplicate <p:cNvPr id> within a slide', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const reloaded = await loadPresentation(await savePresentation(pres));
+    const pkg = _internalPackageOf(reloaded);
+    const slideName = partName('/ppt/slides/slide1.xml');
+    const slidePart = pkg.getPart(slideName);
+    if (!slidePart) throw new Error('expected slide1.xml');
+    // Manufacture two shapes sharing the same id by string-rewriting
+    // the slide. The fixture's first shape has some id="N"; pick any
+    // shape and inject a duplicate sibling.
+    const decoder = new TextDecoder();
+    const encoder = new TextEncoder();
+    const xml = decoder.decode(slidePart.data);
+    const dupSpRegex = /<p:sp\b[^>]*>([\s\S]*?<\/p:sp>)/;
+    const m = xml.match(dupSpRegex);
+    if (!m || !m[0]) throw new Error('expected at least one <p:sp> in the slide');
+    const rewritten = xml.replace('</p:spTree>', `${m[0]}</p:spTree>`);
+    pkg.removePart(slideName);
+    pkg.addPart(slideName, slidePart.contentType, encoder.encode(rewritten));
+    const broken = await loadPresentation(await savePresentation(reloaded));
+    const issues = validatePresentation(broken);
+    expect(issues.some((i) => /duplicate shape id="\d+"/.test(i.message))).toBe(true);
+  });
+
   it('flags a dangling image rel after media removal', async () => {
     const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
     const slide = getSlides(pres)[0]!;


### PR DESCRIPTION
## Summary
- \`validatePresentation\` now reports duplicate \`<p:cNvPr id="N">\` values inside a single slide's \`<p:spTree>\` as errors.
- PowerPoint requires every shape's non-visual ID to be unique within its slide; duplicates often appear after pasting shapes from another slide without re-allocating IDs.
- The walk recurses into \`<p:grpSp>\` so duplicates nested in groups are also caught.

## Test plan
- [x] New test in \`test/fn-validator.test.ts\` that injects a duplicate \`<p:sp>\` into \`spTree\` and asserts the issue is reported.
- [x] \`pnpm test\` — 874 passing (was 873), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)