### PR TITLE
feat: getPresentationNotesLengthsBySlide(pres)

### DIFF
--- a/.changeset/get-presentation-notes-lengths-by-slide.md
+++ b/.changeset/get-presentation-notes-lengths-by-slide.md
@@ -1,0 +1,9 @@
+---
+'pptx-kit': minor
+---
+
+feat: `getPresentationNotesLengthsBySlide(pres)` — dense per-slide
+speaker-notes length array. Pair with
+`getPresentationTextLengthsBySlide` for handout / talk-track audits —
+slides with little on-screen text but heavy notes are usually the
+slow part of a presentation.

--- a/src/api/fn/slide-notes.ts
+++ b/src/api/fn/slide-notes.ts
@@ -595,6 +595,16 @@ export const getPresentationNotesLength = (pres: PresentationData): number => {
 };
 
 /**
+ * Dense per-slide notes-length array. Code-point length per
+ * `getSlideNotesLength` (`0` when the slide has no notes part). Pair
+ * with `getPresentationTextLengthsBySlide` for handout / talk-track
+ * audits — slides with no on-screen text but heavy speaker notes are
+ * often the slow part of a presentation.
+ */
+export const getPresentationNotesLengthsBySlide = (pres: PresentationData): ReadonlyArray<number> =>
+  getSlides(pres).map((s) => getSlideNotesLength(s));
+
+/**
  * Appends `text` to the slide's existing notes on its own line.
  * Equivalent to `setSlideNotes(slide, (getSlideNotes(slide) ?? '') + '\n' + text)`,
  * minus the leading newline when there were no notes yet.

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -259,6 +259,7 @@ export {
   getPresentationModified,
   getPresentationSummary,
   getPresentationNotesLength,
+  getPresentationNotesLengthsBySlide,
   getPresentationNotesText,
   getPresentationHyperlinkCountsBySlide,
   getPresentationImageCountsBySlide,

--- a/test/fn-get-presentation-notes-lengths-by-slide.test.ts
+++ b/test/fn-get-presentation-notes-lengths-by-slide.test.ts
@@ -1,0 +1,32 @@
+// `getPresentationNotesLengthsBySlide(pres)` — dense per-slide notes
+// length array.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  getPresentationNotesLengthsBySlide,
+  getSlides,
+  loadPresentation,
+  setSlideNotes,
+} from '../src/api/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+describe('fn API: getPresentationNotesLengthsBySlide', () => {
+  it('returns 0 for slides without notes', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    expect(getPresentationNotesLengthsBySlide(pres)).toEqual([0, 0]);
+  });
+
+  it('reflects authored notes per slide', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const [slideA, slideB] = getSlides(pres);
+    setSlideNotes(slideA!, 'hello world');
+    setSlideNotes(slideB!, 'hi');
+    const arr = getPresentationNotesLengthsBySlide(pres);
+    expect(arr[0]).toBe('hello world'.length);
+    expect(arr[1]).toBe('hi'.length);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds \`getPresentationNotesLengthsBySlide(pres)\` — dense per-slide speaker-notes length array.
- Pair with \`getPresentationTextLengthsBySlide\` for handout / talk-track audits — slides with little on-screen text but heavy notes are usually the slow part of a presentation.

## Test plan
- [x] 2 new tests in \`test/fn-get-presentation-notes-lengths-by-slide.test.ts\` — 0 for clean deck, authored notes round-trip.
- [x] \`pnpm test\` — 928 passing (was 926), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)