### PR TITLE
feat: findShapeInPresentation accepts RegExp

### DIFF
--- a/.changeset/find-shape-in-presentation-regex.md
+++ b/.changeset/find-shape-in-presentation-regex.md
@@ -1,0 +1,8 @@
+---
+'pptx-kit': minor
+---
+
+feat: `findShapeInPresentation(pres, name)` now accepts a `RegExp` as
+well as a literal string. Mirrors the RegExp support on the
+slide-scoped `findShapeByName`. Backward compatible — string callers
+still get exact-equality.

--- a/src/api/fn/shape-slide-read.ts
+++ b/src/api/fn/shape-slide-read.ts
@@ -418,11 +418,13 @@ export const getShapeIndex = (shape: SlideShapeData): number => {
 
 /**
  * Walks every slide and returns the first shape whose name matches.
+ * Accepts a literal string (exact equality) or a `RegExp` for
+ * pattern matches — same shape as `findShapeByName` but deck-scoped.
  * Useful for "find the logo placeholder anywhere in the deck."
  */
 export const findShapeInPresentation = (
   pres: PresentationData,
-  name: string,
+  name: string | RegExp,
 ): SlideShapeData | null => {
   for (const slide of getSlides(pres)) {
     const hit = findShapeByName(slide, name);


### PR DESCRIPTION
## Summary
- \`findShapeInPresentation(pres, name)\` now accepts a \`RegExp\` as well as a literal string.
- Mirrors the slide-scoped \`findShapeByName\`'s RegExp support landed earlier.
- Backward compatible — string callers still get exact-equality.

## Test plan
- [x] \`pnpm test\` — 939 passing.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)