### PR TITLE
feat: getEmptySlides(pres)

### DIFF
--- a/.changeset/get-empty-slides.md
+++ b/.changeset/get-empty-slides.md
@@ -1,0 +1,7 @@
+---
+'pptx-kit': minor
+---
+
+feat: `getEmptySlides(pres)` — returns every slide whose `<p:spTree>`
+carries no shapes (per `getSlideShapes`). Useful as a pre-publish
+"find the section dividers I forgot to fill in" check.

--- a/src/api/fn/slide-notes.ts
+++ b/src/api/fn/slide-notes.ts
@@ -605,6 +605,19 @@ export const getPresentationNotesLengthsBySlide = (pres: PresentationData): Read
   getSlides(pres).map((s) => getSlideNotesLength(s));
 
 /**
+ * Returns every slide whose `<p:spTree>` carries no shapes (per
+ * `getSlideShapes`). Useful as a "find the section dividers I forgot
+ * to fill in" pre-publish check.
+ */
+export const getEmptySlides = (pres: PresentationData): ReadonlyArray<SlideData> => {
+  const out: SlideData[] = [];
+  for (const slide of getSlides(pres)) {
+    if (slide[SLIDE_SHAPES].length === 0) out.push(slide);
+  }
+  return out;
+};
+
+/**
  * Appends `text` to the slide's existing notes on its own line.
  * Equivalent to `setSlideNotes(slide, (getSlideNotes(slide) ?? '') + '\n' + text)`,
  * minus the leading newline when there were no notes yet.

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -185,6 +185,7 @@ export {
   getCommentsSortedByDate,
   getCoreProperties,
   getDistinctHyperlinkUrls,
+  getEmptySlides,
   getGroupChildren,
   getGroupTransform,
   getHiddenSlides,

--- a/test/fn-get-empty-slides.test.ts
+++ b/test/fn-get-empty-slides.test.ts
@@ -1,0 +1,38 @@
+// `getEmptySlides(pres)` — slides with no shapes.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  addBlankSlide,
+  addSlideTextBox,
+  getEmptySlides,
+  getSlideIndex,
+  getSlides,
+  inches,
+  loadPresentation,
+} from '../src/api/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+describe('fn API: getEmptySlides', () => {
+  it('does not return slides that carry shapes', async () => {
+    const pres = await loadPresentation(await readFile(fixture('blank.pptx')));
+    const populated = addBlankSlide(pres);
+    addSlideTextBox(populated, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(2),
+      h: inches(1),
+      text: 'hi',
+    });
+    const found = getEmptySlides(pres);
+    expect(found.map((s) => getSlideIndex(pres, s))).not.toContain(getSlideIndex(pres, populated));
+  });
+
+  it('result length is at most the deck length', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    expect(getEmptySlides(pres).length).toBeLessThanOrEqual(getSlides(pres).length);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds \`getEmptySlides(pres)\` — returns every slide whose \`<p:spTree>\` carries no shapes per \`getSlideShapes\`.
- Useful as a pre-publish "find the section dividers I forgot to fill in" check.

## Test plan
- [x] 2 new tests in \`test/fn-get-empty-slides.test.ts\` — populated slide not returned, result length is bounded by deck length.
- [x] \`pnpm test\` — 930 passing (was 928), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)