### PR TITLE
feat: findChartsWithDataLabels(slide)

### DIFF
--- a/.changeset/find-charts-with-data-labels.md
+++ b/.changeset/find-charts-with-data-labels.md
@@ -1,0 +1,9 @@
+---
+'pptx-kit': minor
+---
+
+feat: `findChartsWithDataLabels(slide)` — slide-scoped auditor for
+charts whose chart-level or per-series `dataLabels` enable at least
+one of `showValue` / `showCategory` / `showSeriesName` / `showPercent`.
+Purely presence-based; doesn't validate numberFormat or position.
+Charts whose kind isn't modeled are skipped.

--- a/src/api/fn/charts.ts
+++ b/src/api/fn/charts.ts
@@ -430,6 +430,31 @@ export const findChartsWithTrendlines = (slide: SlideData): ReadonlyArray<SlideC
 };
 
 /**
+ * Returns every chart on the slide whose `dataLabels` (chart-level)
+ * or any series-level `dataLabels` enable at least one of `showValue`,
+ * `showCategory`, `showSeriesName`, or `showPercent`. Useful for
+ * "which charts show numbers next to the data?" audits — purely
+ * presence-based; doesn't validate numberFormat or position. Charts
+ * whose kind isn't modeled are skipped.
+ */
+export const findChartsWithDataLabels = (slide: SlideData): ReadonlyArray<SlideChartData> => {
+  const out: SlideChartData[] = [];
+  const hasLabel = (dl: ChartSpec['dataLabels'] | undefined): boolean =>
+    dl !== undefined && (dl.showValue || dl.showCategory || dl.showSeriesName || dl.showPercent);
+  for (const chart of getSlideCharts(slide)) {
+    if (chart.spec === null) continue;
+    if (hasLabel(chart.spec.dataLabels)) {
+      out.push(chart);
+      continue;
+    }
+    if (chart.spec.series.some((s) => hasLabel(s.dataLabels))) {
+      out.push(chart);
+    }
+  }
+  return out;
+};
+
+/**
  * Returns the first chart on the slide whose parsed `kind` matches
  * `kind` (e.g. `'bar'`, `'line'`, `'pie'`). Returns `null` when no
  * chart on the slide has that kind, or when every chart on the slide

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -125,6 +125,7 @@ export {
   duplicateSlideAt,
   findChartByKind,
   findChartsBySeriesName,
+  findChartsWithDataLabels,
   findChartsWithTrendlines,
   findCommentAuthorByName,
   findCommentsAfter,

--- a/test/fn-find-charts-with-data-labels.test.ts
+++ b/test/fn-find-charts-with-data-labels.test.ts
@@ -1,0 +1,109 @@
+// `findChartsWithDataLabels(slide)` — slide-scoped audit for charts
+// that show values / categories / percentages on data points.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  addSlideChart,
+  findChartsWithDataLabels,
+  getSlides,
+  inches,
+  loadPresentation,
+} from '../src/api/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+describe('fn API: findChartsWithDataLabels', () => {
+  it('matches charts with chart-level dataLabels', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(3),
+      h: inches(2),
+      spec: {
+        kind: 'column',
+        categories: ['A'],
+        series: [{ name: 'X', values: [1] }],
+        dataLabels: {
+          showValue: true,
+          showCategory: false,
+          showSeriesName: false,
+          showPercent: false,
+        },
+      },
+    });
+    expect(findChartsWithDataLabels(slide).length).toBe(1);
+  });
+
+  it('matches charts with only per-series dataLabels', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(3),
+      h: inches(2),
+      spec: {
+        kind: 'column',
+        categories: ['A'],
+        series: [
+          {
+            name: 'X',
+            values: [1],
+            dataLabels: {
+              showValue: true,
+              showCategory: false,
+              showSeriesName: false,
+              showPercent: false,
+            },
+          },
+        ],
+      },
+    });
+    expect(findChartsWithDataLabels(slide).length).toBe(1);
+  });
+
+  it('returns an empty array when no chart enables a show* flag', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(3),
+      h: inches(2),
+      spec: {
+        kind: 'column',
+        categories: ['A'],
+        series: [{ name: 'X', values: [1] }],
+      },
+    });
+    expect(findChartsWithDataLabels(slide)).toEqual([]);
+  });
+
+  it('ignores a dataLabels object whose every show* flag is false', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(3),
+      h: inches(2),
+      spec: {
+        kind: 'column',
+        categories: ['A'],
+        series: [{ name: 'X', values: [1] }],
+        dataLabels: {
+          showValue: false,
+          showCategory: false,
+          showSeriesName: false,
+          showPercent: false,
+        },
+      },
+    });
+    expect(findChartsWithDataLabels(slide)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds \`findChartsWithDataLabels(slide)\` — slide-scoped auditor for charts whose chart-level or per-series \`dataLabels\` enable at least one of \`showValue\` / \`showCategory\` / \`showSeriesName\` / \`showPercent\`.
- Purely presence-based; doesn't validate \`numberFormat\` or \`position\`.
- Charts whose kind isn't modeled are skipped (matches \`findChartsBySeriesName\` / \`findChartsWithTrendlines\`).

## Test plan
- [x] 4 new tests in \`test/fn-find-charts-with-data-labels.test.ts\` covering chart-level dataLabels, per-series-only dataLabels, no-dataLabels, and the all-show*=false sentinel case (should not match).
- [x] \`pnpm test\` — 901 passing (was 897), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)