### PR TITLE
feat(preview): vertical text and multi-column bodies in SVG text mode

### DIFF
--- a/.changeset/preview-svg-vertical-columns.md
+++ b/.changeset/preview-svg-vertical-columns.md
@@ -1,0 +1,11 @@
+---
+'@pptx-kit/preview': minor
+---
+
+feat(preview): vertical text (`vert`, `vert270`, `eaVert`, `mongolianVert`,
+`wordArtVert`) and multi-column bodies (`numCol`/`spcCol`) now render in the
+pure-SVG text mode (`textLayout: 'svg'`) used by server-side rasterization.
+Previously they fell back to horizontal single-column layout; now the server
+output matches the browser (`foreignObject`) path: rotated line stacking for
+vertical text and PowerPoint-style sequential column fill for multi-column
+bodies. Browser rendering is unchanged.

--- a/packages/preview/src/render-slide.ts
+++ b/packages/preview/src/render-slide.ts
@@ -138,12 +138,14 @@ import {
   layoutTextSvg,
   substituteFamily,
   type BulletInput,
+  type ColumnLayout,
   type ParaInput,
   type PieceInput,
   type RenderSlideOptions,
   type TextBodyInput,
   type TextLayoutMode,
   type TextMeasurer,
+  type VerticalLayout,
 } from './text-layout.ts';
 
 export type { RenderSlideOptions, TextMeasurer, FontSpec, MeasureResult } from './text-layout.ts';
@@ -2066,10 +2068,33 @@ interface SvgTextArgs {
   readonly innerW: number;
   readonly innerH: number;
   readonly measure: TextMeasurer;
+  readonly vert: VerticalLayout;
+  readonly columns: ColumnLayout | null;
 }
 
 const alignOf = (a: string): ParaInput['align'] =>
   a === 'center' || a === 'right' || a === 'justify' ? a : 'left';
+
+// Map the OOXML `vert` token onto the engine's two supported rotations,
+// mirroring the foreignObject path's writing-mode grouping so server == browser:
+// the `vertical-rl` family (columns right-to-left) rotates 90° clockwise, the
+// `vertical-lr` family (columns left-to-right) rotates 270°. The wordArt variants
+// keep glyphs upright in the browser; the SVG path rotates them with the text
+// (closest a rotated <text> can get), which the W1 brief accepts as the mapping.
+const verticalLayoutOf = (vert: ReturnType<typeof getShapeTextDirection>): VerticalLayout => {
+  switch (vert) {
+    case 'vert':
+    case 'eaVert':
+    case 'wordArtVert':
+    case 'wordArtVertRtl':
+      return 'cw90';
+    case 'vert270':
+    case 'mongolianVert':
+      return 'cw270';
+    case null:
+      return 'none';
+  }
+};
 
 // Build the px-native engine input from the resolved paraData and lay it out.
 const buildAndLayoutSvgText = (a: SvgTextArgs): string => {
@@ -2166,6 +2191,8 @@ const buildAndLayoutSvgText = (a: SvgTextArgs): string => {
     anchor: a.anchor,
     wrap: a.wrap,
     paragraphs,
+    vert: a.vert,
+    columns: a.columns,
   };
   return layoutTextSvg(input, a.measure);
 };
