### PR TITLE
fix: cross-bundle identity for presentation handles

### DIFF
--- a/.changeset/cross-bundle-handle-identity.md
+++ b/.changeset/cross-bundle-handle-identity.md
@@ -1,0 +1,13 @@
+---
+'pptx-kit': patch
+---
+
+fix: presentation handles now interoperate across the `pptx-kit` and
+`pptx-kit/node` entry points. The two entries ship as separate bundles,
+and the opaque handles (`PresentationData`, `SlideData`, …) were keyed by
+plain `Symbol`s minted per bundle. Loading a deck with
+`loadPresentationFile` (from `pptx-kit/node`) and then reading it with,
+say, `getSlides` (from `pptx-kit`) crashed with
+`Cannot read properties of undefined`. The handle keys now use the global
+symbol registry (`Symbol.for`), so a handle from either entry is readable
+by the other — and by companion packages that bundle their own reader copy.

--- a/src/api/_internal-symbols.ts
+++ b/src/api/_internal-symbols.ts
@@ -2,6 +2,15 @@
 // returns (`PresentationData`, `SlideData`, `SlideShapeData`, etc.).
 // Defined in a dedicated module so importers never transitively pull
 // in heavy authoring code paths — readers stay light.
+//
+// These use `Symbol.for` (the process-global registry), NOT plain `Symbol`,
+// so the keys are identical across separately-bundled copies of this module.
+// The public entry (`pptx-kit` → dist/index.js) and the Node entry
+// (`pptx-kit/node` → dist/node.js) are distinct bundles, each with its own
+// copy of this file; companion packages (e.g. `@pptx-kit/preview`) hold a
+// third. With plain `Symbol` a handle built by one bundle is opaque to every
+// other — `getSlides(loadPresentationFile(...))` would read `undefined` and
+// crash. The `pptx-kit.` namespace keeps the registry keys collision-free.
 
 import type { PartName } from '../internal/opc/index.ts';
 import type { OpcPackage } from '../internal/parts/index.ts';
@@ -13,22 +22,22 @@ import type {
 } from '../internal/presentationml/index.ts';
 import type { XmlDocument, XmlElement } from '../internal/xml/index.ts';
 
