### PR TITLE
feat: getSlideMasterUsageCounts(pres)

### DIFF
--- a/.changeset/get-slide-master-usage-counts.md
+++ b/.changeset/get-slide-master-usage-counts.md
@@ -1,0 +1,9 @@
+---
+'pptx-kit': minor
+---
+
+feat: `getSlideMasterUsageCounts(pres)` — master part name → number of
+slides chaining to that master. Every master in the package appears as
+a key (count `0` for unreferenced masters), so it surfaces unused
+masters directly. Pair with `getSlideLayoutUsageCounts` for the
+layout layer in multi-master template decks.

--- a/src/api/fn/shape-read-base.ts
+++ b/src/api/fn/shape-read-base.ts
@@ -219,6 +219,28 @@ export const getSlideMasterPartNames = (pres: PresentationData): ReadonlyArray<s
   return out;
 };
 
+/**
+ * Histogram of master part name → number of slides whose layout chains
+ * up to that master. Every master in the package appears as a key
+ * (count `0` for unreferenced masters), so the function surfaces
+ * unused masters directly — useful for trimming multi-master template
+ * decks. Pair with `getSlideLayoutUsageCounts` for the layout layer.
+ */
+export const getSlideMasterUsageCounts = (
+  pres: PresentationData,
+): Readonly<Record<string, number>> => {
+  const counts: Record<string, number> = {};
+  for (const masterName of getSlideMasterPartNames(pres)) {
+    counts[masterName] = 0;
+  }
+  for (const slide of getSlides(pres)) {
+    const name = getSlideMasterPartName(slide);
+    if (name === null) continue;
+    counts[name] = (counts[name] ?? 0) + 1;
+  }
+  return counts;
+};
+
 export const getShapeName = (shape: SlideShapeData): string => shape[SHAPE_SNAPSHOT].name;
 
 /**

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -338,6 +338,7 @@ export {
   getSlideMasterCount,
   getSlideMasterPartName,
   getSlideMasterPartNames,
+  getSlideMasterUsageCounts,
   getSlideMediaPartNames,
   getSlideNotes,
   getSlideNotesLength,

--- a/test/fn-get-slide-master-usage-counts.test.ts
+++ b/test/fn-get-slide-master-usage-counts.test.ts
@@ -1,0 +1,31 @@
+// `getSlideMasterUsageCounts(pres)` — master part name → slide count.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  getSlideMasterPartNames,
+  getSlideMasterUsageCounts,
+  loadPresentation,
+} from '../src/api/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+describe('fn API: getSlideMasterUsageCounts', () => {
+  it('every master in the package appears as a key', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const masters = getSlideMasterPartNames(pres);
+    const counts = getSlideMasterUsageCounts(pres);
+    for (const m of masters) {
+      expect(counts[m]).toBeDefined();
+    }
+  });
+
+  it('reports a non-zero count for the master that the slides reference', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const counts = getSlideMasterUsageCounts(pres);
+    const total = Object.values(counts).reduce((a, n) => a + n, 0);
+    expect(total).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds \`getSlideMasterUsageCounts(pres)\` — master part name → number of slides whose layout chains to that master.
- Every master in the package appears as a key (count \`0\` for unreferenced masters); surfaces unused masters in multi-master template decks.
- Companion to \`getSlideLayoutUsageCounts\`.

## Test plan
- [x] 2 new tests in \`test/fn-get-slide-master-usage-counts.test.ts\` — every master is a key, non-zero total.
- [x] \`pnpm test\` — 932 passing (was 930), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)