### PR TITLE
feat: findShapesWithAnimation(slide)

### DIFF
--- a/.changeset/find-shapes-with-animation.md
+++ b/.changeset/find-shapes-with-animation.md
@@ -1,0 +1,9 @@
+---
+'pptx-kit': minor
+---
+
+feat: `findShapesWithAnimation(slide)` — returns every shape on the
+slide whose `getShapeAnimation` is not `null`. Pair to
+`slideHasAnimations`. Useful for "which shapes on this slide actually
+animate?" audits before exporting to a video pipeline that doesn't
+honor PowerPoint's timing tree.

--- a/src/api/fn/shape-animation.ts
+++ b/src/api/fn/shape-animation.ts
@@ -17,6 +17,7 @@ import {
   SHAPE_SLIDE,
   SHAPE_SNAPSHOT,
   SLIDE_DOCUMENT,
+  SLIDE_SHAPES,
   type SlideData,
   type SlideShapeData,
 } from '../_internal-symbols.ts';
@@ -145,6 +146,21 @@ export const getShapeAnimation = (shape: SlideShapeData): AnimationEffect | null
 };
 
 /** Removes the slide's `<p:timing>` element entirely. */
+/**
+ * Returns every shape on the slide that has an authored animation
+ * effect (i.e. `getShapeAnimation(shape)` is not `null`). Pair to
+ * `slideHasAnimations`. Useful for audit reports — "which shapes on
+ * this slide actually animate?" before exporting to a video pipeline
+ * that doesn't honor PowerPoint's timing tree.
+ */
+export const findShapesWithAnimation = (slide: SlideData): ReadonlyArray<SlideShapeData> => {
+  const out: SlideShapeData[] = [];
+  for (const shape of slide[SLIDE_SHAPES]) {
+    if (getShapeAnimation(shape) !== null) out.push(shape);
+  }
+  return out;
+};
+
 export const clearSlideAnimations = (slide: SlideData): void => {
   removeExistingTiming(slide);
   commitSlideData(slide);

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -141,6 +141,7 @@ export {
   findShapeByText,
   findShapeInPresentation,
   findShapesByHyperlink,
+  findShapesWithAnimation,
   findShapesInRect,
   findSlidesWithChartKind,
   findSlidesWithChartTrendlines,

--- a/test/fn-find-shapes-with-animation.test.ts
+++ b/test/fn-find-shapes-with-animation.test.ts
@@ -1,0 +1,33 @@
+// `findShapesWithAnimation(slide)` — slide-scoped audit for shapes
+// that have an authored animation effect.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  findShapesWithAnimation,
+  getSlideShapes,
+  getSlides,
+  loadPresentation,
+  setShapeAnimation,
+} from '../src/api/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+describe('fn API: findShapesWithAnimation', () => {
+  it('returns shapes that have an animation effect', async () => {
+    const pres = await loadPresentation(await readFile(fixture('one-text-slide.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const shape = getSlideShapes(slide)[0]!;
+    setShapeAnimation(shape, { effect: 'fadeIn' });
+    const matches = findShapesWithAnimation(slide);
+    expect(matches.length).toBe(1);
+  });
+
+  it('returns an empty array on a slide with no animations', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    expect(findShapesWithAnimation(slide)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds \`findShapesWithAnimation(slide)\` — returns every shape on the slide whose \`getShapeAnimation\` is not \`null\`.
- Useful for "which shapes on this slide actually animate?" audits before exporting to a video pipeline that doesn't honor PowerPoint's timing tree.
- Pair to \`slideHasAnimations\` (slide-level boolean).

## Test plan
- [x] 2 new tests in \`test/fn-find-shapes-with-animation.test.ts\` — animated shape returned, empty-slide returns empty array.
- [x] \`pnpm test\` — 905 passing (was 903), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)