-export const INTERNAL_PACKAGE = Symbol('pptx-kit.package');
-export const SLIDE_PART_NAME = Symbol('pptx-kit.slide.partName');
-export const SLIDE_DOCUMENT = Symbol('pptx-kit.slide.document');
-export const SLIDE_PART = Symbol('pptx-kit.slide.part');
-export const SLIDE_SHAPES = Symbol('pptx-kit.slide.shapes');
-export const SHAPE_SLIDE = Symbol('pptx-kit.shape.slide');
-export const SHAPE_ELEMENT = Symbol('pptx-kit.shape.element');
-export const SHAPE_SNAPSHOT = Symbol('pptx-kit.shape.snapshot');
-export const LAYOUT_PART_NAME = Symbol('pptx-kit.layout.partName');
-export const LAYOUT_PART = Symbol('pptx-kit.layout.part');
-export const COMMENT_SLIDE = Symbol('pptx-kit.comment.slide');
-export const COMMENT_SNAPSHOT = Symbol('pptx-kit.comment.snapshot');
-export const CELL_TABLE = Symbol('pptx-kit.cell.table');
-export const CELL_ELEMENT = Symbol('pptx-kit.cell.element');
-export const CELL_ROW = Symbol('pptx-kit.cell.row');
-export const CELL_COL = Symbol('pptx-kit.cell.col');
+export const INTERNAL_PACKAGE = Symbol.for('pptx-kit.package');
+export const SLIDE_PART_NAME = Symbol.for('pptx-kit.slide.partName');
+export const SLIDE_DOCUMENT = Symbol.for('pptx-kit.slide.document');
+export const SLIDE_PART = Symbol.for('pptx-kit.slide.part');
+export const SLIDE_SHAPES = Symbol.for('pptx-kit.slide.shapes');
+export const SHAPE_SLIDE = Symbol.for('pptx-kit.shape.slide');
+export const SHAPE_ELEMENT = Symbol.for('pptx-kit.shape.element');
+export const SHAPE_SNAPSHOT = Symbol.for('pptx-kit.shape.snapshot');
+export const LAYOUT_PART_NAME = Symbol.for('pptx-kit.layout.partName');
+export const LAYOUT_PART = Symbol.for('pptx-kit.layout.part');
+export const COMMENT_SLIDE = Symbol.for('pptx-kit.comment.slide');
+export const COMMENT_SNAPSHOT = Symbol.for('pptx-kit.comment.snapshot');
+export const CELL_TABLE = Symbol.for('pptx-kit.cell.table');
+export const CELL_ELEMENT = Symbol.for('pptx-kit.cell.element');
+export const CELL_ROW = Symbol.for('pptx-kit.cell.row');
+export const CELL_COL = Symbol.for('pptx-kit.cell.col');
 
 /**
  * Opaque handle to a loaded / created presentation. Constructed via

--- a/test/internal-handle-identity.test.ts
+++ b/test/internal-handle-identity.test.ts
@@ -1,0 +1,47 @@
+// The opaque-handle symbol keys MUST live in the process-global symbol
+// registry (`Symbol.for`), not be minted with plain `Symbol`. The library
+// ships as two separate bundles — `pptx-kit` (dist/index.js) and
+// `pptx-kit/node` (dist/node.js) — and companion packages (e.g.
+// `@pptx-kit/preview`) bundle a third copy of the reader code. A handle built
+// by one bundle is only readable by another if they agree on these keys; plain
+// `Symbol` mints a fresh key per bundle, so e.g. `getSlides` (index bundle)
+// would read `undefined` off a presentation from `loadPresentationFile` (node
+// bundle) and crash. `Symbol.for` makes the keys bundle-independent.
+//
+// This is a white-box guard: it reaches into the internal symbols module so a
+// regression (reverting to plain `Symbol`) fails fast, since the cross-bundle
+// scenario itself is awkward to reproduce inside a single vitest realm.
+
+import { describe, expect, it } from 'vitest';
+import * as symbols from '../src/api/_internal-symbols.ts';
+
+// Every exported value (the module's runtime exports are all symbols; its
+// interfaces are type-only and absent here), paired with its export name.
+const allEntries: ReadonlyArray<readonly [string, symbol]> = Object.entries(symbols);
+const HANDLE_SYMBOLS = allEntries.filter(([, value]) => typeof value === 'symbol');
+
+describe('internal handle symbols', () => {
+  it('exports at least the known handle keys', () => {
+    // Guards against the list silently emptying (e.g. a bad refactor) and the
+    // per-symbol assertions below vacuously passing.
+    expect(HANDLE_SYMBOLS.length).toBeGreaterThanOrEqual(16);
+  });
+
+  it('are all registered in the global symbol registry', () => {
+    for (const [name, sym] of HANDLE_SYMBOLS) {
+      const key = Symbol.keyFor(sym);
+      // `undefined` means a plain `Symbol(...)` — the cross-bundle footgun.
+      expect(key, `${name} must be a Symbol.for(...) registry symbol`).toBeDefined();
+      expect(key).toMatch(/^pptx-kit\./);
+    }
+  });
+
+  it('round-trip through Symbol.for resolves to the same symbol', () => {
+    // The defining property a second bundle relies on: re-deriving the key
+    // yields the identical symbol.
+    for (const [, sym] of HANDLE_SYMBOLS) {
+      const key = Symbol.keyFor(sym);
+      expect(Symbol.for(key!)).toBe(sym);
+    }
+  });
+});


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Presentation handles created through one entry point (`pptx-kit` vs
`pptx-kit/node`) could not be read by the other. Loading a deck with
`loadPresentationFile` (Node entry) and then calling, e.g., `getSlides`
(main entry) threw `Cannot read properties of undefined (reading 'getPart')`.
This makes the two entries interoperate.

## Motivation

The fn API returns opaque handles (`PresentationData`, `SlideData`, …) whose
internal data is stored under `Symbol` keys. Those keys were minted with plain
`Symbol(...)`. Because `pptx-kit` (dist/index.js) and `pptx-kit/node`
(dist/node.js) build as two separate bundles, each bundle got its **own**
distinct set of symbols. A handle built by the Node bundle was therefore
opaque to a reader from the main bundle (the symbol lookup returned
`undefined`), and vice-versa — a real crash for the common pattern of loading
from disk with the Node entry and querying with the main entry. It also blocks
companion packages (which bundle their own copy of the reader code) from
consuming handles a user loaded.

No issue filed — found while building a companion renderer package that mixes
both entries.

## Changes

- The 16 internal handle symbol keys now use the global symbol registry
  (`Symbol.for('pptx-kit.*')`) instead of plain `Symbol('pptx-kit.*')`, giving
  them stable identity across separately-bundled copies of the module. No
  public API surface changes; this is purely a fix to handle interop.

## Testing

- New `test/internal-handle-identity.test.ts` asserts every exported handle
  symbol is a global-registry symbol (`Symbol.keyFor(sym)` is defined and
  namespaced, and `Symbol.for(key)` round-trips to the same symbol). Reverting
  to plain `Symbol` fails this test. The cross-bundle scenario itself can't be
  reproduced inside a single vitest realm, so this is a white-box guard.
- Manually reproduced the original crash and confirmed the fix against the
  built dist:
  ```
  node -e "import('pptx-kit/node').then(async n => { \
    const { getSlides } = await import('pptx-kit'); \
    const p = await n.loadPresentationFile('test/fixtures/minimal/layout-decoration.pptx'); \
    console.log(getSlides(p).length); })"
  ```
  Before: `TypeError: Cannot read properties of undefined (reading 'getPart')`.
  After: `1`.
- `pnpm format:check`, `pnpm lint`, `pnpm typecheck`, `pnpm test` (980 passed),
  `pnpm build` all green.

## Breaking changes

None. The symbols are internal and never part of the public type surface; the
only observable change is that previously-crashing cross-entry usage now works.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and
      flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale
      comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this
      PR represents real work that warrants a maintainer's review, and I am
      willing to defend each line in review.

<!-- pr-template:end -->
