### PR TITLE
site(preview): keep text upright in flipped shapes

### DIFF
--- a/.changeset/preview-flip-text-upright.md
+++ b/.changeset/preview-flip-text-upright.md
@@ -1,0 +1,8 @@
+---
+'pptx-kit-site': patch
+---
+
+site(preview): keep text upright in flipped shapes. A shape's `flipH`/`flipV`
+mirrors its geometry but text should stay readable (as in PowerPoint); the
+preview was mirroring the text too. Text now follows the shape's rotation only,
+not its flips.

--- a/site/src/lib/playground/render-slide.ts
+++ b/site/src/lib/playground/render-slide.ts
@@ -4657,6 +4657,10 @@ const renderShape = (
   if (flip.horizontal) transforms.push(`translate(${E(2 * cx)} 0) scale(-1 1)`);
   if (flip.vertical) transforms.push(`translate(0 ${E(2 * cy)}) scale(1 -1)`);
   const transform = transforms.length > 0 ? ` transform="${transforms.join(' ')}"` : '';
+  // Text follows the shape's ROTATION but not its flips — PowerPoint mirrors a
+  // shape's geometry on flip while keeping its text upright and readable. So
+  // the text overlay gets a rotation-only transform.
+  const textTransform = rotation !== 0 ? ` transform="rotate(${rotation} ${E(cx)} ${E(cy)})"` : '';
 
   const textOverlay =
     kind === 'shape' || kind === 'graphicFrame'
@@ -4936,7 +4940,10 @@ const renderShape = (
   const a11yLabel = altTitle ?? altDesc ?? null;
   const nameAttr = shapeName ? ` data-pptx-shape-name="${escapeXml(shapeName)}"` : '';
   const ariaAttr = a11yLabel ? ` role="img" aria-label="${escapeXml(a11yLabel)}"` : '';
-  const inner = `${p.defs}${fxDefs}<g${transform}${nameAttr}${ariaAttr}>${geomSvg}${textOverlay}</g>`;
+  // Geometry carries rotation + flips; text carries rotation only so it stays
+  // upright when the shape is flipped (matching PowerPoint).
+  const placedText = textOverlay ? `<g${textTransform}>${textOverlay}</g>` : '';
+  const inner = `${p.defs}${fxDefs}<g${nameAttr}${ariaAttr}><g${transform}>${geomSvg}</g>${placedText}</g>`;
   const titleEl = tooltip ? `<title>${escapeXml(tooltip)}</title>` : '';
   if (url) {
     return `<a href="${escapeXml(url)}" target="_blank" rel="noopener noreferrer">${titleEl}${inner}</a>`;


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Text in a flipped shape now stays upright and readable. `flipH`/`flipV` mirrors a shape's geometry, but PowerPoint keeps the text readable — the preview was mirroring the text too (e.g. "flipH" rendered backwards, "flipV" upside down).

## Motivation

No issue — found via the fidelity harness (`12-geometry`). The text overlay shared the geometry's transform, which included the flips.

## Changes

- `renderShape`: split the transform — geometry keeps rotation + flips; the text overlay gets a rotation-only transform (so it rotates with the shape but is never mirrored).

## Testing

- `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm --filter pptx-kit-site check` green; `pnpm test` unaffected (renderer-internal; validated by the harness).
- Verified on `12-geometry`: "flipH"/"flipV" labels upright, "rot 30" still rotates with its arrow. Harness: no regression (overall fg-SSIM ~0.71).

## Breaking changes

None.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [ ] I have added or updated tests for the change. (Renderer-internal transform; covered by the fidelity harness — no unit-test seam without a full render.)
- [x] I have added or updated documentation where user-visible behavior changed.
- [ ] If this is a breaking change, I have added a changeset / CHANGELOG entry and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
