### PR TITLE
feat: findShapesInRect(slide, x, y, w, h) marquee finder

### DIFF
--- a/.changeset/find-shapes-in-rect.md
+++ b/.changeset/find-shapes-in-rect.md
@@ -1,0 +1,9 @@
+---
+'pptx-kit': minor
+---
+
+feat: `findShapesInRect(slide, x, y, w, h)` — marquee-style region
+finder. Returns every shape whose bounds overlap the rectangle
+(touching edges count). Shapes with no resolvable bounds are skipped.
+Companion to `findShapesAtPoint(slide, x, y)` for cases where the
+caller wants a region of the slide rather than a single point.

--- a/src/api/fn/shape-read-base.ts
+++ b/src/api/fn/shape-read-base.ts
@@ -572,6 +572,36 @@ export const findShapesAtPoint = (
 ): ReadonlyArray<SlideShapeData> => slide[SLIDE_SHAPES].filter((s) => pointInShape(s, x, y));
 
 /**
+ * Returns every shape on the slide whose bounds overlap the rectangle
+ * `(x, y, w, h)` (in EMU). "Overlap" means the rectangles intersect at
+ * all — touching edges count. Shapes with no resolvable bounds (e.g.
+ * placeholders that inherit position from the layout) are skipped.
+ *
+ * Useful for marquee-style region selection — e.g. "give me every
+ * shape that lives in the right half of the slide" — without
+ * iterating every shape and comparing bounds by hand.
+ */
+export const findShapesInRect = (
+  slide: SlideData,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+): ReadonlyArray<SlideShapeData> => {
+  const rx2 = x + w;
+  const ry2 = y + h;
+  const out: SlideShapeData[] = [];
+  for (const shape of slide[SLIDE_SHAPES]) {
+    const b = getShapeBounds(shape);
+    if (b === null) continue;
+    const sx2 = b.x + b.w;
+    const sy2 = b.y + b.h;
+    if (b.x <= rx2 && sx2 >= x && b.y <= ry2 && sy2 >= y) out.push(shape);
+  }
+  return out;
+};
+
+/**
  * Moves the shape so its center sits at the slide canvas center.
  * Reads the presentation's slide size, then sets the shape's
  * position to `(slideWidth/2 - shapeWidth/2, slideHeight/2 - shapeHeight/2)`.

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -139,6 +139,7 @@ export {
   findShapeByText,
   findShapeInPresentation,
   findShapesByHyperlink,
+  findShapesInRect,
   findSlidesWithChartKind,
   findShapesByKind,
   findShapesByName,

--- a/test/fn-find-shapes-in-rect.test.ts
+++ b/test/fn-find-shapes-in-rect.test.ts
@@ -1,0 +1,82 @@
+// `findShapesInRect(slide, x, y, w, h)` — marquee-style region
+// finder. Pair to the existing `findShapesAtPoint`.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  addSlideTextBox,
+  findShapesInRect,
+  getShapeName,
+  getSlides,
+  inches,
+  loadPresentation,
+} from '../src/api/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+describe('fn API: findShapesInRect', () => {
+  it('returns shapes overlapping the rectangle', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const a = addSlideTextBox(slide, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(2),
+      h: inches(1),
+      text: 'A',
+    });
+    const b = addSlideTextBox(slide, {
+      x: inches(3),
+      y: inches(0),
+      w: inches(2),
+      h: inches(1),
+      text: 'B',
+    });
+    const c = addSlideTextBox(slide, {
+      x: inches(0),
+      y: inches(3),
+      w: inches(2),
+      h: inches(1),
+      text: 'C',
+    });
+
+    // Rectangle covers the top-left quadrant only — A is inside, B
+    // straddles the right boundary, C is below.
+    const found = findShapesInRect(slide, inches(0), inches(0), inches(3.5), inches(2));
+    const names = found.map((s) => getShapeName(s));
+    expect(names).toContain(getShapeName(a));
+    expect(names).toContain(getShapeName(b));
+    expect(names).not.toContain(getShapeName(c));
+  });
+
+  it('returns an empty array when the rectangle is empty', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideTextBox(slide, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(2),
+      h: inches(1),
+      text: 'A',
+    });
+    // Rectangle far away from any shape.
+    expect(findShapesInRect(slide, inches(100), inches(100), inches(1), inches(1))).toEqual([]);
+  });
+
+  it('counts touching edges as overlap', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const a = addSlideTextBox(slide, {
+      x: inches(2),
+      y: inches(0),
+      w: inches(1),
+      h: inches(1),
+      text: 'A',
+    });
+    // Rectangle just touches A's left edge at x=2".
+    const found = findShapesInRect(slide, inches(0), inches(0), inches(2), inches(1));
+    expect(found.map((s) => getShapeName(s))).toContain(getShapeName(a));
+  });
+});


### PR DESCRIPTION
## Summary
- Adds \`findShapesInRect(slide, x, y, w, h)\` — marquee-style region finder.
- Returns every shape whose bounds overlap the rectangle (touching edges count).
- Shapes with no resolvable bounds (e.g. placeholders that inherit position from the layout) are skipped.
- Companion to \`findShapesAtPoint(slide, x, y)\` for cases where the caller wants a region of the slide.

## Test plan
- [x] 3 new tests in \`test/fn-find-shapes-in-rect.test.ts\` covering basic overlap, empty region, and touching-edge overlap.
- [x] \`pnpm test\` — 883 passing (was 880), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)