### PR TITLE
site(playground): chart-kind counts cell in summary panel

### DIFF
--- a/.changeset/site-chart-kind-counts-panel.md
+++ b/.changeset/site-chart-kind-counts-panel.md
@@ -1,0 +1,8 @@
+---
+'pptx-kit-site': patch
+---
+
+site(playground): surface chart-kind counts in the summary panel.
+When the deck has any charts, a new "chart kinds" row shows the
+counts per kind (e.g. `3 column · 2 pie · 1 line`). Built on the
+`getPresentationChartKindCounts` aggregator.

--- a/site/src/routes/playground/+page.svelte
+++ b/site/src/routes/playground/+page.svelte
@@ -8,6 +8,7 @@
   import {
     getCommentText,
     getCoreProperties,
+    getPresentationChartKindCounts,
     getPresentationSummary,
     getShapeHyperlink,
     getSlideCharts,
@@ -67,6 +68,7 @@
   let coreTitle = $state<string>('');
   let coreCreator = $state<string>('');
   let summary = $state<ReturnType<typeof getPresentationSummary> | null>(null);
+  let chartKindCounts = $state<ReturnType<typeof getPresentationChartKindCounts> | null>(null);
   let masterCount = $state<number>(0);
   let issues = $state<ReadonlyArray<ValidationIssue>>([]);
   let slides = $state<SlideSnapshot[]>([]);
@@ -83,6 +85,7 @@
       coreTitle = core?.title ?? '';
       coreCreator = core?.creator ?? '';
       summary = getPresentationSummary(pres);
+      chartKindCounts = getPresentationChartKindCounts(pres);
       masterCount = getSlideMasterCount(pres);
       issues = validatePresentation(pres);
       // Map section name → 1-based slide index of its first slide. We
@@ -272,6 +275,17 @@
               : ''}
           </span>
         </div>
+        {#if chartKindCounts && Object.values(chartKindCounts).some((n) => n > 0)}
+          <div class="cell">
+            <span class="label">chart kinds</span>
+            <span class="value">
+              {Object.entries(chartKindCounts)
+                .filter(([, n]) => n > 0)
+                .map(([k, n]) => `${n} ${k}`)
+                .join(' · ')}
+            </span>
+          </div>
+        {/if}
       {/if}
     </div>
 


### PR DESCRIPTION
## Summary
- Surfaces \`getPresentationChartKindCounts(pres)\` in the playground summary panel.
- Renders a "chart kinds" row when the deck has any charts (e.g. \`3 column · 2 pie · 1 line\`).
- Hidden when the deck has no charts so the panel doesn't get noisier than it needs to be.

## Test plan
- [x] \`pnpm test\` — 939 passing.
- [x] \`pnpm exec svelte-check\` clean.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)