@@ -2624,9 +2651,9 @@ const renderTextBody = (
   const defaultColor = resolveColor('scheme:tx1', theme, '#000000');
 
   // Pure-SVG text path (browser-free rasterization). Rebuild the px-native
-  // layout model from the already-resolved paraData and hand it to the engine.
-  // Vertical text / multi-column are not yet ported here (PR C) — they lay out
-  // horizontally single-column, which is wrong but visible (vs. blank).
+  // layout model from the already-resolved paraData and hand it to the engine,
+  // matching the foreignObject path's vertical-text and multi-column handling so
+  // server-side rendering agrees with the browser (W1).
   if (ctx.mode === 'svg') {
     // Fidelity path: apply ONLY the authored normAutofit scale. The heuristic
     // shrink (the AVG_GLYPH_W_RATIO estimator) exists to keep the browser
@@ -2635,6 +2662,17 @@ const renderTextBody = (
     // truth (and avoids spuriously shrinking titles that actually fit).
     const svgScale = authoredAutofit?.fontScale ?? 1;
     const svgLineScale = 1 - (authoredAutofit?.lnSpcReduction ?? 0);
+    const svgVert = verticalLayoutOf(effectiveBody.vert ?? getShapeTextDirection(shape));
+    // numCol only applies to horizontal text — see the engine's combination note.
+    const svgCols = getShapeTextColumns(shape);
+    const svgColumns: ColumnLayout | null =
+      svgVert === 'none' && svgCols && svgCols.count >= 2
+        ? {
+            count: svgCols.count,
+            // spcCol is in EMU; default to the foreignObject path's 12px gap.
+            gapPx: svgCols.gapEmu !== undefined ? svgCols.gapEmu / EMU_PER_PX : 12,
+          }
+        : null;
     const svgInner = buildAndLayoutSvgText({
       pres,
       shape,
@@ -2653,6 +2691,8 @@ const renderTextBody = (
       innerW,
       innerH,
       measure: ctx.measure,
+      vert: svgVert,
+      columns: svgColumns,
     });
     const bodyRotDegSvg = getShapeTextBodyRotationDeg(shape);
     if (bodyRotDegSvg !== null && bodyRotDegSvg !== 0) {

--- a/packages/preview/src/text-layout.ts
+++ b/packages/preview/src/text-layout.ts
@@ -155,6 +155,18 @@ export interface ParaInput {
   readonly fallbackSizePx: number; // line height for an empty paragraph
 }
 
+/** Normalized text direction the engine understands. render-slide maps the
+ *  OOXML `vert` token (`vert`/`eaVert`/`vert270`/…) onto one of these — the
+ *  engine stays free of OOXML vocabulary. `cw90` rotates the horizontal layout
+ *  90° clockwise (reading top-to-bottom, columns right-to-left); `cw270` is the
+ *  opposite 270° rotation (columns left-to-right). */
+export type VerticalLayout = 'none' | 'cw90' | 'cw270';
+
+export interface ColumnLayout {
+  readonly count: number; // PowerPoint clamps to >= 2 before this point
+  readonly gapPx: number;
+}
+
 export interface TextBodyInput {
   readonly boxXpx: number;
   readonly boxYpx: number;
@@ -163,6 +175,10 @@ export interface TextBodyInput {
   readonly anchor: 'top' | 'center' | 'bottom';
   readonly wrap: boolean;
   readonly paragraphs: readonly ParaInput[];
+  /** Vertical text direction; omitted / 'none' is the default horizontal flow. */
+  readonly vert?: VerticalLayout;
+  /** Multi-column body (`numCol`/`spcCol`); null / omitted is single column. */
+  readonly columns?: ColumnLayout | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -187,6 +203,28 @@ interface Line {
   textAnchor: 'start' | 'middle' | 'end';
   bullet: { x: number; baselineDy: number; b: BulletInput } | null;
 }
+
+// The box (in local coords) that one horizontal layout pass fills. Horizontal
+// text uses the shape box directly; vertical text uses a swapped-extent frame
+// re-centred on the box (see layoutTextSvg).
+interface Frame {
+  readonly x: number;
+  readonly y: number;
+  readonly w: number;
+  readonly h: number;
+}
+
+// A laid-out line ready to emit: its baseline Y plus an X shift (non-zero only
+// for the second-and-later columns of a multi-column body).
+interface Placement {
+  readonly line: Line;
+  readonly baselineY: number;
+  readonly dx: number;
+}
+
+// Builds the line list for one column of a given content width. Closes over the
+// paragraph model and measurer caches inside layoutTextSvg.
+type LineBuilder = (contentLeft: number, contentRight: number) => { lines: Line[]; blockH: number };
 
 const specOf = (piece: PieceInput): FontSpec => ({
   family: piece.family,
@@ -247,123 +285,216 @@ export const layoutTextSvg = (input: TextBodyInput, measure: TextMeasurer): stri
     return m;
   };
 
-  const contentLeft = input.boxXpx;
-  const contentRight = input.boxXpx + input.boxWpx;
-  const lines: Line[] = [];
-  let cursorY = 0;
+  // One horizontal layout pass, parameterized on the content box's left/right
+  // edges so the same wrap/measure code serves the shape box (horizontal), a
+  // single column of a multi-column body, and the swapped frame of vertical
+  // text. Closes over the measurer caches above.
+  const buildLines: LineBuilder = (contentLeft, contentRight) => {
+    const lines: Line[] = [];
+    let cursorY = 0;
 
-  for (const para of input.paragraphs) {
-    cursorY += para.spcBefPx;
-    const wrapLeft = contentLeft + para.marLpx;
-    const wrapRight = contentRight - para.marRpx;
-    const firstLeft = wrapLeft + para.firstIndentPx;
-    const hasText = para.pieces.some((p) => !p.isBreak && p.text !== '');
-    const bullet = para.bullet && hasText ? para.bullet : null;
-    const bulletLead = bullet ? mWidth(`${bullet.text} `, bulletSpec(bullet)) : 0;
+    for (const para of input.paragraphs) {
+      cursorY += para.spcBefPx;
+      const wrapLeft = contentLeft + para.marLpx;
+      const wrapRight = contentRight - para.marRpx;
+      const firstLeft = wrapLeft + para.firstIndentPx;
+      const hasText = para.pieces.some((p) => !p.isBreak && p.text !== '');
+      const bullet = para.bullet && hasText ? para.bullet : null;
+      const bulletLead = bullet ? mWidth(`${bullet.text} `, bulletSpec(bullet)) : 0;
 
-    // Tokenize: word / whitespace runs per piece, plus break markers. Pre-split
-    // any single token wider than a full line into per-character tokens.
-    const avail = Math.max(1, wrapRight - wrapLeft);
-    const tokens: Token[] = [];
-    for (const piece of para.pieces) {
-      if (piece.isBreak) {
-        tokens.push({ text: '', piece, isSpace: false, isBreak: true, width: 0 });
-        continue;
-      }
-      for (const seg of piece.text.match(/\s+|\S+/g) ?? []) {
-        const isSpace = /^\s+$/.test(seg);
-        const w = mWidth(seg, specOf(piece));
-        if (input.wrap && !isSpace && w > avail - bulletLead && [...seg].length > 1) {
-          for (const ch of seg) {
-            tokens.push({
-              text: ch,
-              piece,
-              isSpace: false,
-              isBreak: false,
-              width: mWidth(ch, specOf(piece)),
-            });
+      // Tokenize: word / whitespace runs per piece, plus break markers. Pre-split
+      // any single token wider than a full line into per-character tokens.
+      const avail = Math.max(1, wrapRight - wrapLeft);
+      const tokens: Token[] = [];
+      for (const piece of para.pieces) {
+        if (piece.isBreak) {
+          tokens.push({ text: '', piece, isSpace: false, isBreak: true, width: 0 });
+          continue;
+        }
+        for (const seg of piece.text.match(/\s+|\S+/g) ?? []) {
+          const isSpace = /^\s+$/.test(seg);
+          const w = mWidth(seg, specOf(piece));
+          if (input.wrap && !isSpace && w > avail - bulletLead && [...seg].length > 1) {
+            for (const ch of seg) {
+              tokens.push({
+                text: ch,
+                piece,
+                isSpace: false,
+                isBreak: false,
+                width: mWidth(ch, specOf(piece)),
+              });
+            }
+          } else {
+            tokens.push({ text: seg, piece, isSpace, isBreak: false, width: w });
           }
-        } else {
-          tokens.push({ text: seg, piece, isSpace, isBreak: false, width: w });
         }
       }
+
+      const wrapped = wrapTokens(tokens, input.wrap, wrapRight - firstLeft - bulletLead, avail);
+      const paraLines: Token[][] = wrapped.length > 0 ? wrapped : [[]];
+
+      for (let li = 0; li < paraLines.length; li++) {
+        const toks = paraLines[li]!;
+        let ascent = 0;
+        let descent = 0;
+        let lineGap = 0;
+        for (const t of toks) {
+          if (t.isSpace || t.isBreak) continue;
+          const m = mMetrics(t.piece);
+          if (m.a > ascent) ascent = m.a;
+          if (m.d > descent) descent = m.d;
+          if (m.g > lineGap) lineGap = m.g;
+        }
+        if (ascent === 0) {
+          ascent = para.fallbackSizePx * FALLBACK_ASCENT;
+          descent = para.fallbackSizePx * FALLBACK_DESCENT;
+          lineGap = para.fallbackSizePx * FALLBACK_LINEGAP;
+        }
+        const isFirst = li === 0;
+        const lineLeft = (isFirst ? firstLeft : wrapLeft) + bulletLead;
+        const line: Line = {
+          tokens: toks,
+          ascent,
+          descent,
+          lineGap,
+          topY: cursorY,
+          advance: 0,
+          anchorX: lineLeft,
+          textAnchor: 'start',
+          bullet: null,
+        };
+        if (para.align === 'center') {
+          line.textAnchor = 'middle';
+          line.anchorX = (lineLeft + wrapRight) / 2;
+        } else if (para.align === 'right') {
+          line.textAnchor = 'end';
+          line.anchorX = wrapRight;
+        }
+        if (isFirst && bullet) {
+          line.bullet = { x: firstLeft, baselineDy: 0, b: bullet };
+        }
+        line.advance = lineAdvance(line, para);
+        cursorY += line.advance;
+        lines.push(line);
+      }
+      cursorY += para.spcAftPx;
     }
+    return { lines, blockH: cursorY };
+  };
 
-    const wrapped = wrapTokens(tokens, input.wrap, wrapRight - firstLeft - bulletLead, avail);
-    const paraLines: Token[][] = wrapped.length > 0 ? wrapped : [[]];
+  const vert = input.vert ?? 'none';
+  const cx = input.boxXpx + input.boxWpx / 2;
+  const cy = input.boxYpx + input.boxHpx / 2;
+  // Vertical text lays out horizontally into a frame whose extents are swapped
+  // and re-centred on the box, so a single rotate(±90) about the box centre
+  // maps that horizontal layout exactly onto the shape. All wrap / anchor /
+  // align math then stays identical to horizontal — only the wrapping transform
+  // differs, which is what keeps the calibrated horizontal path byte-stable.
+  const frame: Frame =
+    vert === 'none'
+      ? { x: input.boxXpx, y: input.boxYpx, w: input.boxWpx, h: input.boxHpx }
+      : { x: cx - input.boxHpx / 2, y: cy - input.boxWpx / 2, w: input.boxHpx, h: input.boxWpx };
 
-    for (let li = 0; li < paraLines.length; li++) {
-      const toks = paraLines[li]!;
-      let ascent = 0;
-      let descent = 0;
-      let lineGap = 0;
-      for (const t of toks) {
-        if (t.isSpace || t.isBreak) continue;
-        const m = mMetrics(t.piece);
-        if (m.a > ascent) ascent = m.a;
-        if (m.d > descent) descent = m.d;
-        if (m.g > lineGap) lineGap = m.g;
-      }
-      if (ascent === 0) {
-        ascent = para.fallbackSizePx * FALLBACK_ASCENT;
-        descent = para.fallbackSizePx * FALLBACK_DESCENT;
-        lineGap = para.fallbackSizePx * FALLBACK_LINEGAP;
-      }
-      const isFirst = li === 0;
-      const lineLeft = (isFirst ? firstLeft : wrapLeft) + bulletLead;
-      const line: Line = {
-        tokens: toks,
-        ascent,
-        descent,
-        lineGap,
-        topY: cursorY,
-        advance: 0,
-        anchorX: lineLeft,
-        textAnchor: 'start',
-        bullet: null,
-      };
-      if (para.align === 'center') {
-        line.textAnchor = 'middle';
-        line.anchorX = (lineLeft + wrapRight) / 2;
-      } else if (para.align === 'right') {
-        line.textAnchor = 'end';
-        line.anchorX = wrapRight;
-      }
-      if (isFirst && bullet) {
-        line.bullet = { x: firstLeft, baselineDy: 0, b: bullet };
-      }
-      line.advance = lineAdvance(line, para);
-      cursorY += line.advance;
-      lines.push(line);
-    }
-    cursorY += para.spcAftPx;
+  // Columns apply to horizontal text only — a faithful rotated-column layout is
+  // disproportionate and PowerPoint itself barely supports vert + numCol, so we
+  // keep the rotation and drop numCol rather than emit a wrong combined layout.
+  const columns = vert === 'none' ? (input.columns ?? null) : null;
+
+  const placements =
+    columns && columns.count >= 2
+      ? placeColumns(frame, columns, input.anchor, buildLines)
+      : placeSingle(frame, input.anchor, buildLines);
+
+  const body = emitPlacements(placements);
+  if (vert === 'none') return body;
+  const deg = vert === 'cw90' ? 90 : 270;
+  return `<g transform="rotate(${deg} ${fmt(cx)} ${fmt(cy)})">${body}</g>`;
+};
+
+// Vertical block offset for an anchor. Center / bottom get the empirical drop
+// calibration (see site/fidelity/README.md): LibreOffice & PowerPoint sit
+// center/bottom-anchored text ≈0.036 of a line's (ascent+descent) lower than
+// the win-metric line box predicts; top-anchored text aligns exactly.
+const anchorOffsetY = (
+  frameY: number,
+  frameH: number,
+  blockH: number,
+  anchor: 'top' | 'center' | 'bottom',
+  firstLine: Line | undefined,
+): number => {
+  let offsetY = frameY;
+  if (anchor === 'center') offsetY = frameY + (frameH - blockH) / 2;
+  else if (anchor === 'bottom') offsetY = frameY + (frameH - blockH);
+  if ((anchor === 'center' || anchor === 'bottom') && firstLine) {
+    offsetY += CENTER_ANCHOR_DROP * (firstLine.ascent + firstLine.descent);
   }
+  return offsetY;
+};
 
-  const blockH = cursorY;
-  let offsetY = input.boxYpx;
-  if (input.anchor === 'center') offsetY = input.boxYpx + (input.boxHpx - blockH) / 2;
-  else if (input.anchor === 'bottom') offsetY = input.boxYpx + (input.boxHpx - blockH);
-  // Empirical calibration: with vertical centering / bottom anchoring,
-  // LibreOffice & PowerPoint sit the text slightly lower than the win-metric
-  // line box implies — verified against ground truth (an IoU offset search) as
-  // ≈0.036 of a line's (ascent+descent), isolated to non-top anchoring
-  // (top-anchored text aligns exactly, so it gets no shift). See
-  // site/fidelity/README.md.
-  if ((input.anchor === 'center' || input.anchor === 'bottom') && lines.length > 0) {
-    const ref = lines[0]!;
-    offsetY += CENTER_ANCHOR_DROP * (ref.ascent + ref.descent);
-  }
+const placeSingle = (
+  frame: Frame,
+  anchor: 'top' | 'center' | 'bottom',
+  buildLines: LineBuilder,
+): Placement[] => {
+  const { lines, blockH } = buildLines(frame.x, frame.x + frame.w);
+  const offsetY = anchorOffsetY(frame.y, frame.h, blockH, anchor, lines[0]);
+  return lines.map((line) => ({
+    line,
+    baselineY: offsetY + line.topY + topPad(line) + line.ascent,
+    dx: 0,
+  }));
+};
 
-  const parts: string[] = [];
+const placeColumns = (
+  frame: Frame,
+  columns: ColumnLayout,
+  anchor: 'top' | 'center' | 'bottom',
+  buildLines: LineBuilder,
+): Placement[] => {
+  const gap = columns.gapPx;
+  const colW = Math.max(1, (frame.w - (columns.count - 1) * gap) / columns.count);
+  const { lines } = buildLines(frame.x, frame.x + colW);
+  // Sequential fill, matching PowerPoint (not CSS column-fill:balance): fill
+  // column 1 down to the box height, then overflow into column 2, and so on. A
+  // column only breaks once it already holds a line, so a single over-tall line
+  // can't loop. With few lines everything stays in column 1.
+  let col = 0;
+  let colStartTopY = 0;
+  const colHasLine: boolean[] = [];
+  let tallest = 0;
+  const placed: { line: Line; localTopY: number; col: number }[] = [];
   for (const line of lines) {
-    const baselineY = offsetY + line.topY + topPad(line) + line.ascent;
+    const localBottom = line.topY - colStartTopY + line.advance;
+    if (col < columns.count - 1 && localBottom > frame.h && colHasLine[col]) {
+      col += 1;
+      colStartTopY = line.topY;
+    }
+    const localTopY = line.topY - colStartTopY;
+    placed.push({ line, localTopY, col });
+    colHasLine[col] = true;
+    if (localTopY + line.advance > tallest) tallest = localTopY + line.advance;
+  }
+  // Vertical anchor applies to the whole body via its tallest column block —
+  // with sequential fill the filled columns reach the box height, so this
+  // matches PowerPoint/LibreOffice anchoring the body as one unit.
+  const offsetY = anchorOffsetY(frame.y, frame.h, tallest, anchor, lines[0]);
+  return placed.map(({ line, localTopY, col: c }) => ({
+    line,
+    baselineY: offsetY + localTopY + topPad(line) + line.ascent,
+    dx: c * (colW + gap),
+  }));
+};
+
+const emitPlacements = (placements: Placement[]): string => {
+  const parts: string[] = [];
+  for (const { line, baselineY, dx } of placements) {
     if (line.bullet) {
       const b = line.bullet.b;
       parts.push(
-        `<text x="${fmt(line.bullet.x)}" y="${fmt(baselineY)}" font-family="${escapeXml(b.family)}" font-size="${fmt(b.sizePx)}" fill="${b.fillHex}" xml:space="preserve">${escapeXml(b.text)}</text>`,
+        `<text x="${fmt(line.bullet.x + dx)}" y="${fmt(baselineY)}" font-family="${escapeXml(b.family)}" font-size="${fmt(b.sizePx)}" fill="${b.fillHex}" xml:space="preserve">${escapeXml(b.text)}</text>`,
       );
     }
-    parts.push(emitLine(line, baselineY));
+    parts.push(emitLine(line, baselineY, dx));
   }
   return parts.join('');
 };
@@ -389,7 +520,7 @@ const lineAdvance = (line: Line, para: ParaInput): number => {
   return adv * para.lineAdvanceScale;
 };
 
-const emitLine = (line: Line, baselineY: number): string => {
+const emitLine = (line: Line, baselineY: number, dx: number): string => {
   const toks = [...line.tokens];
   while (toks.length > 0 && (toks[toks.length - 1]!.isSpace || toks[toks.length - 1]!.isBreak)) {
     toks.pop();
@@ -400,7 +531,7 @@ const emitLine = (line: Line, baselineY: number): string => {
     .map((g) => tspan(g))
     .join('');
   if (tspans === '') return '';
-  return `<text x="${fmt(line.anchorX)}" y="${fmt(baselineY)}" text-anchor="${line.textAnchor}" xml:space="preserve">${tspans}</text>`;
+  return `<text x="${fmt(line.anchorX + dx)}" y="${fmt(baselineY)}" text-anchor="${line.textAnchor}" xml:space="preserve">${tspans}</text>`;
 };
 
 interface Group {

--- a/site/fidelity/baseline.json
+++ b/site/fidelity/baseline.json
@@ -23,6 +23,8 @@
     "18-hyperlinks.pptx": [0.5538],
     "19-token-fill.pptx": [0.7607],
     "20-core-properties.pptx": [0.64],
-    "21-showcase.pptx": [0.7256, 0.9478, 0.6774, 0.1578, 0.9937, 0.7746, 0.6079]
+    "21-showcase.pptx": [0.7256, 0.9478, 0.6774, 0.1578, 0.9937, 0.7746, 0.6079],
+    "22-vertical-text.pptx": [0.2656],
+    "23-columns.pptx": [0.429]
   }
 }

--- a/test/preview-svg-text-modes.test.ts
+++ b/test/preview-svg-text-modes.test.ts
@@ -1,0 +1,141 @@
+// SVG-mode parity for vertical text and multi-column bodies (W1).
+//
+// These exercise the pure-SVG text path (`textLayout: 'svg'`, the server /
+// fidelity renderer) against in-memory decks built with the public
+// setShapeTextDirection / setShapeTextColumns writers, and assert it now
+// honours the same layout decisions the browser (foreignObject) path expresses
+// with CSS writing-mode / column-count. Import pattern follows
+// test/preview-render-svg.test.ts.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  addSlide,
+  addSlideTextBox,
+  findSlideLayout,
+  inches,
+  loadPresentation,
+  setShapeTextColumns,
+  setShapeTextDirection,
+} from '../src/api/index.ts';
+import { renderSlideToSvg } from '../packages/preview/src/index.ts';
+import { attrsOf, countTags } from './lib/svg-query.ts';
+
+const fixturePath = fileURLToPath(new URL('./fixtures/minimal/blank.pptx', import.meta.url));
+
+const blankSlide = async () => {
+  const pres = await loadPresentation(await readFile(fixturePath));
+  const layout = findSlideLayout(pres, 'Blank');
+  if (!layout) throw new Error('Blank layout not found');
+  return { pres, slide: addSlide(pres, { layout }) };
+};
+
+// Enough text to wrap to several lines so column overflow / line stacking is visible.
+const LONG = Array.from({ length: 24 }, (_, i) => `Line ${i + 1}`).join('\n');
+
+// X coordinate of every body <text> (those carry text-anchor; bullets do not).
+const textXs = (svg: string): number[] =>
+  attrsOf(svg, 'text')
+    .filter((a) => a['text-anchor'] !== undefined)
+    .map((a) => Number(a.x));
+
+describe('renderSlideToSvg — vertical text (svg mode)', () => {
+  it('vert: emitted text is wrapped in a clockwise rotate() transform', async () => {
+    const { pres, slide } = await blankSlide();
+    const box = addSlideTextBox(slide, {
+      x: inches(1),
+      y: inches(1),
+      w: inches(2),
+      h: inches(3),
+      text: LONG,
+    });
+    setShapeTextDirection(box, 'vert');
+    const svg = renderSlideToSvg(pres, slide, { textLayout: 'svg' });
+    expect(svg).toContain('transform="rotate(90');
+    expect(countTags(svg, 'foreignObject')).toBe(0);
+    expect(countTags(svg, 'text')).toBeGreaterThan(0);
+  });
+
+  it('vert270: rotates the opposite way (270°)', async () => {
+    const { pres, slide } = await blankSlide();
+    const box = addSlideTextBox(slide, {
+      x: inches(1),
+      y: inches(1),
+      w: inches(2),
+      h: inches(3),
+      text: LONG,
+    });
+    setShapeTextDirection(box, 'vert270');
+    const svg = renderSlideToSvg(pres, slide, { textLayout: 'svg' });
+    expect(svg).toContain('transform="rotate(270');
+    expect(svg).not.toContain('transform="rotate(90');
+  });
+
+  it('foreignObject mode still expresses vert as CSS writing-mode', async () => {
+    const { pres, slide } = await blankSlide();
+    const box = addSlideTextBox(slide, {
+      x: inches(1),
+      y: inches(1),
+      w: inches(2),
+      h: inches(3),
+      text: LONG,
+    });
+    setShapeTextDirection(box, 'vert');
+    const svg = renderSlideToSvg(pres, slide, { textLayout: 'foreignObject' });
+    expect(svg).toContain('writing-mode:vertical-rl');
+    expect(countTags(svg, 'foreignObject')).toBeGreaterThan(0);
+  });
+});
+
+describe('renderSlideToSvg — multi-column text (svg mode)', () => {
+  it('2 columns: wrapped lines split across two distinct x-offsets (sequential fill)', async () => {
+    const { pres, slide } = await blankSlide();
+    const box = addSlideTextBox(slide, {
+      x: inches(1),
+      y: inches(1),
+      w: inches(6),
+      h: inches(1.5),
+      text: LONG,
+    });
+    setShapeTextColumns(box, { count: 2, gapEmu: 228600 }); // 0.25in gap
+    const svg = renderSlideToSvg(pres, slide, { textLayout: 'svg' });
+    const xs = textXs(svg);
+    const distinct = [...new Set(xs)].sort((a, b) => a - b);
+    expect(distinct.length).toBeGreaterThanOrEqual(2);
+    // Column 2 sits to the right of column 1 by (colWidth + gap).
+    expect(distinct[1]!).toBeGreaterThan(distinct[0]!);
+  });
+
+  it('foreignObject mode still expresses numCol as CSS column-count', async () => {
+    const { pres, slide } = await blankSlide();
+    const box = addSlideTextBox(slide, {
+      x: inches(1),
+      y: inches(1),
+      w: inches(6),
+      h: inches(1.5),
+      text: LONG,
+    });
+    setShapeTextColumns(box, { count: 2, gapEmu: 228600 });
+    const svg = renderSlideToSvg(pres, slide, { textLayout: 'foreignObject' });
+    expect(svg).toContain('column-count:2');
+    expect(svg).toContain('column-gap:');
+  });
+});
+
+describe('renderSlideToSvg — horizontal parity (svg mode)', () => {
+  it('a plain horizontal text box is unaffected by the W1 change (snapshot guard)', async () => {
+    const { pres, slide } = await blankSlide();
+    addSlideTextBox(slide, {
+      x: inches(1),
+      y: inches(1),
+      w: inches(4),
+      h: inches(1),
+      text: 'plain horizontal text body',
+    });
+    const svg = renderSlideToSvg(pres, slide, { textLayout: 'svg' });
+    expect(svg).not.toContain('transform="rotate(');
+    // The body lays out as a single left-anchored column.
+    expect(new Set(textXs(svg)).size).toBe(1);
+  });
+});

--- a/test/samples-generate.test.ts
+++ b/test/samples-generate.test.ts
@@ -53,6 +53,8 @@ import {
   setShapeStrokeArrow,
   setShapeStrokeDash,
   setShapeText,
+  setShapeTextColumns,
+  setShapeTextDirection,
   setShapeTextFormat,
   setSlideBackground,
   setSlideNotes,
@@ -804,5 +806,70 @@ describe.skipIf(!ENABLED)('manual-inspection sample generation', () => {
 
     const bytes = await savePresentation(pres);
     await writeSample('21-showcase.pptx', bytes);
+  });
+
+  it('22 — vertical text (vert + vert270)', async () => {
+    const pres = await loadBlank();
+    const slide = freshSlide(pres);
+    setSlideTitle(slide, 'Vertical text');
+
+    // vert: rotated 90° clockwise — reads top-to-bottom, columns right-to-left.
+    const vert = addSlideTextBox(slide, {
+      x: inches(1),
+      y: inches(1.5),
+      w: inches(2),
+      h: inches(4),
+      text: 'Vertical text rotated ninety degrees clockwise, wrapping across several columns.',
+    });
+    setShapeTextDirection(vert, 'vert');
+    setShapeRunFormat(vert, 0, 0, { size: 18 });
+
+    // vert270: rotated 270° — reads bottom-to-top, columns left-to-right.
+    const vert270 = addSlideTextBox(slide, {
+      x: inches(5),
+      y: inches(1.5),
+      w: inches(2),
+      h: inches(4),
+      text: 'Vertical text rotated two hundred seventy degrees, the opposite reading direction.',
+    });
+    setShapeTextDirection(vert270, 'vert270');
+    setShapeRunFormat(vert270, 0, 0, { size: 18 });
+
+    const bytes = await savePresentation(pres);
+    await writeSample('22-vertical-text.pptx', bytes);
+  });
+
+  it('23 — multi-column text (2 and 3 columns)', async () => {
+    const pres = await loadBlank();
+    const slide = freshSlide(pres);
+    setSlideTitle(slide, 'Multi-column text');
+
+    const para =
+      'PowerPoint fills multi-column text bodies sequentially: the first column ' +
+      'is filled down to the box height, then the overflow continues in the next ' +
+      'column, and so on across the body. ';
+
+    const two = addSlideTextBox(slide, {
+      x: inches(0.7),
+      y: inches(1.5),
+      w: inches(8.5),
+      h: inches(1.8),
+      text: para.repeat(3),
+    });
+    setShapeTextColumns(two, { count: 2, gapEmu: 228600 }); // 0.25in gap
+    setShapeRunFormat(two, 0, 0, { size: 14 });
+
+    const three = addSlideTextBox(slide, {
+      x: inches(0.7),
+      y: inches(3.7),
+      w: inches(8.5),
+      h: inches(2.5),
+      text: para.repeat(5),
+    });
+    setShapeTextColumns(three, { count: 3, gapEmu: 182880 }); // 0.2in gap
+    setShapeRunFormat(three, 0, 0, { size: 14 });
+
+    const bytes = await savePresentation(pres);
+    await writeSample('23-columns.pptx', bytes);
   });
 });

--- a/test/text-layout.test.ts
+++ b/test/text-layout.test.ts
@@ -182,3 +182,116 @@ describe('layoutTextSvg', () => {
     expect(yOf(bottom)).toBeGreaterThan(yOf(top));
   });
 });
+
+// X/Y of every emitted <text> in document order (bullets included).
+const coords = (svg: string): { x: number; y: number }[] =>
+  [...svg.matchAll(/<text x="(-?[\d.]+)" y="(-?[\d.]+)"/g)].map((m) => ({
+    x: Number(m[1]),
+    y: Number(m[2]),
+  }));
+
+const br = (): PieceInput => piece('', { isBreak: true });
+
+describe('layoutTextSvg vertical text', () => {
+  // Box 100×200 ⇒ centre (50,100); the rotation pivots there so the swapped
+  // 200×100 layout frame lands back on the shape after rotation.
+  const vbox = { boxXpx: 0, boxYpx: 0, boxWpx: 100, boxHpx: 200 } as const;
+
+  it('cw90 wraps output in a rotate(90) transform about the box centre', () => {
+    const svg = layoutTextSvg(body([para([piece('A')])], { ...vbox, vert: 'cw90' }), stubMeasurer);
+    expect(svg).toMatch(/^<g transform="rotate\(90 50 100\)">/);
+    expect(svg.endsWith('</g>')).toBe(true);
+  });
+
+  it('cw270 rotates the opposite way', () => {
+    const svg = layoutTextSvg(body([para([piece('A')])], { ...vbox, vert: 'cw270' }), stubMeasurer);
+    expect(svg).toMatch(/^<g transform="rotate\(270 50 100\)">/);
+  });
+
+  it('stacks successive lines along the local axis (increasing y before rotation)', () => {
+    const svg = layoutTextSvg(
+      body([para([piece('A'), br(), piece('B')])], { ...vbox, vert: 'cw90' }),
+      stubMeasurer,
+    );
+    const ys = coords(svg).map((c) => c.y);
+    expect(ys).toHaveLength(2);
+    // Lines stack in local +y; the rotate transform turns that into the
+    // right-to-left column stacking that vert text shows visually.
+    expect(ys[1]!).toBeGreaterThan(ys[0]!);
+  });
+
+  it('ignores numCol for vertical text (rotation wins over columns)', () => {
+    const svg = layoutTextSvg(
+      body([para([piece('A'), br(), piece('B')])], {
+        ...vbox,
+        vert: 'cw90',
+        columns: { count: 2, gapPx: 10 },
+      }),
+      stubMeasurer,
+    );
+    // A single x-offset ⇒ no column split was applied.
+    expect(new Set(coords(svg).map((c) => c.x)).size).toBe(1);
+  });
+});
+
+describe('layoutTextSvg multi-column', () => {
+  it('sequentially fills column 1, then spills overflow into column 2 at the gap offset', () => {
+    // 5 lines, each 10px tall (stub metrics); box height 30 fits 3 per column.
+    const fiveLines = para([
+      piece('A'),
+      br(),
+      piece('B'),
+      br(),
+      piece('C'),
+      br(),
+      piece('D'),
+      br(),
+      piece('E'),
+    ]);
+    const svg = layoutTextSvg(
+      body([fiveLines], { boxWpx: 200, boxHpx: 30, columns: { count: 2, gapPx: 10 } }),
+      stubMeasurer,
+    );
+    const xs = coords(svg).map((c) => c.x);
+    // colW = (200 − 1·10) / 2 = 95; column 2 sits at 95 + 10 (gap) = 105.
+    expect(new Set(xs)).toEqual(new Set([0, 105]));
+    expect(xs.filter((x) => x === 105)).toHaveLength(2); // D, E overflowed
+  });
+
+  it('keeps few lines entirely in the first column', () => {
+    const svg = layoutTextSvg(
+      body([para([piece('A'), br(), piece('B')])], {
+        boxWpx: 200,
+        boxHpx: 100,
+        columns: { count: 2, gapPx: 10 },
+      }),
+      stubMeasurer,
+    );
+    expect(new Set(coords(svg).map((c) => c.x))).toEqual(new Set([0]));
+  });
+});
+
+describe('layoutTextSvg horizontal parity', () => {
+  it('omitting vert/columns is identical to passing none/null', () => {
+    const paras = [para([piece('hello world foo bar baz')])];
+    const plain = layoutTextSvg(body(paras, { boxWpx: 60 }), stubMeasurer);
+    const explicit = layoutTextSvg(
+      body(paras, { boxWpx: 60, vert: 'none', columns: null }),
+      stubMeasurer,
+    );
+    expect(plain).toBe(explicit);
+  });
+
+  it('emits the calibrated horizontal layout unchanged (snapshot guard)', () => {
+    const svg = layoutTextSvg(
+      body([para([piece('aa bb cc dd')]), para([piece('ee ff')], { align: 'center' })], {
+        boxWpx: 40,
+        anchor: 'center',
+      }),
+      stubMeasurer,
+    );
+    expect(svg).toMatchInlineSnapshot(
+      `"<text x="0" y="93.36" text-anchor="start" xml:space="preserve"><tspan font-family="Carlito" font-size="10" fill="#000000">aa bb</tspan></text><text x="0" y="103.36" text-anchor="start" xml:space="preserve"><tspan font-family="Carlito" font-size="10" fill="#000000">cc dd</tspan></text><text x="20" y="113.36" text-anchor="middle" xml:space="preserve"><tspan font-family="Carlito" font-size="10" fill="#000000">ee ff</tspan></text>"`,
+    );
+  });
+});


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Lands W1 of `docs/template-and-preview-plan.md`: the pure-SVG text layouter (the path server-side rasterization uses) now renders vertical text (`vert`, `vert270`, `eaVert`, `mongolianVert`, `wordArtVert*`) and multi-column bodies (`numCol`/`spcCol`) instead of falling back to horizontal single-column. Server output now matches the layout decisions the browser path already expressed with CSS `writing-mode` / `column-count`.

## Motivation

Plan W1 / definition-of-done #2 (runtime parity): the SVG mode carried a "not yet ported (PR C)" comment and silently mis-rendered vertical and columnar text on the server. Plan merged in #224; infrastructure in #225.

## Changes

- `@pptx-kit/preview` (svg text mode only — foreignObject path untouched):
  - Vertical text lays out into a swapped, re-centred frame and is mapped back with a single `rotate(±90)` about the box centre, so the calibrated horizontal wrap/anchor/align math runs unchanged. `vertical-rl` family → 90° cw; `vertical-lr` family (`vert270`, `mongolianVert`) → 270°.
  - Multi-column bodies wrap to the per-column width and fill sequentially (PowerPoint behavior: column 1 down to the box height, overflow spills into the next), with the vertical anchor applied to the tallest column block.
  - `vert` + `numCol` combined: rotation wins, columns are dropped, with a why-comment (PowerPoint itself barely supports the combo).
- Fidelity corpus: new samples `22-vertical-text.pptx`, `23-columns.pptx`.
- Changeset: `@pptx-kit/preview` minor.

## Testing

- 8 new engine tests in `test/text-layout.test.ts` (rotation transforms, line stacking direction, sequential column fill, gap offsets, and a byte-stability snapshot proving the horizontal path is untouched by the refactor).
- New `test/preview-svg-text-modes.test.ts` (6 integration tests incl. foreignObject-still-emits-CSS guards).
- Full suite: 1036 passed, 24 skipped. format/lint/typecheck (root + preview) clean. `pnpm samples` → 23 files.
- The fidelity job will fail once on this PR (`missing-in-baseline` for samples 22/23 — by design); the updated baseline gets committed from the CI candidate artifact, which also scores the two new samples for the first time.

## Breaking changes

None

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and flagged it above. (changeset added; not breaking)
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, the PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)