### PR TITLE
site(playground): add notes-length badge to per-slide row

### DIFF
--- a/.changeset/site-notes-badge.md
+++ b/.changeset/site-notes-badge.md
@@ -1,0 +1,9 @@
+---
+'pptx-kit-site': patch
+---
+
+site(playground): add a `notes` count badge to each slide row when
+speaker notes are authored. Same character-count as the existing
+expanded notes details, but visible without clicking into the
+disclosure — pairs naturally with the chart / table / link / media
+badges added recently.

--- a/site/src/routes/playground/+page.svelte
+++ b/site/src/routes/playground/+page.svelte
@@ -309,6 +309,7 @@
             {#if s.tableCount > 0}<span class="s-badge" title="number of <p:graphicFrame> table shapes on the slide">{s.tableCount} table</span>{/if}
             {#if s.hyperlinkCount > 0}<span class="s-badge" title="shapes whose text body carries an <a:hlinkClick>">{s.hyperlinkCount} link</span>{/if}
             {#if s.mediaCount > 0}<span class="s-badge" title="number of media parts (images / audio / video) the slide references">{s.mediaCount} media</span>{/if}
+            {#if s.notes && s.notes.length > 0}<span class="s-badge" title="speaker notes character count">{s.notes.length} notes</span>{/if}
             <span class="s-len">{s.textLength} chars · {s.shapeKinds.length} shapes</span>
           </div>
           <div class="s-canvas">


### PR DESCRIPTION
## Summary
- Adds a \`notes\` count badge to each slide row when speaker notes are authored.
- Shows the character count without requiring the existing details disclosure to be expanded.
- Pairs with the chart / table / link / media badges added recently.

## Test plan
- [x] \`pnpm test\` — 935 passing.
- [x] \`pnpm exec svelte-check\` clean.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)