### PR TITLE
site(playground): comment-authors cell in summary panel

### DIFF
--- a/.changeset/site-comment-authors-panel.md
+++ b/.changeset/site-comment-authors-panel.md
@@ -1,0 +1,8 @@
+---
+'pptx-kit-site': patch
+---
+
+site(playground): show "comment authors" in the summary panel when
+the deck has any review comments. Entries are sorted by count desc
+and render as `Name (n) · …` — built on
+`getPresentationCommentCountsByAuthor`.

--- a/site/src/routes/playground/+page.svelte
+++ b/site/src/routes/playground/+page.svelte
@@ -9,6 +9,7 @@
     getCommentText,
     getCoreProperties,
     getPresentationChartKindCounts,
+    getPresentationCommentCountsByAuthor,
     getPresentationSummary,
     getSlideLayoutUsageCountsByType,
     getShapeHyperlink,
@@ -71,6 +72,9 @@
   let summary = $state<ReturnType<typeof getPresentationSummary> | null>(null);
   let chartKindCounts = $state<ReturnType<typeof getPresentationChartKindCounts> | null>(null);
   let layoutTypeCounts = $state<ReturnType<typeof getSlideLayoutUsageCountsByType> | null>(null);
+  let commentAuthorCounts = $state<ReturnType<typeof getPresentationCommentCountsByAuthor> | null>(
+    null,
+  );
   let masterCount = $state<number>(0);
   let issues = $state<ReadonlyArray<ValidationIssue>>([]);
   let slides = $state<SlideSnapshot[]>([]);
@@ -89,6 +93,7 @@
       summary = getPresentationSummary(pres);
       chartKindCounts = getPresentationChartKindCounts(pres);
       layoutTypeCounts = getSlideLayoutUsageCountsByType(pres);
+      commentAuthorCounts = getPresentationCommentCountsByAuthor(pres);
       masterCount = getSlideMasterCount(pres);
       issues = validatePresentation(pres);
       // Map section name → 1-based slide index of its first slide. We
@@ -295,6 +300,17 @@
             <span class="value">
               {Object.entries(layoutTypeCounts)
                 .map(([k, n]) => `${n} ${k}`)
+                .join(' · ')}
+            </span>
+          </div>
+        {/if}
+        {#if commentAuthorCounts && Object.keys(commentAuthorCounts).length > 0}
+          <div class="cell">
+            <span class="label">comment authors</span>
+            <span class="value">
+              {Object.entries(commentAuthorCounts)
+                .sort(([, a], [, b]) => b - a)
+                .map(([k, n]) => `${k} (${n})`)
                 .join(' · ')}
             </span>
           </div>


### PR DESCRIPTION
## Summary
- Surfaces \`getPresentationCommentCountsByAuthor(pres)\` in the playground summary panel.
- Renders entries sorted by count desc, formatted as \`Alice (12) · Bob (3)\`.
- Hidden when the deck has no comments.

## Test plan
- [x] \`pnpm test\` — 939 passing.
- [x] \`pnpm exec svelte-check\` clean.
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec oxlint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)