### PR TITLE
feat: getSlideTables(slide) helper

### DIFF
--- a/.changeset/get-slide-tables.md
+++ b/.changeset/get-slide-tables.md
@@ -1,0 +1,8 @@
+---
+'pptx-kit': minor
+---
+
+feat: `getSlideTables(slide)` — returns every table graphic-frame
+shape on the slide, in document order. Pair to `getSlideCharts` for
+cases where the caller wants just the tables; convenience over
+`getSlideShapes(slide).filter(isTableShape)`.

--- a/src/api/fn/tables.ts
+++ b/src/api/fn/tables.ts
@@ -33,6 +33,8 @@ import {
   SHAPE_ELEMENT,
   SHAPE_SLIDE,
   SHAPE_SNAPSHOT,
+  SLIDE_SHAPES,
+  type SlideData,
   type SlideShapeData,
   type TableCellData,
 } from '../_internal-symbols.ts';
@@ -71,6 +73,20 @@ const findTblElement = (shape: SlideShapeData): XmlElement | null => {
  * which also matches charts and SmartArt frames.
  */
 export const isTableShape = (shape: SlideShapeData): boolean => findTblElement(shape) !== null;
+
+/**
+ * Returns every table graphic-frame shape on the slide, in document
+ * order. Convenience over `getSlideShapes(slide).filter(isTableShape)`
+ * — pairs `getSlideCharts(slide)` for cases where the caller wants
+ * just the tables.
+ */
+export const getSlideTables = (slide: SlideData): ReadonlyArray<SlideShapeData> => {
+  const out: SlideShapeData[] = [];
+  for (const shape of slide[SLIDE_SHAPES]) {
+    if (isTableShape(shape)) out.push(shape);
+  }
+  return out;
+};
 
 /**
  * `true` when the shape is a `<p:graphicFrame>` wrapping a chart

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -332,6 +332,7 @@ export {
   getSlidePartName,
   getSlideSections,
   getSlideShapes,
+  getSlideTables,
   getSlideSize,
   getSlideText,
   getSlideTextLength,

--- a/test/fn-get-slide-tables.test.ts
+++ b/test/fn-get-slide-tables.test.ts
@@ -1,0 +1,55 @@
+// `getSlideTables(slide)` — slide-scoped table-shape listing.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  addSlideTable,
+  addSlideTextBox,
+  getSlideTables,
+  getSlides,
+  inches,
+  isTableShape,
+  loadPresentation,
+} from '../src/api/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+describe('fn API: getSlideTables', () => {
+  it('returns every table on the slide', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideTable(slide, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(4),
+      h: inches(2),
+      rows: [['A', 'B']],
+    });
+    addSlideTable(slide, {
+      x: inches(0),
+      y: inches(2),
+      w: inches(4),
+      h: inches(2),
+      rows: [['C', 'D']],
+    });
+    // Plus a non-table shape that shouldn't show up.
+    addSlideTextBox(slide, {
+      x: inches(0),
+      y: inches(4),
+      w: inches(4),
+      h: inches(1),
+      text: 'ignored',
+    });
+    const tables = getSlideTables(slide);
+    expect(tables.length).toBe(2);
+    expect(tables.every((t) => isTableShape(t))).toBe(true);
+  });
+
+  it('returns an empty array on a slide without tables', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    expect(getSlideTables(slide)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds \`getSlideTables(slide)\` — returns every table graphic-frame shape on the slide, in document order.
- Convenience over \`getSlideShapes(slide).filter(isTableShape)\`.
- Pair to \`getSlideCharts(slide)\` for cases where the caller wants just the tables.

## Test plan
- [x] 2 new tests in \`test/fn-get-slide-tables.test.ts\` — multi-table return, empty-result.
- [x] \`pnpm test\` — 903 passing (was 901), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)