### PR TITLE
feat: getUnusedSlideMasters(pres)

### DIFF
--- a/.changeset/get-unused-slide-masters.md
+++ b/.changeset/get-unused-slide-masters.md
@@ -1,0 +1,8 @@
+---
+'pptx-kit': minor
+---
+
+feat: `getUnusedSlideMasters(pres)` — master part names that no slide
+chains to (count of `0` in `getSlideMasterUsageCounts`). Pair to
+`getUnusedSlideLayouts`. Useful when trimming multi-master template
+decks of dead theme variants.

--- a/src/api/fn/shape-read-base.ts
+++ b/src/api/fn/shape-read-base.ts
@@ -241,6 +241,17 @@ export const getSlideMasterUsageCounts = (
   return counts;
 };
 
+/**
+ * Master part names that no slide chains to (count of `0` in
+ * `getSlideMasterUsageCounts`). Pair to `getUnusedSlideLayouts`.
+ * Useful when trimming multi-master template decks of dead theme
+ * variants.
+ */
+export const getUnusedSlideMasters = (pres: PresentationData): ReadonlyArray<string> => {
+  const counts = getSlideMasterUsageCounts(pres);
+  return getSlideMasterPartNames(pres).filter((m) => (counts[m] ?? 0) === 0);
+};
+
 export const getShapeName = (shape: SlideShapeData): string => shape[SHAPE_SNAPSHOT].name;
 
 /**

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -331,6 +331,7 @@ export {
   getSlideLayoutType,
   getSlideLayoutUsageCounts,
   getUnusedSlideLayouts,
+  getUnusedSlideMasters,
   getSlideMasterBackground,
   getSlideMasterBackgroundGradientFill,
   getSlideMasterBackgroundImageBytes,

--- a/test/fn-get-unused-slide-masters.test.ts
+++ b/test/fn-get-unused-slide-masters.test.ts
@@ -1,0 +1,33 @@
+// `getUnusedSlideMasters(pres)` — master part names no slide chains to.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  getSlideMasterPartNames,
+  getSlideMasterUsageCounts,
+  getUnusedSlideMasters,
+  loadPresentation,
+} from '../src/api/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+describe('fn API: getUnusedSlideMasters', () => {
+  it('every returned name has a usage count of 0', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const unused = getUnusedSlideMasters(pres);
+    const counts = getSlideMasterUsageCounts(pres);
+    for (const name of unused) {
+      expect(counts[name]).toBe(0);
+    }
+  });
+
+  it('result is a subset of every master in the package', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const all = new Set(getSlideMasterPartNames(pres));
+    for (const name of getUnusedSlideMasters(pres)) {
+      expect(all.has(name)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds \`getUnusedSlideMasters(pres)\` — master part names that no slide chains to (count of \`0\` in \`getSlideMasterUsageCounts\`).
- Pair to \`getUnusedSlideLayouts\` for the layout layer.
- Useful when trimming multi-master template decks of dead theme variants.

## Test plan
- [x] 2 new tests in \`test/fn-get-unused-slide-masters.test.ts\` — every returned name has count 0, result is a subset of package masters.
- [x] \`pnpm test\` — 934 passing (was 932), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)