### PR TITLE
feat: findShapeByName accepts RegExp

### DIFF
--- a/.changeset/find-shape-by-name-regex.md
+++ b/.changeset/find-shape-by-name-regex.md
@@ -1,0 +1,8 @@
+---
+'pptx-kit': minor
+---
+
+feat: `findShapeByName(slide, name)` now accepts a `RegExp` as well
+as a literal string. Mirrors the RegExp support just landed on
+`findShapesByName` (multi-match). Returns the first match in document
+order; backward compatible with existing string callers.

--- a/src/api/fn/shape-slide-read.ts
+++ b/src/api/fn/shape-slide-read.ts
@@ -243,13 +243,20 @@ export const findSlidePlaceholders = (
 };
 
 /**
- * First shape on the slide whose `cNvPr@name` equals `name`, or `null`
- * if none. Use the multi-match variant when more than one shape can
- * share the same name (common with template-cloned shapes).
+ * First shape on the slide whose `cNvPr@name` matches `name`. Accepts
+ * either a literal string (exact-equality) or a `RegExp` for pattern
+ * matches — mirroring `findShapeByText`. Returns `null` when nothing
+ * matches.
  */
-export const findShapeByName = (slide: SlideData, name: string): SlideShapeData | null => {
+export const findShapeByName = (slide: SlideData, name: string | RegExp): SlideShapeData | null => {
+  if (typeof name === 'string') {
+    for (const shape of slide[SLIDE_SHAPES]) {
+      if (shape[SHAPE_SNAPSHOT].name === name) return shape;
+    }
+    return null;
+  }
   for (const shape of slide[SLIDE_SHAPES]) {
-    if (shape[SHAPE_SNAPSHOT].name === name) return shape;
+    if (name.test(shape[SHAPE_SNAPSHOT].name)) return shape;
   }
   return null;
 };


### PR DESCRIPTION
## Summary
- \`findShapeByName(slide, name)\` now accepts a \`RegExp\` as well as a literal string.
- Mirrors the multi-match \`findShapesByName\` RegExp support that landed in the previous PR.
- Returns the first match in document order; backward compatible with existing string callers.

## Test plan
- [x] \`pnpm test\` — 939 passing.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)