### PR TITLE
feat: isShapeTextBox + center autoshape text by default in preview

### DIFF
--- a/.changeset/is-shape-textbox.md
+++ b/.changeset/is-shape-textbox.md
@@ -1,0 +1,8 @@
+---
+'pptx-kit': minor
+---
+
+feat: add `isShapeTextBox(shape)` — `true` when a shape is a text box
+(`<p:cNvSpPr txBox="1">`) rather than an autoshape. The two have different
+default text formatting (text boxes left/top, autoshapes center/middle), so
+renderers and layout code need to tell them apart.

--- a/.changeset/preview-autoshape-align.md
+++ b/.changeset/preview-autoshape-align.md
@@ -1,0 +1,8 @@
+---
+'pptx-kit-site': patch
+---
+
+site(preview): autoshape text with no authored alignment now centers
+horizontally and anchors middle (matching PowerPoint/LibreOffice), while text
+boxes and placeholder bodies keep left/top. Fixes shape labels rendering at the
+shape's left edge instead of centered.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -122,6 +122,8 @@ import {
   getTableRowHeights,
   isChartShape,
   isShapeImageGrayscale,
+  isShapePlaceholder,
+  isShapeTextBox,
   isTableShape,
   type PresentationData,
   type PresentationTheme,
@@ -2263,7 +2265,15 @@ const renderTextBody = (
       margins: getShapeTextMargins(shape) ?? { left: null, top: null, right: null, bottom: null },
     };
   }
-  const anchor = effectiveBody.anchor ?? 'top';
+  // Default text alignment depends on the shape kind, matching PowerPoint /
+  // LibreOffice: autoshapes (preset geometry that is neither a placeholder nor
+  // a text box) center text horizontally and anchor it middle by default,
+  // whereas text boxes and placeholder bodies default to left / top. Authored
+  // algn / anchor still win.
+  const isAutoshape = !isShapePlaceholder(shape) && !isShapeTextBox(shape);
+  const defaultAlign = isAutoshape ? 'center' : 'left';
+  const defaultAnchor: 'top' | 'center' | 'bottom' = isAutoshape ? 'center' : 'top';
+  const anchor = effectiveBody.anchor ?? defaultAnchor;
   const margins = effectiveBody.margins;
   const lIns = margins.left ?? DEFAULT_INSET_X;
   const tIns = margins.top ?? DEFAULT_INSET_Y;
@@ -2303,7 +2313,7 @@ const renderTextBody = (
         rtl: null,
       };
     }
