### PR TITLE
feat: more name-based finders accept RegExp

### DIFF
--- a/.changeset/more-name-finders-regex.md
+++ b/.changeset/more-name-finders-regex.md
@@ -1,0 +1,10 @@
+---
+'pptx-kit': minor
+---
+
+feat: more name-based finders now accept `RegExp` —
+`findSlideLayout(pres, name)`,
+`findCommentAuthorByName(pres, authorName)`, and
+`findSlidesByLayoutName(pres, layoutName)`. Pairs the RegExp support
+recently added to `findShapeByName` / `findShapesByName` /
+`findCommentsByAuthor` / `findSlideByTitle`. String callers unchanged.

--- a/src/api/fn/comments.ts
+++ b/src/api/fn/comments.ts
@@ -235,17 +235,19 @@ export const getPresentationCommentCountsBySlide = (
 
 /**
  * Looks up a `CommentAuthor` from `commentAuthors.xml` by display
- * name (case-sensitive equality). Returns `null` when no author has
- * that name. Sibling of `findCommentsByAuthor` — the latter returns
- * the matching comments; this returns the author handle for
- * downstream metadata reads (id, initials, color).
+ * name. Accepts a literal string (exact equality) or a `RegExp` for
+ * pattern matches. Returns `null` when no author matches. Sibling of
+ * `findCommentsByAuthor` — the latter returns the matching comments;
+ * this returns the author handle for downstream metadata reads (id,
+ * initials, color).
  */
 export const findCommentAuthorByName = (
   pres: PresentationData,
-  authorName: string,
+  authorName: string | RegExp,
 ): CommentAuthor | null => {
   for (const a of getCommentAuthors(pres)) {
-    if (a.name === authorName) return a;
+    const hit = typeof authorName === 'string' ? a.name === authorName : authorName.test(a.name);
+    if (hit) return a;
   }
   return null;
 };

--- a/src/api/fn/layouts.ts
+++ b/src/api/fn/layouts.ts
@@ -101,11 +101,18 @@ export const getSlideLayoutPlaceholders = (
 
 /**
  * Finds the first slide layout whose user-visible name matches `name`,
- * or `null` if none does. Convenience over `getSlideLayouts(...).find(...)`.
+ * or `null` if none does. Accepts a literal string (exact equality)
+ * or a `RegExp` for pattern matches — useful when template providers
+ * suffix versions onto names (`'Title and Content v2'`).
  */
-export const findSlideLayout = (pres: PresentationData, name: string): SlideLayoutData | null => {
+export const findSlideLayout = (
+  pres: PresentationData,
+  name: string | RegExp,
+): SlideLayoutData | null => {
   for (const layout of getSlideLayouts(pres)) {
-    if (layout[LAYOUT_PART].name === name) return layout;
+    const n = layout[LAYOUT_PART].name;
+    const hit = typeof name === 'string' ? n === name : name.test(n);
+    if (hit) return layout;
   }
   return null;
 };

--- a/src/api/fn/shape-image-effects.ts
+++ b/src/api/fn/shape-image-effects.ts
@@ -190,12 +190,16 @@ export const findShapesOutsideCanvas = (
  */
 export const findSlidesByLayoutName = (
   pres: PresentationData,
-  layoutName: string,
+  layoutName: string | RegExp,
 ): ReadonlyArray<SlideData> => {
+  const matches =
+    typeof layoutName === 'string'
+      ? (n: string) => n === layoutName
+      : (n: string) => layoutName.test(n);
   const out: SlideData[] = [];
   for (const slide of getSlides(pres)) {
     const layout = getSlideLayout(slide);
-    if (layout !== null && getSlideLayoutName(layout) === layoutName) out.push(slide);
+    if (layout !== null && matches(getSlideLayoutName(layout))) out.push(slide);
   }
   return out;
 };


### PR DESCRIPTION
## Summary
Three more name-based finders accept \`RegExp\` alongside the literal-string form:

- \`findSlideLayout(pres, name)\`
- \`findCommentAuthorByName(pres, authorName)\`
- \`findSlidesByLayoutName(pres, layoutName)\`

Pairs the RegExp support added to \`findShapeByName\` / \`findShapesByName\` / \`findCommentsByAuthor\` / \`findSlideByTitle\` in the last few PRs. String callers unchanged (backward compatible).

## Test plan
- [x] \`pnpm test\` — 939 passing.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)