### PR TITLE
feat: findShapesByEffect(pres, slide, kind)

### DIFF
--- a/.changeset/find-shapes-by-effect.md
+++ b/.changeset/find-shapes-by-effect.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: `findShapesByEffect(pres, slide, kind)` — returns every shape on
+the slide whose `<a:effectLst>` carries an effect of the given `kind`
+(`'outerShdw'`, `'innerShdw'`, `'glow'`, `'reflection'`, `'softEdge'`,
+`'blur'`). Pure presence check; doesn't walk the layout / master
+cascade. Useful for "which shapes have a shadow / glow on this
+slide?" audits.

--- a/src/api/fn/shape-effects.ts
+++ b/src/api/fn/shape-effects.ts
@@ -27,6 +27,8 @@ import {
   type PresentationData,
   SHAPE_ELEMENT,
   SHAPE_SLIDE,
+  SLIDE_SHAPES,
+  type SlideData,
   type SlideShapeData,
 } from '../_internal-symbols.ts';
 import { commitAndRefresh, decode, requireSpPr } from './_helpers.ts';
@@ -257,6 +259,26 @@ export const getShapeEffects = (
   const effectLst = firstChildElement(spPr, qname('a', 'effectLst', NS.dml));
   if (!effectLst) return [];
   return parseEffectLst(effectLst, getPresentationTheme(pres));
+};
+
+/**
+ * Every shape on the slide whose `<a:effectLst>` carries an effect
+ * of the given `kind` (`'outerShdw'`, `'innerShdw'`, `'glow'`,
+ * `'reflection'`, `'softEdge'`, `'blur'`). Pure presence check — only
+ * looks at the shape's own effect list, not the layout / master
+ * cascade. Pair with `findShapesByEffect(pres, slide, 'softEdge')`
+ * style call sites for visual-effect audits.
+ */
+export const findShapesByEffect = (
+  pres: PresentationData,
+  slide: SlideData,
+  kind: ShapeEffectAny['kind'],
+): ReadonlyArray<SlideShapeData> => {
+  const out: SlideShapeData[] = [];
+  for (const shape of slide[SLIDE_SHAPES]) {
+    if (getShapeEffects(pres, shape).some((e) => e.kind === kind)) out.push(shape);
+  }
+  return out;
 };
 
 /**

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -140,6 +140,7 @@ export {
   findShapeByName,
   findShapeByText,
   findShapeInPresentation,
+  findShapesByEffect,
   findShapesByHyperlink,
   findShapesInRect,
   findShapesWithAnimation,

--- a/test/fn-find-shapes-by-effect.test.ts
+++ b/test/fn-find-shapes-by-effect.test.ts
@@ -1,0 +1,56 @@
+// `findShapesByEffect(pres, slide, kind)` — visual-effect audit.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  addSlideTextBox,
+  findShapesByEffect,
+  getSlides,
+  inches,
+  loadPresentation,
+  setShapeGlow,
+  setShapeShadow,
+} from '../src/api/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+describe('fn API: findShapesByEffect', () => {
+  it('matches shapes by effect kind', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const a = addSlideTextBox(slide, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(2),
+      h: inches(1),
+      text: 'A',
+    });
+    const b = addSlideTextBox(slide, {
+      x: inches(0),
+      y: inches(1),
+      w: inches(2),
+      h: inches(1),
+      text: 'B',
+    });
+    addSlideTextBox(slide, {
+      x: inches(0),
+      y: inches(2),
+      w: inches(2),
+      h: inches(1),
+      text: 'C',
+    });
+    setShapeShadow(a, { color: '#000000', blurEmu: 50000, offsetEmu: 30000, angleDeg: 45 });
+    setShapeGlow(b, { color: '#00FF00', radiusEmu: 50000 });
+    expect(findShapesByEffect(pres, slide, 'outerShdw').length).toBe(1);
+    expect(findShapesByEffect(pres, slide, 'glow').length).toBe(1);
+    expect(findShapesByEffect(pres, slide, 'softEdge')).toEqual([]);
+  });
+
+  it('returns an empty array on a slide with no effects', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    expect(findShapesByEffect(pres, slide, 'glow')).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds \`findShapesByEffect(pres, slide, kind)\` — returns every shape on the slide whose \`<a:effectLst>\` carries an effect of the given \`kind\` (\`'outerShdw'\`, \`'innerShdw'\`, \`'glow'\`, \`'reflection'\`, \`'softEdge'\`, \`'blur'\`).
- Pure presence check on the shape's own effect list; doesn't walk the layout / master cascade.
- Useful for "which shapes have a shadow / glow on this slide?" audits.

## Test plan
- [x] 2 new tests in \`test/fn-find-shapes-by-effect.test.ts\` — single-effect match + multi-kind branching, empty-slide case.
- [x] \`pnpm test\` — 914 passing (was 912), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)