### PR TITLE
feat: getPresentationCommentCountsBySlide(pres)

### DIFF
--- a/.changeset/get-presentation-comment-counts-by-slide.md
+++ b/.changeset/get-presentation-comment-counts-by-slide.md
@@ -1,0 +1,8 @@
+---
+'pptx-kit': minor
+---
+
+feat: `getPresentationCommentCountsBySlide(pres)` — dense per-slide
+comment count array. Every slide appears as an element (count `0`
+when the slide has no comments), so callers can chart comment
+density per slide without re-indexing.

--- a/src/api/fn/comments.ts
+++ b/src/api/fn/comments.ts
@@ -217,6 +217,19 @@ export const getPresentationCommentCountsByAuthor = (
 };
 
 /**
+ * Dense histogram of comment counts by 0-based slide index. Every
+ * slide in the deck appears as an element (count `0` when the slide
+ * has no comments), so the array shape is dense — handy for charting
+ * comment density per slide without re-indexing.
+ */
+export const getPresentationCommentCountsBySlide = (
+  pres: PresentationData,
+): ReadonlyArray<number> => {
+  const slides = getSlides(pres);
+  return slides.map((s) => getSlideComments(s).length);
+};
+
+/**
  * Looks up a `CommentAuthor` from `commentAuthors.xml` by display
  * name (case-sensitive equality). Returns `null` when no author has
  * that name. Sibling of `findCommentsByAuthor` — the latter returns

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -250,6 +250,7 @@ export {
   getPackageSize,
   getPresentationChartKindCounts,
   getPresentationCommentCountsByAuthor,
+  getPresentationCommentCountsBySlide,
   getPresentationCommenters,
   getPresentationCreated,
   getPresentationFonts,

--- a/test/fn-get-presentation-comment-counts-by-slide.test.ts
+++ b/test/fn-get-presentation-comment-counts-by-slide.test.ts
@@ -1,0 +1,49 @@
+// `getPresentationCommentCountsBySlide(pres)` — dense per-slide
+// comment count histogram.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  addSlideComment,
+  getPresentationCommentCountsBySlide,
+  getSlides,
+  inches,
+  loadPresentation,
+} from '../src/api/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+describe('fn API: getPresentationCommentCountsBySlide', () => {
+  it('returns 0 for every slide on a clean deck', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    expect(getPresentationCommentCountsBySlide(pres)).toEqual([0, 0]);
+  });
+
+  it('counts comments per slide', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const [slideA, slideB] = getSlides(pres);
+    addSlideComment(slideA!, {
+      author: { name: 'A', initials: 'a' },
+      text: 'a1',
+      position: { x: inches(0), y: inches(0) },
+    });
+    addSlideComment(slideA!, {
+      author: { name: 'A', initials: 'a' },
+      text: 'a2',
+      position: { x: inches(0), y: inches(0) },
+    });
+    addSlideComment(slideB!, {
+      author: { name: 'B', initials: 'b' },
+      text: 'b1',
+      position: { x: inches(0), y: inches(0) },
+    });
+    expect(getPresentationCommentCountsBySlide(pres)).toEqual([2, 1]);
+  });
+
+  it('array length matches the slide count', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    expect(getPresentationCommentCountsBySlide(pres).length).toBe(getSlides(pres).length);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds \`getPresentationCommentCountsBySlide(pres)\` — dense per-slide comment count array.
- Every slide appears as an element (count \`0\` when no comments), so callers can chart comment density per slide without re-indexing.
- Companion to \`getPresentationCommentCountsByAuthor\` (just landed).

## Test plan
- [x] 3 new tests in \`test/fn-get-presentation-comment-counts-by-slide.test.ts\` — empty deck, multi-slide multi-comment, length-matches-slide-count.
- [x] \`pnpm test\` — 912 passing (was 909), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)