### PR TITLE
feat: findShapesByHyperlink(slide, url) finder

### DIFF
--- a/.changeset/find-shapes-by-hyperlink.md
+++ b/.changeset/find-shapes-by-hyperlink.md
@@ -1,0 +1,9 @@
+---
+'pptx-kit': minor
+---
+
+feat: `findShapesByHyperlink(slide, url)` — slide-scoped finder that
+returns every shape whose hyperlink target matches `url` (substring or
+`RegExp`). Pairs the existing presentation-level
+`findSlidesByHyperlink` for cases where the caller already has a
+specific slide and wants the linking shapes inside it.

--- a/src/api/fn/shape-slide-read.ts
+++ b/src/api/fn/shape-slide-read.ts
@@ -38,6 +38,7 @@ import {
   type SlideShapeData,
 } from '../_internal-symbols.ts';
 import { commitSlideData, decode, refreshSlideData } from './_helpers.ts';
+import { getShapeHyperlink } from './shape-paragraph.ts';
 import { getSlides } from './slide-query.ts';
 import { hasShapeText } from './embedded.ts';
 
@@ -315,6 +316,27 @@ export const findShapesByKind = (
   kind: ShapeKind,
 ): ReadonlyArray<SlideShapeData> =>
   slide[SLIDE_SHAPES].filter((s) => s[SHAPE_SNAPSHOT].kind === kind);
+
+/**
+ * Every shape on the slide whose hyperlink target matches `url`
+ * (substring or `RegExp`). Pairs the existing presentation-level
+ * `findSlidesByHyperlink` for cases where the caller already has a
+ * specific slide and wants the linking shapes inside it.
+ */
+export const findShapesByHyperlink = (
+  slide: SlideData,
+  url: string | RegExp,
+): ReadonlyArray<SlideShapeData> => {
+  const out: SlideShapeData[] = [];
+  for (const shape of slide[SLIDE_SHAPES]) {
+    const target = getShapeHyperlink(shape);
+    if (target === null) continue;
+    if (typeof url === 'string' ? target.includes(url) : url.test(target)) {
+      out.push(shape);
+    }
+  }
+  return out;
+};
 
 /**
  * Returns every shape on the slide whose `<a:prstGeom prst="…"/>`

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -138,6 +138,7 @@ export {
   findShapeByName,
   findShapeByText,
   findShapeInPresentation,
+  findShapesByHyperlink,
   findShapesByKind,
   findShapesByName,
   findShapesByPreset,

--- a/test/fn-find-shapes-by-hyperlink.test.ts
+++ b/test/fn-find-shapes-by-hyperlink.test.ts
@@ -1,0 +1,72 @@
+// `findShapesByHyperlink(slide, url)` — slide-scoped finder pairing
+// the presentation-level `findSlidesByHyperlink`.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  addSlideTextBox,
+  findShapesByHyperlink,
+  getSlides,
+  inches,
+  loadPresentation,
+  setShapeHyperlink,
+} from '../src/api/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+describe('fn API: findShapesByHyperlink', () => {
+  it('matches by exact-substring url', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const a = addSlideTextBox(slide, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(2),
+      h: inches(1),
+      text: 'A',
+    });
+    setShapeHyperlink(a, 'https://example.com/a');
+    const b = addSlideTextBox(slide, {
+      x: inches(0),
+      y: inches(1),
+      w: inches(2),
+      h: inches(1),
+      text: 'B',
+    });
+    setShapeHyperlink(b, 'https://example.com/b');
+    const c = addSlideTextBox(slide, {
+      x: inches(0),
+      y: inches(2),
+      w: inches(2),
+      h: inches(1),
+      text: 'C',
+    });
+    setShapeHyperlink(c, 'https://other.example/page');
+
+    const matches = findShapesByHyperlink(slide, 'example.com');
+    expect(matches).toHaveLength(2);
+  });
+
+  it('matches by RegExp', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const a = addSlideTextBox(slide, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(2),
+      h: inches(1),
+      text: 'A',
+    });
+    setShapeHyperlink(a, 'https://example.com/path?q=1');
+    const matches = findShapesByHyperlink(slide, /[?&]q=/);
+    expect(matches).toHaveLength(1);
+  });
+
+  it('returns an empty array when no shape links match', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    expect(findShapesByHyperlink(slide, 'https://anywhere.example/')).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds \`findShapesByHyperlink(slide, url)\` — slide-scoped finder for shapes whose hyperlink target matches \`url\` (substring or \`RegExp\`).
- Pairs the existing presentation-level \`findSlidesByHyperlink\` for cases where the caller already has a specific slide.

## Test plan
- [x] 3 new tests in \`test/fn-find-shapes-by-hyperlink.test.ts\` covering substring match, RegExp match, and empty-result.
- [x] \`pnpm test\` — 877 passing (was 874), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)