### PR TITLE
feat: ChartSpec.categoryAxisNoMultiLevelLabel round-trip

### DIFF
--- a/.changeset/chart-cat-axis-no-multi-lvl-lbl.md
+++ b/.changeset/chart-cat-axis-no-multi-lvl-lbl.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: `ChartSpec.categoryAxisNoMultiLevelLabel` — toggle multi-level
+(hierarchical) category labels via `<c:catAx><c:noMultiLvlLbl val/>`.
+PowerPoint defaults to `0` (multi-level labels stack); set to `true`
+to flatten hierarchical categories into a single row. Read by
+chart-reader, written by chart-builder at the schema-required last
+position inside `<c:catAx>`.

--- a/src/internal/chartml/chart-builder.ts
+++ b/src/internal/chartml/chart-builder.ts
@@ -387,6 +387,7 @@ const catAxis = (spec: ChartSpec): XmlElement => {
   if (spec.categoryAxisTickMarkSkip !== undefined) {
     children.push(valNode(c('tickMarkSkip'), spec.categoryAxisTickMarkSkip));
   }
+  if (spec.categoryAxisNoMultiLevelLabel) children.push(valNode(c('noMultiLvlLbl'), '1'));
   return elem(c('catAx'), { children });
 };
 

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -901,6 +901,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
   let categoryAxisLabelOffset: number | undefined;
   let categoryAxisLabelAlign: ChartSpec['categoryAxisLabelAlign'];
   let categoryAxisNumberFormat: string | undefined;
+  let categoryAxisNoMultiLevelLabel: boolean | undefined;
   let categoryAxisLineColor: string | undefined;
   let valueAxisLineColor: string | undefined;
   let categoryAxisMajorGridlines: boolean | undefined;
@@ -1026,6 +1027,11 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     if (catNumFmtEl) {
       const fc = getAttrValue(catNumFmtEl, qname('', 'formatCode', ''));
       if (fc !== null && fc.length > 0 && fc !== 'General') categoryAxisNumberFormat = fc;
+    }
+    const noMultiLvlEl = firstChildElement(catAx, qname('c', 'noMultiLvlLbl', NS_C));
+    if (noMultiLvlEl) {
+      const v = getAttrValue(noMultiLvlEl, ATTR_VAL);
+      if (v === '1' || v === 'true') categoryAxisNoMultiLevelLabel = true;
     }
   }
   // <c:majorGridlines> / <c:minorGridlines> presence governs visibility.
@@ -1308,6 +1314,7 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     ...(categoryAxisLabelOffset !== undefined ? { categoryAxisLabelOffset } : {}),
     ...(categoryAxisLabelAlign !== undefined ? { categoryAxisLabelAlign } : {}),
     ...(categoryAxisNumberFormat !== undefined ? { categoryAxisNumberFormat } : {}),
+    ...(categoryAxisNoMultiLevelLabel === true ? { categoryAxisNoMultiLevelLabel: true } : {}),
     ...(categoryAxisLineColor !== undefined ? { categoryAxisLineColor } : {}),
     ...(valueAxisLineColor !== undefined ? { valueAxisLineColor } : {}),
     ...(categoryAxisMajorGridlines === true ? { categoryAxisMajorGridlines: true } : {}),

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -450,6 +450,13 @@ export interface ChartSpec {
    */
   readonly categoryAxisNumberFormat?: string;
   /**
+   * Toggle multi-level (hierarchical) category labels —
+   * `<c:catAx><c:noMultiLvlLbl val="0|1"/>`. PowerPoint defaults to
+   * `0` (multi-level labels stack). Set to `true` to flatten
+   * hierarchical categories into a single row.
+   */
+  readonly categoryAxisNoMultiLevelLabel?: boolean;
+  /**
    * Category-axis order — `'minMax'` (the data's natural order) or
    * `'maxMin'` (reversed). For bar charts PowerPoint typically emits
    * `maxMin` so the first category sits at the top instead of the

--- a/test/fn-chart-readback.test.ts
+++ b/test/fn-chart-readback.test.ts
@@ -855,6 +855,27 @@ describe('fn API: getSlideCharts', () => {
     expect(spec.valueAxisLineColor).toBe('#00AA00');
   });
 
+  it('round-trips categoryAxisNoMultiLevelLabel=true', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'column',
+        categories: ['A', 'B'],
+        series: [{ name: 'X', values: [1, 2] }],
+        categoryAxisNoMultiLevelLabel: true,
+      },
+    });
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    const spec = getSlideCharts(getSlides(reloaded)[0]!)[0]!.spec!;
+    expect(spec.categoryAxisNoMultiLevelLabel).toBe(true);
+  });
+
   it('round-trips categoryAxisNumberFormat', async () => {
     const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
     const slide = getSlides(pres)[0]!;


### PR DESCRIPTION
## Summary
- Adds \`ChartSpec.categoryAxisNoMultiLevelLabel\` — toggle multi-level (hierarchical) category labels via \`<c:catAx><c:noMultiLvlLbl val/>\`.
- PowerPoint defaults to \`0\` (multi-level labels stack); set to \`true\` to flatten hierarchical categories.
- Read by chart-reader (surfaces only when wire is explicit true), written by chart-builder at the schema-required last position inside \`<c:catAx>\`.

## Test plan
- [x] New round-trip test in \`test/fn-chart-readback.test.ts\` covering \`true\`.
- [x] \`pnpm test\` — 935 passing (was 934), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)