### PR TITLE
feat: getPresentationCommentCountsByAuthor(pres)

### DIFF
--- a/.changeset/get-presentation-comment-counts-by-author.md
+++ b/.changeset/get-presentation-comment-counts-by-author.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: `getPresentationCommentCountsByAuthor(pres)` — deck-wide
+histogram of comment counts keyed by author display name. Useful for
+"who reviewed this deck the most?" audits. Authors sharing a display
+name get merged into the same bucket; pair with
+`getPresentationCommenters` when authors with identical names need to
+be kept separate by `id`.

--- a/src/api/fn/comments.ts
+++ b/src/api/fn/comments.ts
@@ -196,6 +196,27 @@ export const getPresentationCommenters = (pres: PresentationData): ReadonlyArray
 };
 
 /**
+ * Histogram of comment counts by author display name across the whole
+ * deck. Useful for "who reviewed this deck the most?" audits.
+ * Authors with the same display name (a real-world case for shared
+ * mailbox identities) get merged into the same bucket; pair with
+ * `getPresentationCommenters` when you need to keep authors with
+ * identical names separate by `id`.
+ */
+export const getPresentationCommentCountsByAuthor = (
+  pres: PresentationData,
+): Readonly<Record<string, number>> => {
+  const counts: Record<string, number> = {};
+  for (const slide of getSlides(pres)) {
+    for (const c of getSlideComments(slide)) {
+      const name = c.author.name;
+      counts[name] = (counts[name] ?? 0) + 1;
+    }
+  }
+  return counts;
+};
+
+/**
  * Looks up a `CommentAuthor` from `commentAuthors.xml` by display
  * name (case-sensitive equality). Returns `null` when no author has
  * that name. Sibling of `findCommentsByAuthor` — the latter returns

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -249,6 +249,7 @@ export {
   getOutlineText,
   getPackageSize,
   getPresentationChartKindCounts,
+  getPresentationCommentCountsByAuthor,
   getPresentationCommenters,
   getPresentationCreated,
   getPresentationFonts,

--- a/test/fn-get-presentation-comment-counts-by-author.test.ts
+++ b/test/fn-get-presentation-comment-counts-by-author.test.ts
@@ -1,0 +1,46 @@
+// `getPresentationCommentCountsByAuthor(pres)` — deck-wide histogram
+// of comment counts by author display name.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  addSlideComment,
+  getPresentationCommentCountsByAuthor,
+  getSlides,
+  inches,
+  loadPresentation,
+} from '../src/api/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+describe('fn API: getPresentationCommentCountsByAuthor', () => {
+  it('counts comments per author display name', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const [slideA, slideB] = getSlides(pres);
+    addSlideComment(slideA!, {
+      author: { name: 'Alice', initials: 'A' },
+      text: 'a1',
+      position: { x: inches(0), y: inches(0) },
+    });
+    addSlideComment(slideA!, {
+      author: { name: 'Alice', initials: 'A' },
+      text: 'a2',
+      position: { x: inches(0), y: inches(0) },
+    });
+    addSlideComment(slideB!, {
+      author: { name: 'Bob', initials: 'B' },
+      text: 'b1',
+      position: { x: inches(0), y: inches(0) },
+    });
+    const counts = getPresentationCommentCountsByAuthor(pres);
+    expect(counts.Alice).toBe(2);
+    expect(counts.Bob).toBe(1);
+  });
+
+  it('returns an empty object on a deck with no comments', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    expect(getPresentationCommentCountsByAuthor(pres)).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary
- Adds \`getPresentationCommentCountsByAuthor(pres)\` — deck-wide histogram of comment counts keyed by author display name.
- Useful for "who reviewed this deck the most?" audits.
- Authors sharing a display name (e.g. shared-mailbox identities) get merged into the same bucket; pair with \`getPresentationCommenters\` when authors with identical names need to be kept separate by \`id\`.

## Test plan
- [x] 2 new tests in \`test/fn-get-presentation-comment-counts-by-author.test.ts\` — multi-author count, empty-deck.
- [x] \`pnpm test\` — 909 passing (was 907), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)