### PR TITLE
feat: getPresentationTextLengthsBySlide(pres)

### DIFF
--- a/.changeset/get-presentation-text-lengths-by-slide.md
+++ b/.changeset/get-presentation-text-lengths-by-slide.md
@@ -1,0 +1,8 @@
+---
+'pptx-kit': minor
+---
+
+feat: `getPresentationTextLengthsBySlide(pres)` — dense per-slide
+visible-text length array. Counts code points (surrogate pairs as 1)
+per `getSlideTextLength`. Pair with `getPresentationShapeCountsBySlide`
+for slide-density audits.

--- a/src/api/fn/slide-query.ts
+++ b/src/api/fn/slide-query.ts
@@ -250,6 +250,17 @@ export const getPresentationShapeCountsBySlide = (pres: PresentationData): Reado
   getSlides(pres).map((s) => s[SLIDE_SHAPES].length);
 
 /**
+ * Dense per-slide visible-text length array, 0-based by slide index.
+ * Counts code points (surrogate pairs as 1) per `getSlideTextLength`.
+ * Pair with `getPresentationShapeCountsBySlide` for slide-density
+ * audits — high text length on a slide with few shapes usually means
+ * one paragraph-heavy text box; low text on a many-shape slide
+ * usually means a busy diagram.
+ */
+export const getPresentationTextLengthsBySlide = (pres: PresentationData): ReadonlyArray<number> =>
+  getSlides(pres).map((s) => Array.from(slideText(s[SLIDE_PART])).length);
+
+/**
  * Returns the 0-based index of `slide` within `pres`, or `-1` if the
  * slide doesn't belong to this presentation (e.g. after a removeSlide
  * call, or if it was constructed from a different package).

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -262,6 +262,7 @@ export {
   getPresentationShapeCountsBySlide,
   getPresentationText,
   getPresentationTextLength,
+  getPresentationTextLengthsBySlide,
   getPresentationTheme,
   getShapePlaceholderType,
   getShapePosition,

--- a/test/fn-get-presentation-text-lengths-by-slide.test.ts
+++ b/test/fn-get-presentation-text-lengths-by-slide.test.ts
@@ -1,0 +1,47 @@
+// `getPresentationTextLengthsBySlide(pres)` — dense per-slide text
+// length histogram.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  addSlideTextBox,
+  getPresentationTextLengthsBySlide,
+  getSlides,
+  getSlideTextLength,
+  inches,
+  loadPresentation,
+} from '../src/api/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+describe('fn API: getPresentationTextLengthsBySlide', () => {
+  it('matches getSlideTextLength for every slide', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const arr = getPresentationTextLengthsBySlide(pres);
+    const slides = getSlides(pres);
+    expect(arr.length).toBe(slides.length);
+    for (let i = 0; i < slides.length; i++) {
+      expect(arr[i]).toBe(getSlideTextLength(slides[i]!));
+    }
+  });
+
+  it('responds to new text after mutation', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const before = getPresentationTextLengthsBySlide(pres);
+    const slideA = getSlides(pres)[0]!;
+    addSlideTextBox(slideA, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(2),
+      h: inches(1),
+      text: 'hello',
+    });
+    const after = getPresentationTextLengthsBySlide(pres);
+    // Adding the textbox raises the slide's text length by at least the
+    // string itself; PowerPoint inserts an inter-paragraph separator
+    // between text bodies so we don't pin to an exact delta.
+    expect(after[0]!).toBeGreaterThanOrEqual(before[0]! + 'hello'.length);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds \`getPresentationTextLengthsBySlide(pres)\` — dense per-slide visible-text length array.
- Counts code points (surrogate pairs as 1) per \`getSlideTextLength\`.
- Companion to \`getPresentationShapeCountsBySlide\` for slide-density audits — high text length on a slide with few shapes usually means a paragraph-heavy text box; low text on a many-shape slide usually means a busy diagram.

## Test plan
- [x] 2 new tests in \`test/fn-get-presentation-text-lengths-by-slide.test.ts\` — matches \`getSlideTextLength\` per-slide, responds to mutation.
- [x] \`pnpm test\` — 918 passing (was 916), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)