### PR TITLE
site(playground): layout-type counts cell in summary panel

### DIFF
--- a/.changeset/site-layout-type-counts-panel.md
+++ b/.changeset/site-layout-type-counts-panel.md
@@ -1,0 +1,8 @@
+---
+'pptx-kit-site': patch
+---
+
+site(playground): show "layout types in use" in the summary panel
+when slides reference at least one typed layout. Built on the new
+`getSlideLayoutUsageCountsByType` aggregator; renders e.g.
+`3 title · 12 obj · 1 blank`.

--- a/site/src/routes/playground/+page.svelte
+++ b/site/src/routes/playground/+page.svelte
@@ -10,6 +10,7 @@
     getCoreProperties,
     getPresentationChartKindCounts,
     getPresentationSummary,
+    getSlideLayoutUsageCountsByType,
     getShapeHyperlink,
     getSlideCharts,
     getSlideMasterCount,
@@ -69,6 +70,7 @@
   let coreCreator = $state<string>('');
   let summary = $state<ReturnType<typeof getPresentationSummary> | null>(null);
   let chartKindCounts = $state<ReturnType<typeof getPresentationChartKindCounts> | null>(null);
+  let layoutTypeCounts = $state<ReturnType<typeof getSlideLayoutUsageCountsByType> | null>(null);
   let masterCount = $state<number>(0);
   let issues = $state<ReadonlyArray<ValidationIssue>>([]);
   let slides = $state<SlideSnapshot[]>([]);
@@ -86,6 +88,7 @@
       coreCreator = core?.creator ?? '';
       summary = getPresentationSummary(pres);
       chartKindCounts = getPresentationChartKindCounts(pres);
+      layoutTypeCounts = getSlideLayoutUsageCountsByType(pres);
       masterCount = getSlideMasterCount(pres);
       issues = validatePresentation(pres);
       // Map section name → 1-based slide index of its first slide. We
@@ -281,6 +284,16 @@
             <span class="value">
               {Object.entries(chartKindCounts)
                 .filter(([, n]) => n > 0)
+                .map(([k, n]) => `${n} ${k}`)
+                .join(' · ')}
+            </span>
+          </div>
+        {/if}
+        {#if layoutTypeCounts && Object.keys(layoutTypeCounts).length > 0}
+          <div class="cell">
+            <span class="label">layout types in use</span>
+            <span class="value">
+              {Object.entries(layoutTypeCounts)
                 .map(([k, n]) => `${n} ${k}`)
                 .join(' · ')}
             </span>


### PR DESCRIPTION
## Summary
- Surfaces \`getSlideLayoutUsageCountsByType(pres)\` in the playground summary panel.
- Renders e.g. \`3 title · 12 obj · 1 blank\`. Hidden when no typed layouts are in use.

## Test plan
- [x] \`pnpm test\` — 939 passing.
- [x] \`pnpm exec svelte-check\` clean.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)