### PR TITLE
fix: text boxes no longer inherit the master body text size

### DIFF
--- a/.changeset/nonplaceholder-text-size.md
+++ b/.changeset/nonplaceholder-text-size.md
@@ -1,0 +1,11 @@
+---
+'pptx-kit': patch
+---
+
+fix: `getShapeRunFormatEffective` / `getParagraphPropertiesEffective` no longer
+inherit the slide master's `bodyStyle` for plain text boxes. A shape without a
+`<p:ph>` is not a placeholder, so its unsized runs now resolve to no inherited
+size (consumers apply the ~18pt text-box default) instead of wrongly picking up
+the master body size (often much larger). Real placeholders — including ones
+whose `<p:ph>` omits a `type` — still inherit as before. This makes effective
+text formatting match what PowerPoint and LibreOffice render for text boxes.

--- a/src/api/fn/shape-paragraph.ts
+++ b/src/api/fn/shape-paragraph.ts
@@ -144,6 +144,24 @@ const extractPlaceholderLstStyle = (placeholderEl: XmlElement): XmlElement | nul
   return firstChildElement(txBody, NAME_A_LST_STYLE);
 };
 
+const NAME_P_NV_SP_PR = qname('p', 'nvSpPr', NS.pml);
+const NAME_P_NV_PR = qname('p', 'nvPr', NS.pml);
+const NAME_P_PH = qname('p', 'ph', NS.pml);
+
+// A shape participates in placeholder inheritance only when it actually carries
+// a `<p:ph>`. A plain text box (no `<p:ph>`) must NOT inherit the slide master's
+// titleStyle / bodyStyle / otherStyle — PowerPoint resolves it against the
+// presentation's default text style (≈18pt), not the master body style.
+// `getShapePlaceholderType()` returns null both for "placeholder with no type"
+// (which DOES default to body) and "not a placeholder at all" (which does not),
+// so we must check for the element directly to tell them apart.
+const shapeIsPlaceholder = (shape: SlideShapeData): boolean => {
+  const nvSpPr = firstChildElement(shape[SHAPE_ELEMENT], NAME_P_NV_SP_PR);
+  if (!nvSpPr) return false;
+  const nvPr = firstChildElement(nvSpPr, NAME_P_NV_PR);
+  return nvPr !== null && firstChildElement(nvPr, NAME_P_PH) !== null;
+};
+
 const masterTxStyleFor = (masterRoot: XmlElement, phType: string | null): XmlElement | null => {
   const txStyles = firstChildElement(masterRoot, NAME_P_TX_STYLES);
   if (!txStyles) return null;
@@ -229,11 +247,16 @@ export const getShapeRunFormatEffective = (
 
   const phIdx = getShapePlaceholderIdx(shape);
   const phType = getShapePlaceholderType(shape);
+  const isPlaceholder = shapeIsPlaceholder(shape);
 
   const slide = shape[SHAPE_SLIDE];
   const layout = getSlideLayout(slide);
 
-  if (layout) {
+  // Steps 5-6 are placeholder inheritance: skip them entirely for non-
+  // placeholder shapes (plain text boxes), which do not read the master's
+  // txStyles. Without this guard an unsized text-box run wrongly inherits the
+  // master body size (e.g. 32pt) instead of the ~18pt text-box default.
+  if (layout && isPlaceholder) {
     // 5. Matching placeholder on the layout — both its inline rPr-bearing
     //    paragraph children (if the layout authored prompt text) and its
     //    own lstStyle.
@@ -490,10 +513,13 @@ export const getParagraphPropertiesEffective = (
 
   const phIdx = getShapePlaceholderIdx(shape);
   const phType = getShapePlaceholderType(shape);
+  const isPlaceholder = shapeIsPlaceholder(shape);
   const slide = shape[SHAPE_SLIDE];
   const layout = getSlideLayout(slide);
 
-  if (layout) {
+  // Placeholder inheritance only: a plain text box does not read the master's
+  // txStyles for paragraph defaults (align / indent / spacing) either.
+  if (layout && isPlaceholder) {
     // 3. Layout placeholder lstStyle.
     const layoutPh = findPlaceholderShapeIn(layout[LAYOUT_PART].shapes, phIdx, phType);
     if (layoutPh) {

--- a/test/fn-run-format-effective.test.ts
+++ b/test/fn-run-format-effective.test.ts
@@ -86,4 +86,27 @@ describe('fn API: getShapeRunFormatEffective', () => {
     expect(fmt.font).toBeDefined();
     expect(fmt.font!.startsWith('+')).toBe(false);
   });
+
+  it('does NOT inherit the master body size for a plain text box', async () => {
+    // A text box (no <p:ph>) is not a placeholder, so it must not read the
+    // master's bodyStyle. An unsized run resolves to no size — the consumer
+    // applies the ~18pt text-box default — not the master body size (which can
+    // be much larger). Regression guard: previously phType===null conflated
+    // "text box" with "body placeholder" and leaked the master body size.
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const tb = addSlideTextBox(slide, {
+      x: inches(1),
+      y: inches(1),
+      w: inches(4),
+      h: inches(1),
+      text: 'unsized',
+    });
+    expect(getShapeRunFormat(tb, 0, 0)?.size).toBeUndefined();
+    const fmt = getShapeRunFormatEffective(pres, tb, 0, 0);
+    expect(fmt.size).toBeUndefined();
+    // Font still resolves via the theme fontScheme fallback (not placeholder
+    // inheritance), so this stays defined.
+    expect(fmt.font).toBe('Calibri');
+  });
 });


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

`getShapeRunFormatEffective` and `getParagraphPropertiesEffective` wrongly inherited the slide master's `bodyStyle` for **plain text boxes**. A shape without a `<p:ph>` is not a placeholder and must not read the master's `titleStyle`/`bodyStyle`/`otherStyle`. The resolvers keyed placeholder inheritance on `getShapePlaceholderType()`, which is `null` both for a placeholder with no `type` (which *does* default to body) and for a non-placeholder text box (which does *not* inherit) — conflating the two. As a result, an unsized run in a text box resolved to the master body size (e.g. 32pt) instead of the ~18pt text-box default.

## Motivation

No issue — found via the preview-fidelity harness (#202): LibreOffice renders an unsized text-box run at 18pt, but `getShapeRunFormatEffective` reported 32pt. This is the cascade-correctness concern the foundation plan flags as load-bearing for "preserve formatting" on edit, so it matters beyond rendering.

## Changes

- Add an internal `shapeIsPlaceholder` check (presence of `<p:ph>` in the shape's `nvSpPr/nvPr`).
- Gate the layout + master placeholder/txStyles inheritance (steps 5–6) in **both** `getShapeRunFormatEffective` and `getParagraphPropertiesEffective` on it.
- Behavior change (read path): an unsized run / unset paragraph property in a plain text box now resolves to "no inherited value" (consumer applies the text-box default) instead of the master body value. Real placeholders — including those whose `<p:ph>` omits a `type` — are unaffected.

## Testing

- New regression test in `test/fn-run-format-effective.test.ts`: a text box's unsized run resolves to `size === undefined` (verified it fails — "expected 32 to be undefined" — without the fix), while the existing "placeholder inherits master title size" test still passes.
- Full suite green: `pnpm test` (950 tests), `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm build`.

## Breaking changes

None in API shape. Behavior of the two effective-resolver reads changes for non-placeholder text boxes as described; shipped as a patch since the previous result was incorrect. Flagged via changeset.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
