### PR TITLE
chore(preview): make @pptx-kit/preview publishable to npm

### DIFF
--- a/packages/preview/README.md
+++ b/packages/preview/README.md
@@ -4,11 +4,11 @@ Preview renderer for [`pptx-kit`](https://github.com/baseballyama/pptx-kit).
 Turns a `pptx-kit` slide model into an **SVG** (browser + Node) or rasterizes
 it to a **PNG / RGBA image in Node — with no headless browser**.
 
-> **Experimental (0.x), not yet published.** This package lives in the
-> `pptx-kit` monorepo and currently powers the docs-site playground and the
-> fidelity harness. The renderer is an _approximation_ of PowerPoint /
-> LibreOffice output and is still evolving; the API may change between minor
-> versions. See [fidelity](#fidelity) below.
+> **Experimental (0.x).** This package lives in the `pptx-kit` monorepo and
+> also powers the docs-site playground and the fidelity harness. The renderer
+> is an _approximation_ of PowerPoint / LibreOffice output and is still
+> evolving; the API may change between minor versions, and `0.x` semver applies
+> (a minor bump may break). See [fidelity](#fidelity) below.
 
 ## Why
 

--- a/packages/preview/package.json
+++ b/packages/preview/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@pptx-kit/preview",
   "version": "0.1.0",
-  "private": true,
   "description": "Experimental preview renderer for pptx-kit: render a slide to SVG (browser + Node) or rasterize it to a PNG/RGBA image in Node, with no browser binary.",
   "keywords": [
     "ooxml",
@@ -36,9 +35,14 @@
     },
     "./package.json": "./package.json"
   },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "scripts": {
     "build": "tsup",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "tsup"
   },
   "dependencies": {
     "@resvg/resvg-js": "^2.6.2",
@@ -52,6 +56,5 @@
   },
   "peerDependencies": {
     "pptx-kit": "workspace:*"
-  },
-  "//private": "Experimental; consumed only inside this monorepo (docs site + fidelity harness) while the renderer matures. To publish: drop `private`, add a build step to release.yml, and write a changeset."
+  }
 }


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Makes `@pptx-kit/preview` publishable to npm (it was marked `private`). This is
the repo-side enablement only — it does **not** publish anything. The actual
first publish is a human-gated, account-level bootstrap (see Motivation).

## Motivation

Following the package extraction (#217), the next step is to publish
`@pptx-kit/preview` so it's installable outside the monorepo. A publish-readiness
audit found three repo-side gaps that would make a publish fail or ship a broken
package, plus account-level prerequisites only the maintainer can satisfy.

## Changes

- Remove `"private": true` (it blocks `npm publish` and makes `changeset publish`
  skip the package).
- Add `"publishConfig": { "access": "public", "provenance": true }` — scoped
  packages publish *restricted* by default; this makes it public and opts into
  provenance, matching the root package.
- Add `"prepublishOnly": "tsup"` — `release.yml`'s `pnpm build` only builds the
  root, and `changeset publish` runs `npm publish` per package; the
  `prepublishOnly` hook (run in the package dir) guarantees a fresh `dist` lands
  in the tarball. (`pnpm -r build` was rejected — it would also run the heavy
  `site` build.)
- README: drop the "not yet published" line; keep the 0.x / approximate-renderer
  warning.

## Testing

- `npm pack --dry-run`: 29 files (dist `*.js`/`*.d.ts`/`*.map`, 20 fonts +
  `fonts/LICENSES.md`, README, package.json), 4.0 MB packed. No `private` flag,
  no secrets, font license text ships, browser entry stays free of node-only code.
- `pnpm format:check`, `pnpm lint`, `pnpm typecheck`, `pnpm --filter
  @pptx-kit/preview typecheck`, `pnpm --filter @pptx-kit/preview build` — all green.

## Breaking changes

None. New public package; `pptx-kit` core is unaffected.

## Notes for the maintainer (account-level, not in this PR)

The first publish **cannot** go through the existing OIDC workflow:
- The `@pptx-kit` npm scope/org doesn't exist yet — it must be created.
- npm cannot configure a Trusted Publisher (OIDC) for a package that doesn't
  exist yet (npm/cli#8544), so the *first* publish must be bootstrapped (one-time
  local `npm publish`, or a temporary `NPM_TOKEN` in CI), after which OIDC handles
  every subsequent release.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and
      flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale
      comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this
      PR represents real work that warrants a maintainer's review, and I am
      willing to defend each line in review.

<!-- pr-template:end -->
