### PR TITLE
feat: findSlidesWithChartKind(pres, kind) finder

### DIFF
--- a/.changeset/find-slides-with-chart-kind.md
+++ b/.changeset/find-slides-with-chart-kind.md
@@ -1,0 +1,9 @@
+---
+'pptx-kit': minor
+---
+
+feat: `findSlidesWithChartKind(pres, kind)` — kind-filtered variant of
+the existing `getSlidesWithCharts`. Returns every slide carrying at
+least one chart of the given `ChartKind` (`'bar'`, `'column'`,
+`'line'`, `'pie'`, `'doughnut'`, `'area'`). Built on `getSlideCharts`
+so the predicate respects the spec the renderers actually see.

--- a/src/api/fn/slide-notes.ts
+++ b/src/api/fn/slide-notes.ts
@@ -31,6 +31,7 @@ import {
   isChartShape,
   isTableShape,
 } from './embedded.ts';
+import type { ChartKind } from '../../internal/chartml/index.ts';
 
 // ---------------------------------------------------------------------------
 // Speaker notes.
@@ -139,6 +140,28 @@ export const getSlidesWithCharts = (pres: PresentationData): ReadonlyArray<Slide
   const out: SlideData[] = [];
   for (const slide of getSlides(pres)) {
     if (slide[SLIDE_SHAPES].some((s) => isChartShape(s))) out.push(slide);
+  }
+  return out;
+};
+
+/**
+ * Filters `getSlidesWithCharts` to slides carrying at least one chart
+ * of the given `kind` (`'bar'`, `'column'`, `'line'`, `'pie'`,
+ * `'doughnut'`, `'area'`). Reads each chart's spec via `getSlideCharts`
+ * so the predicate respects what the renderers actually see.
+ */
+export const findSlidesWithChartKind = (
+  pres: PresentationData,
+  kind: ChartKind,
+): ReadonlyArray<SlideData> => {
+  const out: SlideData[] = [];
+  for (const slide of getSlides(pres)) {
+    for (const c of getSlideCharts(slide)) {
+      if (c.spec?.kind === kind) {
+        out.push(slide);
+        break;
+      }
+    }
   }
   return out;
 };

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -139,6 +139,7 @@ export {
   findShapeByText,
   findShapeInPresentation,
   findShapesByHyperlink,
+  findSlidesWithChartKind,
   findShapesByKind,
   findShapesByName,
   findShapesByPreset,

--- a/test/fn-find-slides-with-chart-kind.test.ts
+++ b/test/fn-find-slides-with-chart-kind.test.ts
@@ -1,0 +1,67 @@
+// `findSlidesWithChartKind` — kind-filtered version of
+// `getSlidesWithCharts`.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  addBlankSlide,
+  addSlideChart,
+  findSlidesWithChartKind,
+  getSlideIndex,
+  getSlides,
+  inches,
+  loadPresentation,
+} from '../src/api/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+describe('fn API: findSlidesWithChartKind', () => {
+  it('returns only slides whose chart matches the kind', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const [slideA, slideB] = getSlides(pres);
+    addSlideChart(slideA!, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(6),
+      h: inches(4),
+      spec: { kind: 'column', categories: ['A'], series: [{ name: 'X', values: [1] }] },
+    });
+    addSlideChart(slideB!, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(6),
+      h: inches(4),
+      spec: { kind: 'pie', categories: ['A'], series: [{ name: 'X', values: [1] }] },
+    });
+
+    const cols = findSlidesWithChartKind(pres, 'column');
+    expect(cols.map((s) => getSlideIndex(pres, s))).toEqual([getSlideIndex(pres, slideA!)]);
+    const pies = findSlidesWithChartKind(pres, 'pie');
+    expect(pies.map((s) => getSlideIndex(pres, s))).toEqual([getSlideIndex(pres, slideB!)]);
+    expect(findSlidesWithChartKind(pres, 'line')).toEqual([]);
+  });
+
+  it('returns an empty array on a clean deck', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    expect(findSlidesWithChartKind(pres, 'column')).toEqual([]);
+  });
+
+  it('counts a slide once even when it carries multiple charts of the same kind', async () => {
+    const pres = await loadPresentation(await readFile(fixture('blank.pptx')));
+    const slide = addBlankSlide(pres);
+    for (let i = 0; i < 2; i++) {
+      addSlideChart(slide, {
+        x: inches(0),
+        y: inches(i),
+        w: inches(3),
+        h: inches(1),
+        spec: { kind: 'bar', categories: ['A'], series: [{ name: 'X', values: [1] }] },
+      });
+    }
+    const bars = findSlidesWithChartKind(pres, 'bar');
+    expect(bars).toHaveLength(1);
+    expect(getSlideIndex(pres, bars[0]!)).toBe(getSlideIndex(pres, slide));
+  });
+});


### PR DESCRIPTION
## Summary
- Adds \`findSlidesWithChartKind(pres, kind)\` — kind-filtered variant of \`getSlidesWithCharts\`.
- Returns every slide carrying at least one chart of the given \`ChartKind\` (\`'bar'\`, \`'column'\`, \`'line'\`, \`'pie'\`, \`'doughnut'\`, \`'area'\`).
- Built on \`getSlideCharts\` so the predicate respects the spec the renderers actually see; each slide appears once even if it carries multiple charts of the same kind.

## Test plan
- [x] 3 new tests in \`test/fn-find-slides-with-chart-kind.test.ts\` covering kind-match (column / pie), empty-deck, and multiple-charts-same-slide.
- [x] \`pnpm test\` — 880 passing (was 877), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)