### PR TITLE
feat: findShapesByName now accepts RegExp

### DIFF
--- a/.changeset/find-shapes-by-name-regex.md
+++ b/.changeset/find-shapes-by-name-regex.md
@@ -1,0 +1,8 @@
+---
+'pptx-kit': minor
+---
+
+feat: `findShapesByName(slide, name)` now accepts a `RegExp` as well
+as a literal string. Useful when template-cloned shapes share a
+prefix (`'TextPlaceholder1'`, `'TextPlaceholder2'`, …). Backward
+compatible — string callers still get exact-equality matching.

--- a/src/api/fn/shape-slide-read.ts
+++ b/src/api/fn/shape-slide-read.ts
@@ -267,9 +267,21 @@ export const findShapeById = (slide: SlideData, id: number): SlideShapeData | nu
   return null;
 };
 
-/** Every shape on the slide whose `cNvPr@name` equals `name`. */
-export const findShapesByName = (slide: SlideData, name: string): ReadonlyArray<SlideShapeData> =>
-  slide[SLIDE_SHAPES].filter((s) => s[SHAPE_SNAPSHOT].name === name);
+/**
+ * Every shape on the slide whose `cNvPr@name` matches `name`. Accepts
+ * either a literal string (exact-equality, case-sensitive) or a
+ * `RegExp` for pattern matches — useful when template-cloned shapes
+ * share a prefix (`'TextPlaceholder1'`, `'TextPlaceholder2'`, …).
+ */
+export const findShapesByName = (
+  slide: SlideData,
+  name: string | RegExp,
+): ReadonlyArray<SlideShapeData> => {
+  if (typeof name === 'string') {
+    return slide[SLIDE_SHAPES].filter((s) => s[SHAPE_SNAPSHOT].name === name);
+  }
+  return slide[SLIDE_SHAPES].filter((s) => name.test(s[SHAPE_SNAPSHOT].name));
+};
 
 /**
  * First shape on the slide whose visible text matches `needle`

--- a/test/fn-find-shapes-by-name-regex.test.ts
+++ b/test/fn-find-shapes-by-name-regex.test.ts
@@ -1,0 +1,59 @@
+// `findShapesByName(slide, RegExp)` — pattern-match variant.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  addSlideTextBox,
+  findShapesByName,
+  getShapeName,
+  getSlides,
+  inches,
+  loadPresentation,
+  renameShape,
+} from '../src/api/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+describe('fn API: findShapesByName (RegExp)', () => {
+  it('matches every shape whose name fits the pattern', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    for (const i of [1, 2, 3]) {
+      const tb = addSlideTextBox(slide, {
+        x: inches(0),
+        y: inches(i - 1),
+        w: inches(2),
+        h: inches(1),
+        text: `t${i}`,
+      });
+      renameShape(tb, `BrandPlaceholder${i}`);
+    }
+    addSlideTextBox(slide, {
+      x: inches(0),
+      y: inches(4),
+      w: inches(2),
+      h: inches(1),
+      text: 'ignored',
+    });
+    const matches = findShapesByName(slide, /^BrandPlaceholder\d+$/);
+    expect(matches.length).toBe(3);
+    expect(matches.every((m) => /^BrandPlaceholder\d+$/.test(getShapeName(m)))).toBe(true);
+  });
+
+  it('still matches exact strings (backwards-compat)', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const tb = addSlideTextBox(slide, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(2),
+      h: inches(1),
+      text: 't',
+    });
+    renameShape(tb, 'OnlyMe');
+    const matches = findShapesByName(slide, 'OnlyMe');
+    expect(matches.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- \`findShapesByName(slide, name)\` now accepts a \`RegExp\` as well as a literal string.
- Useful when template-cloned shapes share a prefix (e.g. \`'TextPlaceholder1'\`, \`'TextPlaceholder2'\`, …).
- Backward compatible — string callers still get exact-equality matching.

## Test plan
- [x] 2 new tests in \`test/fn-find-shapes-by-name-regex.test.ts\` covering the regex match and the unchanged string-match path.
- [x] \`pnpm test\` — 939 passing (was 937), 22 skipped.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)