### PR TITLE
feat: getPresentationShapeCountsBySlide(pres)

### DIFF
--- a/.changeset/get-presentation-shape-counts-by-slide.md
+++ b/.changeset/get-presentation-shape-counts-by-slide.md
@@ -1,0 +1,8 @@
+---
+'pptx-kit': minor
+---
+
+feat: `getPresentationShapeCountsBySlide(pres)` — dense per-slide
+shape count array. Counts whatever `getSlideShapes` flattens (top-
+level + group-children). Useful for charting shape density per slide
+and identifying outliers for cleanup.

--- a/src/api/fn/slide-query.ts
+++ b/src/api/fn/slide-query.ts
@@ -241,6 +241,15 @@ export const getPresentationTextLength = (pres: PresentationData): number => {
 };
 
 /**
+ * Dense per-slide shape count array, 0-based by slide index. Counts
+ * top-level + group-children shapes (whatever `getSlideShapes` flattens).
+ * Useful for charting shape density per slide and identifying outliers
+ * (the 200-shape "soup" slide everybody complains about) for cleanup.
+ */
+export const getPresentationShapeCountsBySlide = (pres: PresentationData): ReadonlyArray<number> =>
+  getSlides(pres).map((s) => s[SLIDE_SHAPES].length);
+
+/**
  * Returns the 0-based index of `slide` within `pres`, or `-1` if the
  * slide doesn't belong to this presentation (e.g. after a removeSlide
  * call, or if it was constructed from a different package).

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -259,6 +259,7 @@ export {
   getPresentationSummary,
   getPresentationNotesLength,
   getPresentationNotesText,
+  getPresentationShapeCountsBySlide,
   getPresentationText,
   getPresentationTextLength,
   getPresentationTheme,

--- a/test/fn-get-presentation-shape-counts-by-slide.test.ts
+++ b/test/fn-get-presentation-shape-counts-by-slide.test.ts
@@ -1,0 +1,53 @@
+// `getPresentationShapeCountsBySlide(pres)` — dense per-slide shape
+// count histogram.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  addSlideTextBox,
+  getPresentationShapeCountsBySlide,
+  getSlides,
+  inches,
+  loadPresentation,
+} from '../src/api/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+describe('fn API: getPresentationShapeCountsBySlide', () => {
+  it("reports each slide's shape count in order", async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const [slideA, slideB] = getSlides(pres);
+    const baseline = getPresentationShapeCountsBySlide(pres);
+    addSlideTextBox(slideA!, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(2),
+      h: inches(1),
+      text: 'A1',
+    });
+    addSlideTextBox(slideA!, {
+      x: inches(0),
+      y: inches(1),
+      w: inches(2),
+      h: inches(1),
+      text: 'A2',
+    });
+    addSlideTextBox(slideB!, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(2),
+      h: inches(1),
+      text: 'B1',
+    });
+    const counts = getPresentationShapeCountsBySlide(pres);
+    expect(counts[0]).toBe(baseline[0]! + 2);
+    expect(counts[1]).toBe(baseline[1]! + 1);
+  });
+
+  it('array length matches the slide count', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    expect(getPresentationShapeCountsBySlide(pres).length).toBe(getSlides(pres).length);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds \`getPresentationShapeCountsBySlide(pres)\` — dense per-slide shape count array.
- Counts whatever \`getSlideShapes\` flattens (top-level + group-children).
- Useful for charting shape density per slide and identifying outliers for cleanup.

## Test plan
- [x] 2 new tests in \`test/fn-get-presentation-shape-counts-by-slide.test.ts\` — counts deltas vs baseline, length-matches-slide-count.
- [x] \`pnpm test\` — 916 passing (was 914), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)