### PR TITLE
feat: getSlideLayoutUsageCounts(pres) layout histogram

### DIFF
--- a/.changeset/get-slide-layout-usage-counts.md
+++ b/.changeset/get-slide-layout-usage-counts.md
@@ -1,0 +1,9 @@
+---
+'pptx-kit': minor
+---
+
+feat: `getSlideLayoutUsageCounts(pres)` — layout name → number-of-slides
+histogram. Every layout enumerated by `getSlideLayouts` appears as a
+key (count `0` for unreferenced layouts), so the function surfaces
+unused layouts directly — useful for trimming template decks that
+ship with placeholder layouts the working deck never picks up.

--- a/src/api/fn/layouts.ts
+++ b/src/api/fn/layouts.ts
@@ -12,7 +12,9 @@ import {
   type SlideLayoutData,
 } from '../_internal-symbols.ts';
 import { SLIDE_LAYOUT_CONTENT_TYPE, decode } from './_helpers.ts';
+import { getSlideLayout } from './shape-slide-read.ts';
 import type { ShapeBounds } from './shapes.ts';
+import { getSlides } from './slide-query.ts';
 
 // ---------------------------------------------------------------------------
 // Slide layouts.
@@ -168,4 +170,27 @@ export const getSlideLayouts = (pres: PresentationData): ReadonlyArray<SlideLayo
     });
   }
   return out;
+};
+
+/**
+ * Returns a map of layout name → number of slides that reference it.
+ * Every layout enumerated by `getSlideLayouts` appears as a key (zero
+ * count for unreferenced layouts), so this surfaces unused layouts
+ * directly — e.g. for templates that ship with placeholder layouts the
+ * deck never picks up.
+ */
+export const getSlideLayoutUsageCounts = (
+  pres: PresentationData,
+): Readonly<Record<string, number>> => {
+  const counts: Record<string, number> = {};
+  for (const layout of getSlideLayouts(pres)) {
+    counts[getSlideLayoutName(layout)] = 0;
+  }
+  for (const slide of getSlides(pres)) {
+    const layout = getSlideLayout(slide);
+    if (layout === null) continue;
+    const name = getSlideLayoutName(layout);
+    counts[name] = (counts[name] ?? 0) + 1;
+  }
+  return counts;
 };

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -312,6 +312,7 @@ export {
   getSlideLayoutPlaceholders,
   getSlideLayouts,
   getSlideLayoutType,
+  getSlideLayoutUsageCounts,
   getSlideMasterBackground,
   getSlideMasterBackgroundGradientFill,
   getSlideMasterBackgroundImageBytes,

--- a/test/fn-get-slide-layout-usage-counts.test.ts
+++ b/test/fn-get-slide-layout-usage-counts.test.ts
@@ -1,0 +1,45 @@
+// `getSlideLayoutUsageCounts(pres)` — name → number-of-slides
+// histogram, including unreferenced layouts (count = 0).
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  addSlide,
+  findSlideLayout,
+  getSlideLayoutUsageCounts,
+  getSlideLayouts,
+  loadPresentation,
+} from '../src/api/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+describe('fn API: getSlideLayoutUsageCounts', () => {
+  it('every layout in the package appears as a key', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const counts = getSlideLayoutUsageCounts(pres);
+    const expected = getSlideLayouts(pres).length;
+    expect(Object.keys(counts).length).toBe(expected);
+  });
+
+  it('counts every slide reference', async () => {
+    const pres = await loadPresentation(await readFile(fixture('blank.pptx')));
+    const layout = findSlideLayout(pres, 'Title and Content');
+    if (!layout) throw new Error('expected Title and Content layout');
+    addSlide(pres, { layout });
+    addSlide(pres, { layout });
+    const counts = getSlideLayoutUsageCounts(pres);
+    expect(counts['Title and Content']).toBe(2);
+  });
+
+  it('unreferenced layouts come back with count 0', async () => {
+    const pres = await loadPresentation(await readFile(fixture('blank.pptx')));
+    const counts = getSlideLayoutUsageCounts(pres);
+    // The blank fixture has many layouts but only one slide that
+    // references one specific layout; at least one layout must have a
+    // count of 0.
+    const zeros = Object.entries(counts).filter(([, n]) => n === 0);
+    expect(zeros.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds \`getSlideLayoutUsageCounts(pres)\` — layout name → number-of-slides histogram.
- Every layout enumerated by \`getSlideLayouts\` appears as a key (count \`0\` for unreferenced layouts).
- Surfaces unused layouts directly — useful for trimming template decks that ship with placeholder layouts the working deck never picks up.

## Test plan
- [x] 3 new tests in \`test/fn-get-slide-layout-usage-counts.test.ts\` covering all-layouts-as-keys, multi-slide reference counts, and the zero-count for unreferenced layouts.
- [x] \`pnpm test\` — 889 passing (was 886), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)