### PR TITLE
feat: getPresentationChartCountsBySlide(pres)

### DIFF
--- a/.changeset/get-presentation-chart-counts-by-slide.md
+++ b/.changeset/get-presentation-chart-counts-by-slide.md
@@ -1,0 +1,11 @@
+---
+'pptx-kit': minor
+---
+
+feat: `getPresentationChartCountsBySlide(pres)` — dense per-slide chart
+count array. Counts every chart returned by `getSlideCharts` regardless
+of whether its spec parsed; pair with `getPresentationChartKindCounts`
+for kind-level totals. Rounds out the density-array family alongside
+`getPresentationCommentCountsBySlide`,
+`getPresentationShapeCountsBySlide`, and
+`getPresentationTextLengthsBySlide`.

--- a/src/api/fn/charts.ts
+++ b/src/api/fn/charts.ts
@@ -498,6 +498,16 @@ export const getPresentationChartKindCounts = (
   return counts;
 };
 
+/**
+ * Dense per-slide chart count array, 0-based by slide index. Counts
+ * every chart returned by `getSlideCharts` regardless of whether its
+ * `spec` parsed — useful for "which slides carry charts the renderer
+ * doesn't yet model?" audits. Pair with
+ * `getPresentationChartKindCounts` for kind-level totals.
+ */
+export const getPresentationChartCountsBySlide = (pres: PresentationData): ReadonlyArray<number> =>
+  getSlides(pres).map((s) => getSlideCharts(s).length);
+
 export const getSlideCharts = (slide: SlideData): ReadonlyArray<SlideChartData> => {
   const pkg = slide[INTERNAL_PACKAGE];
   const out: SlideChartData[] = [];

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -249,6 +249,7 @@ export {
   getOrphanMediaPartNames,
   getOutlineText,
   getPackageSize,
+  getPresentationChartCountsBySlide,
   getPresentationChartKindCounts,
   getPresentationCommentCountsByAuthor,
   getPresentationCommentCountsBySlide,

--- a/test/fn-get-presentation-chart-counts-by-slide.test.ts
+++ b/test/fn-get-presentation-chart-counts-by-slide.test.ts
@@ -1,0 +1,55 @@
+// `getPresentationChartCountsBySlide(pres)` — dense per-slide chart
+// count array.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  addSlideChart,
+  getPresentationChartCountsBySlide,
+  getSlides,
+  inches,
+  loadPresentation,
+} from '../src/api/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+describe('fn API: getPresentationChartCountsBySlide', () => {
+  it('returns 0 for every slide on a chart-less deck', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    expect(getPresentationChartCountsBySlide(pres)).toEqual([0, 0]);
+  });
+
+  it('counts charts per slide', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const [slideA, slideB] = getSlides(pres);
+    addSlideChart(slideA!, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(3),
+      h: inches(2),
+      spec: { kind: 'column', categories: ['A'], series: [{ name: 'X', values: [1] }] },
+    });
+    addSlideChart(slideA!, {
+      x: inches(0),
+      y: inches(2),
+      w: inches(3),
+      h: inches(2),
+      spec: { kind: 'pie', categories: ['A'], series: [{ name: 'X', values: [1] }] },
+    });
+    addSlideChart(slideB!, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(3),
+      h: inches(2),
+      spec: { kind: 'line', categories: ['A'], series: [{ name: 'X', values: [1] }] },
+    });
+    expect(getPresentationChartCountsBySlide(pres)).toEqual([2, 1]);
+  });
+
+  it('array length matches the slide count', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    expect(getPresentationChartCountsBySlide(pres).length).toBe(getSlides(pres).length);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds \`getPresentationChartCountsBySlide(pres)\` — dense per-slide chart count array.
- Counts every chart returned by \`getSlideCharts\` regardless of whether its spec parsed.
- Rounds out the density-array family (\`getPresentationCommentCountsBySlide\`, \`getPresentationShapeCountsBySlide\`, \`getPresentationTextLengthsBySlide\`, now charts).
- Pair with \`getPresentationChartKindCounts\` for kind-level totals.

## Test plan
- [x] 3 new tests in \`test/fn-get-presentation-chart-counts-by-slide.test.ts\` — empty deck, multi-slide multi-chart, length-matches-slide-count.
- [x] \`pnpm test\` — 921 passing (was 918), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)