### PR TITLE
feat: getUnusedSlideLayouts(pres)

### DIFF
--- a/.changeset/get-unused-slide-layouts.md
+++ b/.changeset/get-unused-slide-layouts.md
@@ -1,0 +1,8 @@
+---
+'pptx-kit': minor
+---
+
+feat: `getUnusedSlideLayouts(pres)` — returns the layouts in the
+package that no slide references. Useful when trimming a template
+deck — unused layouts contribute parts and rels without ever
+rendering. Iteration order matches `getSlideLayouts`.

--- a/src/api/fn/layouts.ts
+++ b/src/api/fn/layouts.ts
@@ -173,6 +173,20 @@ export const getSlideLayouts = (pres: PresentationData): ReadonlyArray<SlideLayo
 };
 
 /**
+ * Layouts in the package that no slide references. Useful when
+ * trimming a template deck — these layouts contribute parts and rels
+ * without ever rendering. Iteration order matches `getSlideLayouts`.
+ */
+export const getUnusedSlideLayouts = (pres: PresentationData): ReadonlyArray<SlideLayoutData> => {
+  const referenced = new Set<string>();
+  for (const slide of getSlides(pres)) {
+    const layout = getSlideLayout(slide);
+    if (layout !== null) referenced.add(getSlideLayoutName(layout));
+  }
+  return getSlideLayouts(pres).filter((l) => !referenced.has(getSlideLayoutName(l)));
+};
+
+/**
  * Returns a map of layout name → number of slides that reference it.
  * Every layout enumerated by `getSlideLayouts` appears as a key (zero
  * count for unreferenced layouts), so this surfaces unused layouts

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -313,6 +313,7 @@ export {
   getSlideLayouts,
   getSlideLayoutType,
   getSlideLayoutUsageCounts,
+  getUnusedSlideLayouts,
   getSlideMasterBackground,
   getSlideMasterBackgroundGradientFill,
   getSlideMasterBackgroundImageBytes,

--- a/test/fn-get-unused-slide-layouts.test.ts
+++ b/test/fn-get-unused-slide-layouts.test.ts
@@ -1,0 +1,37 @@
+// `getUnusedSlideLayouts(pres)` — layouts no slide references.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  addSlide,
+  findSlideLayout,
+  getSlideLayoutName,
+  getSlideLayouts,
+  getUnusedSlideLayouts,
+  loadPresentation,
+} from '../src/api/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+describe('fn API: getUnusedSlideLayouts', () => {
+  it('returns an empty array when every layout has at least one slide', async () => {
+    const pres = await loadPresentation(await readFile(fixture('blank.pptx')));
+    const layouts = getSlideLayouts(pres);
+    // Add a slide per layout so none is unused.
+    for (const layout of layouts) addSlide(pres, { layout });
+    expect(getUnusedSlideLayouts(pres)).toEqual([]);
+  });
+
+  it('lists layouts no slide references', async () => {
+    const pres = await loadPresentation(await readFile(fixture('blank.pptx')));
+    const layout = findSlideLayout(pres, 'Title and Content');
+    if (!layout) throw new Error('expected Title and Content layout');
+    addSlide(pres, { layout });
+    const unused = getUnusedSlideLayouts(pres);
+    const unusedNames = unused.map((l) => getSlideLayoutName(l));
+    expect(unusedNames).not.toContain('Title and Content');
+    expect(unusedNames.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds \`getUnusedSlideLayouts(pres)\` — returns the layouts in the package that no slide references.
- Useful when trimming a template deck: unused layouts contribute parts and rels without ever rendering.
- Iteration order matches \`getSlideLayouts\`. Complements the recently-added \`getSlideLayoutUsageCounts\` for a stronger-typed iteration.

## Test plan
- [x] 2 new tests in \`test/fn-get-unused-slide-layouts.test.ts\` — every-layout-used returns empty, partial-use lists the unused remainder.
- [x] \`pnpm test\` — 891 passing (was 889), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)