### PR TITLE
site(playground): render ChartTrendline.name at the line endpoint

### DIFF
--- a/.changeset/site-trendline-name-label.md
+++ b/.changeset/site-trendline-name-label.md
@@ -1,0 +1,7 @@
+---
+'pptx-kit-site': patch
+---
+
+site(playground): render `ChartTrendline.name` as a small label at the
+trendline's right endpoint. Only emitted when the name is authored, so
+charts without a custom trendline label look the same as before.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -3209,7 +3209,14 @@ const renderColumnChart = (
 const trendlinePath = (
   xs: ReadonlyArray<number>,
   ys: ReadonlyArray<number>,
-  tl: { type: string; period?: number; order?: number; forward?: number; backward?: number },
+  tl: {
+    type: string;
+    period?: number;
+    order?: number;
+    forward?: number;
+    backward?: number;
+    name?: string;
+  },
   color: string,
 ): string => {
   const n = xs.length;
@@ -3273,7 +3280,16 @@ const trendlinePath = (
   }
   if (pts.length < 2) return '';
   const d = pts.map(([x, y], i) => `${i === 0 ? 'M' : 'L'}${px(x)},${px(y)}`).join(' ');
-  return `<path d="${d}" fill="none" stroke="${color}" stroke-width="1.5" stroke-dasharray="6 3" stroke-linecap="round"/>`;
+  const path = `<path d="${d}" fill="none" stroke="${color}" stroke-width="1.5" stroke-dasharray="6 3" stroke-linecap="round"/>`;
+  // Authored <c:trendline><c:name> shows as a small label at the
+  // trendline's right endpoint. Only emit when the name is set; the
+  // default look stays unchanged.
+  if (tl.name !== undefined && tl.name.length > 0) {
+    const [lx, ly] = pts[pts.length - 1]!;
+    const label = `<text x="${px(lx + 4)}" y="${px(ly)}" dominant-baseline="middle" font-family="sans-serif" font-size="9" fill="${color}">${escapeXml(tl.name)}</text>`;
+    return path + label;
+  }
+  return path;
 };
 
 const linearFit = (


### PR DESCRIPTION
## Summary
- Honors the new \`ChartTrendline.name\` in the playground's chart preview.
- Renders a small \`<text>\` label at the trendline's right endpoint, color-matched to the line.
- Only emitted when the name is authored — default look unchanged.

## Test plan
- [x] \`pnpm test\` — 874 passing.
- [x] \`pnpm exec svelte-check\` clean.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)