### PR TITLE
feat: findSlidesByLayoutPartName(pres, layoutPartName)

### DIFF
--- a/.changeset/find-slides-by-layout-part-name.md
+++ b/.changeset/find-slides-by-layout-part-name.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: `findSlidesByLayoutPartName(pres, layoutPartName)` — finds every
+slide whose resolved layout part name matches `layoutPartName` (e.g.
+`'/ppt/slideLayouts/slideLayout3.xml'`). Pair to the existing
+`findSlidesByLayoutName` / `findSlidesByLayoutType`. Keyed on the
+actual package path, so it's stable across template-name collisions
+and PowerPoint UI locales.

--- a/src/api/fn/shape-image-effects.ts
+++ b/src/api/fn/shape-image-effects.ts
@@ -30,6 +30,7 @@ import {
   type SlideShapeData,
 } from '../_internal-symbols.ts';
 import { commitAndRefresh } from './_helpers.ts';
+import { getSlideLayoutPartName } from './layouts.ts';
 import { getPresentationTheme, getSlideLayoutName, getSlideLayoutType } from './package.ts';
 import {
   getShapeBounds,
@@ -186,6 +187,27 @@ export const findSlidesByLayoutName = (
   for (const slide of getSlides(pres)) {
     const layout = getSlideLayout(slide);
     if (layout !== null && getSlideLayoutName(layout) === layoutName) out.push(slide);
+  }
+  return out;
+};
+
+/**
+ * Every slide whose resolved layout part name equals `layoutPartName`
+ * (e.g. `'/ppt/slideLayouts/slideLayout3.xml'`). Stable across
+ * template-name collisions and locale renames — keyed on the actual
+ * package path. Pair to `findSlidesByLayoutName` /
+ * `findSlidesByLayoutType` for cases where the caller already has a
+ * layout part name in hand (typical when iterating over a layouts
+ * collection programmatically).
+ */
+export const findSlidesByLayoutPartName = (
+  pres: PresentationData,
+  layoutPartName: string,
+): ReadonlyArray<SlideData> => {
+  const out: SlideData[] = [];
+  for (const slide of getSlides(pres)) {
+    const layout = getSlideLayout(slide);
+    if (layout !== null && getSlideLayoutPartName(layout) === layoutPartName) out.push(slide);
   }
   return out;
 };

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -158,6 +158,7 @@ export {
   findSlidePlaceholders,
   findSlidesByHyperlink,
   findSlidesByLayoutName,
+  findSlidesByLayoutPartName,
   findSlidesByLayoutType,
   findSlidesByNotes,
   findSlidesByText,

--- a/test/fn-find-slides-by-layout-part-name.test.ts
+++ b/test/fn-find-slides-by-layout-part-name.test.ts
@@ -1,0 +1,34 @@
+// `findSlidesByLayoutPartName(pres, layoutPartName)` — finds slides
+// keyed on the layout's package part name (stable across locales).
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  addSlide,
+  findSlideLayout,
+  findSlidesByLayoutPartName,
+  getSlideLayoutPartName,
+  loadPresentation,
+} from '../src/api/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+describe('fn API: findSlidesByLayoutPartName', () => {
+  it('returns slides whose layout part name matches', async () => {
+    const pres = await loadPresentation(await readFile(fixture('blank.pptx')));
+    const layout = findSlideLayout(pres, 'Title and Content');
+    if (!layout) throw new Error('expected Title and Content layout');
+    addSlide(pres, { layout });
+    addSlide(pres, { layout });
+    const partName = getSlideLayoutPartName(layout);
+    const matches = findSlidesByLayoutPartName(pres, partName);
+    expect(matches.length).toBe(2);
+  });
+
+  it('returns an empty array for an unknown part name', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    expect(findSlidesByLayoutPartName(pres, '/ppt/slideLayouts/slideLayout999.xml')).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds \`findSlidesByLayoutPartName(pres, layoutPartName)\` — third lookup dimension complementing \`findSlidesByLayoutName\` / \`findSlidesByLayoutType\`.
- Keyed on the layout's package part name (e.g. \`'/ppt/slideLayouts/slideLayout3.xml'\`), so it's stable across template-name collisions and PowerPoint UI locales.

## Test plan
- [x] 2 new tests in \`test/fn-find-slides-by-layout-part-name.test.ts\` — match by part name (multi-slide), empty-result for unknown name.
- [x] \`pnpm test\` — 893 passing (was 891), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)