### PR TITLE
feat: findSlideByTitle accepts RegExp

### DIFF
--- a/.changeset/find-slide-by-title-regex.md
+++ b/.changeset/find-slide-by-title-regex.md
@@ -1,0 +1,8 @@
+---
+'pptx-kit': minor
+---
+
+feat: `findSlideByTitle(pres, title)` now accepts a `RegExp` as well
+as a literal string. Pairs the RegExp support on
+`findSlidesByText` / `findShapeByName` / `findCommentsByAuthor`.
+Backward compatible — string callers still get exact-equality.

--- a/src/api/fn/slide-query.ts
+++ b/src/api/fn/slide-query.ts
@@ -327,13 +327,19 @@ export const getSlidesByLayout = (
 /**
  * Returns the first slide whose title-placeholder text equals
  * `title` exactly. Returns `null` when no slide matches. Different
- * from `findSlideByText`, which matches any visible text via
- * substring / regex — this one is a strict equality match against
- * the title placeholder only.
+ * from `findSlideByText`, which matches any visible text — this one
+ * is title-placeholder-scoped. Accepts a literal string (exact
+ * equality) or a `RegExp` for pattern matches.
  */
-export const findSlideByTitle = (pres: PresentationData, title: string): SlideData | null => {
+export const findSlideByTitle = (
+  pres: PresentationData,
+  title: string | RegExp,
+): SlideData | null => {
   for (const slide of getSlides(pres)) {
-    if (getSlideTitle(slide) === title) return slide;
+    const t = getSlideTitle(slide);
+    if (t === null) continue;
+    const hit = typeof title === 'string' ? t === title : title.test(t);
+    if (hit) return slide;
   }
   return null;
 };


### PR DESCRIPTION
## Summary
- \`findSlideByTitle(pres, title)\` now accepts a \`RegExp\` as well as a literal string.
- Pairs the RegExp support on \`findSlidesByText\` / \`findShapeByName\` / \`findCommentsByAuthor\`.
- Backward compatible — string callers still get exact-equality.

## Test plan
- [x] \`pnpm test\` — 939 passing.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)