### PR TITLE
feat: getPresentationHyperlinkCountsBySlide(pres)

### DIFF
--- a/.changeset/get-presentation-hyperlink-counts-by-slide.md
+++ b/.changeset/get-presentation-hyperlink-counts-by-slide.md
@@ -1,0 +1,8 @@
+---
+'pptx-kit': minor
+---
+
+feat: `getPresentationHyperlinkCountsBySlide(pres)` — dense per-slide
+hyperlink count array. Counts shapes whose `getShapeHyperlink` is
+non-null. Cheaper than `getAllHyperlinks` when the caller only wants
+per-slide counts. Rounds out the deck-density family.

--- a/src/api/fn/slide-notes.ts
+++ b/src/api/fn/slide-notes.ts
@@ -357,6 +357,18 @@ export const getAllHyperlinks = (
 };
 
 /**
+ * Dense per-slide hyperlink count array. Counts shapes whose
+ * `getShapeHyperlink` is non-null, mirroring `getAllHyperlinks` but
+ * cheaper when the caller only wants per-slide counts. Rounds out the
+ * deck-density family alongside the chart / table / image / shape /
+ * text / comment counters.
+ */
+export const getPresentationHyperlinkCountsBySlide = (
+  pres: PresentationData,
+): ReadonlyArray<number> =>
+  getSlides(pres).map((s) => s[SLIDE_SHAPES].filter((sh) => getShapeHyperlink(sh) !== null).length);
+
+/**
  * Returns every distinct external URL referenced by any shape in
  * the deck, in first-seen order. Sibling of `getAllHyperlinks`
  * (which keeps duplicates and slide indices). Useful for "are

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -260,6 +260,7 @@ export {
   getPresentationSummary,
   getPresentationNotesLength,
   getPresentationNotesText,
+  getPresentationHyperlinkCountsBySlide,
   getPresentationImageCountsBySlide,
   getPresentationShapeCountsBySlide,
   getPresentationTableCountsBySlide,

--- a/test/fn-get-presentation-hyperlink-counts-by-slide.test.ts
+++ b/test/fn-get-presentation-hyperlink-counts-by-slide.test.ts
@@ -1,0 +1,54 @@
+// `getPresentationHyperlinkCountsBySlide(pres)` — dense per-slide
+// hyperlink count array.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  addSlideTextBox,
+  getPresentationHyperlinkCountsBySlide,
+  getSlides,
+  inches,
+  loadPresentation,
+  setShapeHyperlink,
+} from '../src/api/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+describe('fn API: getPresentationHyperlinkCountsBySlide', () => {
+  it('counts hyperlinks per slide', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const [slideA, slideB] = getSlides(pres);
+    const tA1 = addSlideTextBox(slideA!, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(2),
+      h: inches(1),
+      text: 'A1',
+    });
+    const tA2 = addSlideTextBox(slideA!, {
+      x: inches(0),
+      y: inches(1),
+      w: inches(2),
+      h: inches(1),
+      text: 'A2',
+    });
+    const tB1 = addSlideTextBox(slideB!, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(2),
+      h: inches(1),
+      text: 'B1',
+    });
+    setShapeHyperlink(tA1, 'https://a1.example/');
+    setShapeHyperlink(tA2, 'https://a2.example/');
+    setShapeHyperlink(tB1, 'https://b1.example/');
+    expect(getPresentationHyperlinkCountsBySlide(pres)).toEqual([2, 1]);
+  });
+
+  it('returns all zeros when no shape has a hyperlink', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    expect(getPresentationHyperlinkCountsBySlide(pres)).toEqual([0, 0]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds \`getPresentationHyperlinkCountsBySlide(pres)\` — dense per-slide hyperlink count array.
- Counts shapes whose \`getShapeHyperlink\` is non-null.
- Cheaper than \`getAllHyperlinks\` when the caller only wants per-slide counts.
- Rounds out the deck-density family (chart / comment / image / shape / table / text / now hyperlinks).

## Test plan
- [x] 2 new tests in \`test/fn-get-presentation-hyperlink-counts-by-slide.test.ts\` — multi-slide hyperlink count, all-zeros on clean deck.
- [x] \`pnpm test\` — 926 passing (was 924), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)