### PR TITLE
feat: findChartsWithTrendlines(slide) auditor

### DIFF
--- a/.changeset/find-charts-with-trendlines.md
+++ b/.changeset/find-charts-with-trendlines.md
@@ -1,0 +1,8 @@
+---
+'pptx-kit': minor
+---
+
+feat: `findChartsWithTrendlines(slide)` — slide-scoped finder for
+charts that carry at least one `<c:trendline>` on any of their
+series. Useful for deck-audit reports — trendlines are easy to add
+and easy to forget. Charts whose kind isn't modeled are skipped.

--- a/src/api/fn/charts.ts
+++ b/src/api/fn/charts.ts
@@ -414,6 +414,22 @@ export const findChartsBySeriesName = (
 };
 
 /**
+ * Returns every chart on the slide that carries at least one
+ * `<c:trendline>` on any of its series. Useful for deck-audit reports
+ * — trendlines are easy to add and easy to forget, and authors often
+ * want to inventory them before publishing. Skips charts whose kind
+ * isn't modeled.
+ */
+export const findChartsWithTrendlines = (slide: SlideData): ReadonlyArray<SlideChartData> => {
+  const out: SlideChartData[] = [];
+  for (const chart of getSlideCharts(slide)) {
+    if (chart.spec === null) continue;
+    if (chart.spec.series.some((s) => s.trendline !== undefined)) out.push(chart);
+  }
+  return out;
+};
+
+/**
  * Returns the first chart on the slide whose parsed `kind` matches
  * `kind` (e.g. `'bar'`, `'line'`, `'pie'`). Returns `null` when no
  * chart on the slide has that kind, or when every chart on the slide

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -125,6 +125,7 @@ export {
   duplicateSlideAt,
   findChartByKind,
   findChartsBySeriesName,
+  findChartsWithTrendlines,
   findCommentAuthorByName,
   findCommentsAfter,
   findCommentsBefore,

--- a/test/fn-find-charts-with-trendlines.test.ts
+++ b/test/fn-find-charts-with-trendlines.test.ts
@@ -1,0 +1,62 @@
+// `findChartsWithTrendlines(slide)` — slide-scoped trendline auditor.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  addSlideChart,
+  findChartsWithTrendlines,
+  getSlides,
+  inches,
+  loadPresentation,
+} from '../src/api/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+describe('fn API: findChartsWithTrendlines', () => {
+  it('returns charts with a trendline on any series', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(3),
+      h: inches(2),
+      spec: {
+        kind: 'line',
+        categories: ['A', 'B'],
+        series: [{ name: 'X', values: [1, 2], trendline: { type: 'linear' } }],
+      },
+    });
+    addSlideChart(slide, {
+      x: inches(3),
+      y: inches(0),
+      w: inches(3),
+      h: inches(2),
+      spec: {
+        kind: 'line',
+        categories: ['A', 'B'],
+        series: [{ name: 'Y', values: [3, 4] }],
+      },
+    });
+    expect(findChartsWithTrendlines(slide).length).toBe(1);
+  });
+
+  it('returns an empty array when no chart has a trendline', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(3),
+      h: inches(2),
+      spec: {
+        kind: 'column',
+        categories: ['A'],
+        series: [{ name: 'X', values: [1] }],
+      },
+    });
+    expect(findChartsWithTrendlines(slide)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds \`findChartsWithTrendlines(slide)\` — slide-scoped finder for charts that carry at least one \`<c:trendline>\` on any of their series.
- Useful for deck-audit reports.
- Charts whose kind isn't modeled are skipped (matches \`findChartsBySeriesName\`).

## Test plan
- [x] 2 new tests in \`test/fn-find-charts-with-trendlines.test.ts\` — a chart with a trendline + a chart without (returns just the first), and the empty-result case.
- [x] \`pnpm test\` — 895 passing (was 893), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)