### PR TITLE
fix: apply ctrTitle/title placeholder equivalence in property inheritance

### DIFF
--- a/.changeset/placeholder-type-equivalence.md
+++ b/.changeset/placeholder-type-equivalence.md
@@ -1,0 +1,11 @@
+---
+'pptx-kit': patch
+---
+
+fix: placeholder inheritance now applies the OOXML `ctrTitle`↔`title` and
+`subTitle`→`body` type equivalence. A `ctrTitle` (centered title) now inherits
+its layout/master `title` placeholder's `bodyPr` (e.g. `anchor="ctr"`),
+`lstStyle`, and geometry instead of dropping them — fixing
+`getShapeBodyPrEffective`, `getShapeBoundsResolved`,
+`getShapeRunFormatEffective`, and `getParagraphPropertiesEffective` for
+centered titles and subtitles.

--- a/src/api/fn/shape-paragraph.ts
+++ b/src/api/fn/shape-paragraph.ts
@@ -10,7 +10,11 @@ import {
   runsOf,
 } from './shape-runs.ts';
 import { parseRPrLikeElement } from './shape-color.ts';
-import { getShapePlaceholderIdx, getShapePlaceholderType } from './shape-read-base.ts';
+import {
+  getShapePlaceholderIdx,
+  getShapePlaceholderType,
+  matchPlaceholderShape,
+} from './shape-read-base.ts';
 import { getSlideLayout } from './shape-slide-read.ts';
 import {
   type ParagraphAlignment,
@@ -130,13 +134,7 @@ const findPlaceholderShapeIn = (
   }>,
   phIdx: number | null,
   phType: string | null,
-): { element: XmlElement } | undefined => {
-  let match = phIdx !== null ? shapes.find((s) => s.placeholderIdx === phIdx) : undefined;
-  if (!match && phType !== null) {
-    match = shapes.find((s) => s.placeholderType === phType);
-  }
-  return match;
-};
+): { element: XmlElement } | undefined => matchPlaceholderShape(shapes, phIdx, phType);
 
 const extractPlaceholderLstStyle = (placeholderEl: XmlElement): XmlElement | null => {
   const txBody = firstChildElement(placeholderEl, NAME_P_TX_BODY_PML);

--- a/src/api/fn/shape-read-base.ts
+++ b/src/api/fn/shape-read-base.ts
@@ -492,6 +492,45 @@ export const getShapeBounds = (shape: SlideShapeData): ShapeBounds | null => {
 };
 
 /**
+ * OOXML placeholder-type equivalence for inheritance. A `ctrTitle` inherits
+ * from a `title` placeholder (and vice versa), and a `subTitle` from `body` —
+ * so a centered title on a title-slide layout still picks up the master title
+ * placeholder's bodyPr / lstStyle / geometry. Returns the acceptable
+ * layout/master placeholder types for `phType`, most specific first.
+ */
+export const placeholderTypeCandidates = (phType: string | null): string[] => {
+  if (phType === null) return [];
+  if (phType === 'ctrTitle') return ['ctrTitle', 'title'];
+  if (phType === 'title') return ['title', 'ctrTitle'];
+  if (phType === 'subTitle') return ['subTitle', 'body'];
+  return [phType];
+};
+
+/**
+ * Finds the layout/master placeholder shape that `(phIdx, phType)` inherits
+ * from: match by `<p:ph idx>` first, then by `<p:ph type>` using the
+ * equivalence above. Shared by the bounds / bodyPr / rPr / pPr resolvers so
+ * they agree on what a placeholder inherits.
+ */
+export const matchPlaceholderShape = <
+  T extends { placeholderIdx: number | null; placeholderType: string | null },
+>(
+  shapes: ReadonlyArray<T>,
+  phIdx: number | null,
+  phType: string | null,
+): T | undefined => {
+  if (phIdx !== null) {
+    const byIdx = shapes.find((s) => s.placeholderIdx === phIdx);
+    if (byIdx) return byIdx;
+  }
+  for (const t of placeholderTypeCandidates(phType)) {
+    const byType = shapes.find((s) => s.placeholderType === t);
+    if (byType) return byType;
+  }
+  return undefined;
+};
+
+/**
  * Same as `getShapeBounds` but walks the placeholder inheritance chain
  * when the shape has no `<a:xfrm>` of its own:
  *
@@ -528,10 +567,7 @@ export const getShapeBoundsResolved = (
       kind: ShapeKind;
     }>,
   ): ShapeBounds | null => {
-    let match = phIdx !== null ? shapes.find((s) => s.placeholderIdx === phIdx) : undefined;
-    if (!match && phType !== null) {
-      match = shapes.find((s) => s.placeholderType === phType);
-    }
+    const match = matchPlaceholderShape(shapes, phIdx, phType);
     if (!match) return null;
     const pos = readPosition(match.element, match.kind);
     const size = readSize(match.element, match.kind);

--- a/src/api/fn/shape-text.ts
+++ b/src/api/fn/shape-text.ts
@@ -1,6 +1,10 @@
 // Shape mutation: text body, autofit, margins, wrap, anchor.
 
-import { getShapePlaceholderIdx, getShapePlaceholderType } from './shape-read-base.ts';
+import {
+  getShapePlaceholderIdx,
+  getShapePlaceholderType,
+  matchPlaceholderShape,
+} from './shape-read-base.ts';
 import { getSlideLayout } from './shape-slide-read.ts';
 import {
   type BulletStyle,
@@ -546,13 +550,7 @@ export const getShapeBodyPrEffective = (
       placeholderType: string | null;
       element: XmlElement;
     }>,
-  ): XmlElement | null => {
-    let match = phIdx !== null ? shapes.find((s) => s.placeholderIdx === phIdx) : undefined;
-    if (!match && phType !== null) {
-      match = shapes.find((s) => s.placeholderType === phType);
-    }
-    return match?.element ?? null;
-  };
+  ): XmlElement | null => matchPlaceholderShape(shapes, phIdx, phType)?.element ?? null;
 
   const layoutPhEl = findPh(layout[LAYOUT_PART].shapes);
   if (layoutPhEl) {

--- a/test/fn-placeholder-inheritance.test.ts
+++ b/test/fn-placeholder-inheritance.test.ts
@@ -1,0 +1,74 @@
+// Placeholder-type equivalence for inheritance. A `ctrTitle` must inherit from
+// a `title` placeholder (and `subTitle` from `body`) when walking the layout /
+// master cascade — otherwise a centered title on a title-slide layout drops the
+// master title placeholder's bodyPr (anchor), lstStyle and geometry. Regression
+// guard for the matcher shared by the bounds / bodyPr / rPr / pPr resolvers.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { matchPlaceholderShape, placeholderTypeCandidates } from '../src/api/fn/shape-read-base.ts';
+import {
+  addTitleSlide,
+  getShapeBodyPrEffective,
+  getShapePlaceholderType,
+  getSlideShapes,
+  loadPresentation,
+} from '../src/api/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+describe('placeholderTypeCandidates', () => {
+  it('treats ctrTitle/title and subTitle/body as equivalent', () => {
+    expect(placeholderTypeCandidates('ctrTitle')).toEqual(['ctrTitle', 'title']);
+    expect(placeholderTypeCandidates('title')).toEqual(['title', 'ctrTitle']);
+    expect(placeholderTypeCandidates('subTitle')).toEqual(['subTitle', 'body']);
+    expect(placeholderTypeCandidates('body')).toEqual(['body']);
+    expect(placeholderTypeCandidates('ftr')).toEqual(['ftr']);
+    expect(placeholderTypeCandidates(null)).toEqual([]);
+  });
+});
+
+describe('matchPlaceholderShape', () => {
+  const shape = (placeholderType: string | null, placeholderIdx: number | null = null) => ({
+    placeholderType,
+    placeholderIdx,
+  });
+
+  it('matches by idx before type', () => {
+    const shapes = [shape('title', 1), shape('body', 2)];
+    expect(matchPlaceholderShape(shapes, 2, 'title')?.placeholderType).toBe('body');
+  });
+
+  it('falls back from ctrTitle to a title placeholder', () => {
+    const shapes = [shape('title'), shape('body')];
+    expect(matchPlaceholderShape(shapes, null, 'ctrTitle')?.placeholderType).toBe('title');
+  });
+
+  it('prefers the exact type over the equivalent one', () => {
+    const shapes = [shape('title'), shape('ctrTitle')];
+    expect(matchPlaceholderShape(shapes, null, 'ctrTitle')?.placeholderType).toBe('ctrTitle');
+  });
+
+  it('falls back from subTitle to body', () => {
+    const shapes = [shape('body')];
+    expect(matchPlaceholderShape(shapes, null, 'subTitle')?.placeholderType).toBe('body');
+  });
+
+  it('returns undefined when nothing matches', () => {
+    expect(matchPlaceholderShape([shape('ftr')], null, 'ctrTitle')).toBeUndefined();
+  });
+});
+
+describe('ctrTitle inherits the master title bodyPr', () => {
+  it('resolves the centered-title vertical anchor from the master title placeholder', async () => {
+    const pres = await loadPresentation(await readFile(fixture('blank.pptx')));
+    const slide = addTitleSlide(pres, 'Hello');
+    const ctr = getSlideShapes(slide).find((s) => getShapePlaceholderType(s) === 'ctrTitle');
+    expect(ctr).toBeDefined();
+    // The master title placeholder carries anchor="ctr"; a ctrTitle must inherit
+    // it (it returned null before the placeholder-type equivalence fix).
+    expect(getShapeBodyPrEffective(pres, ctr!).anchor).toBe('center');
+  });
+});


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Placeholder inheritance now applies the OOXML placeholder-type equivalence (`ctrTitle`↔`title`, `subTitle`→`body`). A centered title (`ctrTitle`) on a title-slide layout was matched only by exact `<p:ph type>`, so it never found the master's `title` placeholder and dropped its `bodyPr` (`anchor="ctr"`), `lstStyle`, and geometry — rendering top-anchored instead of vertically centered.

## Motivation

No issue — found via the preview-fidelity harness: a `ctrTitle`'s `getShapeBodyPrEffective(...).anchor` resolved to `null` (→ rendered at the box top) when the master `title` placeholder authored `anchor="ctr"`. This is the same class of placeholder-matching bug as #203 and affects every effective-property reader.

## Changes

- New shared `matchPlaceholderShape()` + `placeholderTypeCandidates()` in `shape-read-base.ts` (internal; not added to the public surface) implementing the equivalence: match by `<p:ph idx>` first, then by type with `ctrTitle↔title` / `subTitle→body` fallbacks (exact type preferred).
- Used in all four placeholder-matching resolvers, which previously each did exact-type matching: `getShapeBoundsResolved`, `getShapeBodyPrEffective`, `getShapeRunFormatEffective`, `getParagraphPropertiesEffective`.

## Testing

- New `test/fn-placeholder-inheritance.test.ts` (7): unit tests for the matcher/equivalence + an integration test that a `ctrTitle` inherits the master title `anchor="ctr"` (returned `null` before this fix).
- Full suite green: `pnpm test` (972), `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm build`.
- Preview-fidelity harness vs LibreOffice 26.2: `02-layouts` 0.44→0.57 (centered titles/subtitles now aligned), overall fg-SSIM 0.66→0.68, no regression.

## Breaking changes

None in API shape. The four effective-property reads now return inherited values for `ctrTitle`/`subTitle` where they previously returned defaults; shipped as a patch since the previous result was incorrect. Flagged via changeset.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [ ] If this is a breaking change, I have added a changeset / CHANGELOG entry and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