-    const align = effective.align ?? 'left';
+    const align = effective.align ?? defaultAlign;
     const level = effective.level;
     const bulletStyle = getParagraphBullet(shape, p);
     let bulletDetail: ReturnType<typeof getParagraphBulletStyle> = {

--- a/src/api/fn/shape-read-base.ts
+++ b/src/api/fn/shape-read-base.ts
@@ -380,6 +380,25 @@ export const isShapePlaceholder = (shape: SlideShapeData): boolean => {
   return snap.placeholderType !== null || snap.placeholderIdx !== null;
 };
 
+const NAME_P_NV_SP_PR = qname('p', 'nvSpPr', NS.pml);
+const NAME_P_C_NV_SP_PR = qname('p', 'cNvSpPr', NS.pml);
+const ATTR_TX_BOX = qname('', 'txBox', '');
+
+/**
+ * `true` when the shape is a **text box** (`<p:cNvSpPr txBox="1">`) rather than
+ * an autoshape. The distinction drives default text formatting: PowerPoint /
+ * LibreOffice left-align and top-anchor text-box text, but center-align and
+ * middle-anchor autoshape text when the deck author left those unset.
+ */
+export const isShapeTextBox = (shape: SlideShapeData): boolean => {
+  const nvSpPr = firstChildElement(shape[SHAPE_ELEMENT], NAME_P_NV_SP_PR);
+  if (!nvSpPr) return false;
+  const cNvSpPr = firstChildElement(nvSpPr, NAME_P_C_NV_SP_PR);
+  if (!cNvSpPr) return false;
+  const v = getAttrValue(cNvSpPr, ATTR_TX_BOX);
+  return v === '1' || v === 'true';
+};
+
 export const getShapeText = (shape: SlideShapeData): string => shape[SHAPE_SNAPSHOT].text;
 
 export const getShapePosition = (shape: SlideShapeData): Position | null =>

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -396,6 +396,7 @@ export {
   isShapeHidden,
   isShapeImageGrayscale,
   isShapePlaceholder,
+  isShapeTextBox,
   isSlideHidden,
   isTableShape,
   listPackageParts,

--- a/test/fn-is-shape-textbox.test.ts
+++ b/test/fn-is-shape-textbox.test.ts
@@ -1,0 +1,52 @@
+// `isShapeTextBox` — distinguishes a text box (`<p:cNvSpPr txBox="1">`) from an
+// autoshape. The distinction drives default text formatting (text boxes
+// left/top, autoshapes center/middle), so it must be reliable.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  addSlideShape,
+  addSlideTextBox,
+  addTitleSlide,
+  getShapePlaceholderType,
+  getSlideShapes,
+  getSlides,
+  inches,
+  isShapeTextBox,
+  loadPresentation,
+} from '../src/api/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+describe('fn API: isShapeTextBox', () => {
+  it('is true for a text box and false for an autoshape', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const tb = addSlideTextBox(slide, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(2),
+      h: inches(1),
+      text: 'box',
+    });
+    const shape = addSlideShape(slide, {
+      preset: 'rect',
+      x: inches(2),
+      y: inches(0),
+      w: inches(2),
+      h: inches(1),
+    });
+    expect(isShapeTextBox(tb)).toBe(true);
+    expect(isShapeTextBox(shape)).toBe(false);
+  });
+
+  it('is false for a placeholder', async () => {
+    const pres = await loadPresentation(await readFile(fixture('blank.pptx')));
+    const slide = addTitleSlide(pres, 'Hi');
+    const ctr = getSlideShapes(slide).find((s) => getShapePlaceholderType(s) === 'ctrTitle');
+    expect(ctr).toBeDefined();
+    expect(isShapeTextBox(ctr!)).toBe(false);
+  });
+});


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Autoshape text with no authored alignment now renders centered horizontally and anchored middle (matching PowerPoint/LibreOffice); text boxes and placeholder bodies keep left/top. Adds the `isShapeTextBox` reader the preview needs to tell them apart.

## Motivation

No issue — found via the preview-fidelity harness. Shape labels (e.g. on `05-preset-shapes`) were left-aligned at the shape's left edge while the ground truth centers them, because the renderer defaulted all unaligned text to left. PowerPoint/LibreOffice default *autoshape* text to center/middle; only text boxes default to left/top.

## Changes

- **core (new public API):** `isShapeTextBox(shape)` — `true` for `<p:cNvSpPr txBox="1">`, `false` for autoshapes/placeholders.
- **preview:** choose the default paragraph alignment and vertical anchor by shape kind — autoshape (neither placeholder nor text box) → center/middle; text box / placeholder → left/top. Authored `algn`/`anchor` still win.

## Testing

- New `test/fn-is-shape-textbox.test.ts` (text box vs autoshape vs placeholder).
- `pnpm test` (974), `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm build`, `pnpm --filter pptx-kit-site check` — all green.
- Harness vs LibreOffice 26.2: overall fg-SSIM 0.68 → 0.70; `05-preset-shapes` 0.38 → 0.61, `07-fills` 0.88 → 0.93, `13-zorder` 0.95 → 0.99; no per-slide regression.

## Breaking changes

None. `isShapeTextBox` is additive (minor). The preview default change only affects autoshape text that had no authored alignment.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [ ] If this is a breaking change, I have added a changeset / CHANGELOG entry and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
