### PR TITLE
feat: findSlidesWithChartTrendlines(pres)

### DIFF
--- a/.changeset/find-slides-with-chart-trendlines.md
+++ b/.changeset/find-slides-with-chart-trendlines.md
@@ -1,0 +1,8 @@
+---
+'pptx-kit': minor
+---
+
+feat: `findSlidesWithChartTrendlines(pres)` — deck-level variant of
+the slide-scoped `findChartsWithTrendlines`. Returns every slide
+carrying at least one chart with a trendline on any series. Useful
+for "audit every trendline in this deck" workflows before publishing.

--- a/src/api/fn/slide-notes.ts
+++ b/src/api/fn/slide-notes.ts
@@ -167,6 +167,26 @@ export const findSlidesWithChartKind = (
 };
 
 /**
+ * Presentation-level version of `findChartsWithTrendlines`. Returns
+ * every slide carrying at least one chart with a trendline on any
+ * series. Useful for "audit every trendline in this deck" workflows
+ * before publishing.
+ */
+export const findSlidesWithChartTrendlines = (pres: PresentationData): ReadonlyArray<SlideData> => {
+  const out: SlideData[] = [];
+  for (const slide of getSlides(pres)) {
+    for (const c of getSlideCharts(slide)) {
+      if (c.spec === null) continue;
+      if (c.spec.series.some((s) => s.trendline !== undefined)) {
+        out.push(slide);
+        break;
+      }
+    }
+  }
+  return out;
+};
+
+/**
  * Returns every slide where at least two shapes have overlapping
  * bounding boxes. Built on `findOverlappingShapePairs`. Useful for
  * deck-wide layout audits — surfacing slides that may have stacked

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -142,6 +142,7 @@ export {
   findShapesByHyperlink,
   findShapesInRect,
   findSlidesWithChartKind,
+  findSlidesWithChartTrendlines,
   findShapesByKind,
   findShapesByName,
   findShapesByPreset,

--- a/test/fn-find-slides-with-chart-trendlines.test.ts
+++ b/test/fn-find-slides-with-chart-trendlines.test.ts
@@ -1,0 +1,53 @@
+// `findSlidesWithChartTrendlines(pres)` — deck-level trendline auditor.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  addSlideChart,
+  findSlidesWithChartTrendlines,
+  getSlideIndex,
+  getSlides,
+  inches,
+  loadPresentation,
+} from '../src/api/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+describe('fn API: findSlidesWithChartTrendlines', () => {
+  it('returns every slide with at least one trendline-carrying chart', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const [slideA, slideB] = getSlides(pres);
+    addSlideChart(slideA!, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(3),
+      h: inches(2),
+      spec: {
+        kind: 'line',
+        categories: ['A'],
+        series: [{ name: 'X', values: [1], trendline: { type: 'linear' } }],
+      },
+    });
+    addSlideChart(slideB!, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(3),
+      h: inches(2),
+      spec: {
+        kind: 'line',
+        categories: ['A'],
+        series: [{ name: 'Y', values: [2] }],
+      },
+    });
+    const slides = findSlidesWithChartTrendlines(pres);
+    expect(slides.length).toBe(1);
+    expect(getSlideIndex(pres, slides[0]!)).toBe(getSlideIndex(pres, slideA!));
+  });
+
+  it('returns an empty array when no chart has a trendline', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    expect(findSlidesWithChartTrendlines(pres)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds \`findSlidesWithChartTrendlines(pres)\` — deck-level companion to the slide-scoped \`findChartsWithTrendlines\`.
- Returns every slide carrying at least one chart with a trendline on any series.
- Useful for "audit every trendline in this deck" workflows before publishing.

## Test plan
- [x] 2 new tests in \`test/fn-find-slides-with-chart-trendlines.test.ts\` covering the match-and-skip case and the empty-result case.
- [x] \`pnpm test\` — 897 passing (was 895), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)