### PR TITLE
site(preview): render zero-height/width connectors (lines & arrows)

### DIFF
--- a/.changeset/preview-zero-dim-connectors.md
+++ b/.changeset/preview-zero-dim-connectors.md
@@ -1,0 +1,8 @@
+---
+'pptx-kit-site': patch
+---
+
+site(preview): render horizontal and vertical connectors. Lines have a
+zero-height (horizontal) or zero-width (vertical) bounding box, which the
+shape renderer's degenerate-shape guard was discarding — so straight lines and
+arrows simply didn't appear. Connectors now render unless they are a true point.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -4636,9 +4636,12 @@ const renderShape = (
   const y = bounds.y as number;
   const w = bounds.w as number;
   const h = bounds.h as number;
-  if (w <= 0 || h <= 0) return '';
-
   const kind = getShapeKind(shape);
+  // Connectors (lines) are legitimately zero-height when horizontal or
+  // zero-width when vertical — only a true point (both zero) is degenerate.
+  // Every other shape with no area is invisible, so skip it.
+  if (kind === 'connector' ? w <= 0 && h <= 0 : w <= 0 || h <= 0) return '';
+
   const fill = getShapeFillEffective(pres, shape);
   const stroke = getShapeStrokeEffective(pres, shape);
   const rotation = getShapeRotation(shape);


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Horizontal and vertical connectors (straight lines / arrows) now render in the preview. They were silently dropped because their bounding box has a zero dimension.

## Motivation

No issue — found via the fidelity harness. `06-lines-arrows` rendered only its one diagonal arrow; the black line, red arrow, and dashed line (all horizontal, `h=0`) were missing.

## Changes

- `renderShape` skipped any shape with `w <= 0 || h <= 0`. A horizontal connector has `h=0` and a vertical one `w=0`, so the guard discarded them. Connectors are now exempt — only a true point (both dimensions zero) is skipped; other shapes keep the area guard.

## Testing

- `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm --filter pptx-kit-site check` green; `pnpm test` unaffected (renderer-internal change; validated by the harness).
- Harness vs LibreOffice 26.2: `06-lines-arrows` fg-SSIM 0.45 → 0.85 (the three horizontal lines now appear), overall 0.70 → 0.71, no per-slide regression.

## Breaking changes

None.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [ ] I have added or updated tests for the change. (Renderer-internal; covered by the fidelity harness — no unit-test seam without a full render pipeline.)
- [x] I have added or updated documentation where user-visible behavior changed.
- [ ] If this is a breaking change, I have added a changeset / CHANGELOG entry and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
