### PR TITLE
feat(preview): real per-run table cell text formatting

### DIFF
--- a/.changeset/preview-table-text.md
+++ b/.changeset/preview-table-text.md
@@ -1,0 +1,10 @@
+---
+'@pptx-kit/preview': patch
+---
+
+fix(preview): table cell text now renders with its real per-run formatting —
+font size, bold, italic, color, typeface, and paragraph alignment — and wraps
+within the cell width, in both the browser (`foreignObject`) and server
+(`svg`) text modes. Previously every cell was drawn at a flat 18 pt with no
+styling. Cells with no explicit run size still fall back to PowerPoint's 18 pt
+default in the theme's body font.

--- a/.changeset/table-cell-paragraphs.md
+++ b/.changeset/table-cell-paragraphs.md
@@ -1,0 +1,8 @@
+---
+'pptx-kit': minor
+---
+
+feat: `getTableCellParagraphs(cell)` returns a table cell's text as structured
+paragraphs — each carrying its alignment and per-run format (`size`, `bold`,
+`italic`, `color`, `font`, …) — the rich counterpart to `getTableCellText`,
+which only returns the flat visible string.

--- a/packages/preview/src/render-slide.ts
+++ b/packages/preview/src/render-slide.ts
@@ -105,13 +105,12 @@ import {
   getSlideMasterBackgroundPatternFill,
   getSlideShapes,
   getSlideSize,
-  getTableCellAlignment,
   getTableCellAnchor,
   getTableCellMargins,
   getTableCellBorders,
   getTableCellFill,
+  getTableCellParagraphs,
   getTableCellSpan,
-  getTableCellText,
   getTableCells,
   getTableStyleFlags,
   getTableColumnWidths,
@@ -133,6 +132,7 @@ import {
   type ShapeStroke,
   type SlideData,
   type SlideShapeData,
+  type TableCellParagraph,
   type TextFormat,
 } from 'pptx-kit';
 import {
@@ -4385,43 +4385,72 @@ const renderChart = (
 };
 
 // ---------------------------------------------------------------------------
-// Table rendering. Real table layout (cell borders, banded rows, header
-// row, merged cells, per-run text formatting) needs a much bigger pass;
-// this version draws the grid, fills, and centred cell text — enough to
-// recognise the table at a glance.
+// Table rendering. Draws the grid, cell fills, banded rows, header row, merged
+// cells, and per-run cell text. Cell text reuses the same layout building
+// blocks as shape text (buildAndLayoutSvgText / renderRun), so it inherits
+// per-run size / bold / italic / color / font, paragraph alignment, line
+// wrapping, and the svg ↔ foreignObject split for free.
 
-const ALIGNMENT_TEXT_ANCHOR: Record<string, string> = {
-  left: 'start',
-  center: 'middle',
-  right: 'end',
-  justify: 'start',
+// Builds the per-paragraph layout model the shared text engine consumes from a
+// cell's structured paragraphs. Table cells have no bullets, levels, indents,
+// or paragraph spacing, so those fields are inert. A run's effective point
+// size resolves to its explicit `<a:rPr sz>` when present, else the table-cell
+// default: pptx-kit doesn't model `<a:tblStyle>` text props, so unstyled cells
+// fall to PowerPoint's authored default cell size (18 pt — what it writes for a
+// freshly inserted table) in the theme's minor font and the cell's text color.
+const cellParaData = (
+  paragraphs: ReadonlyArray<TableCellParagraph>,
+): { paraData: ParaData[]; hasText: boolean } => {
+  let hasText = false;
+  const paraData = paragraphs.map((para): ParaData => {
+    const runs: RunData[] = [];
+    for (const el of para.elements) {
+      if (el.kind === 'br') {
+        runs.push({ text: '\n', fmt: null, sizePt: DEFAULT_BODY_PT });
+        continue;
+      }
+      if (el.text.trim()) hasText = true;
+      runs.push({ text: el.text, fmt: el.format, sizePt: el.format?.size ?? DEFAULT_BODY_PT });
+    }
+    return {
+      align: para.align ?? 'left',
+      level: 0,
+      bulletStyle: null,
+      bulletDetail: { color: null, sizePct: null, sizePts: null, font: null },
+      bulletIsPicture: false,
+      runs,
+      lineSpacing: null,
+      spcBefPts: null,
+      spcAftPts: null,
+      indent: { leftEmu: null, rightEmu: null, firstLineEmu: null },
+    };
+  });
+  return { paraData, hasText };
 };
 
 const renderTableCellText = (
-  text: string,
+  paragraphs: ReadonlyArray<TableCellParagraph>,
   cx: number,
   cy: number,
   cw: number,
   ch: number,
-  alignment: string | null,
   color: string,
+  pres: PresentationData,
+  shape: SlideShapeData,
+  theme: PresentationTheme | null,
+  themeFace: string | null,
   ctx: LayoutCtx,
-  vAnchor: 'top' | 'center' | 'bottom' = 'center',
+  vAnchor: 'top' | 'center' | 'bottom',
   margins: {
     left: number | null;
     right: number | null;
     top: number | null;
     bottom: number | null;
-  } = {
-    left: null,
-    right: null,
-    top: null,
-    bottom: null,
   },
 ): string => {
-  if (!text.trim()) return '';
+  const { paraData, hasText } = cellParaData(paragraphs);
+  if (!hasText) return '';
   // PowerPoint stores margins in EMU; fall back to ~4px when unset.
-  const ta = alignment && ALIGNMENT_TEXT_ANCHOR[alignment] !== undefined ? alignment : 'left';
   const defaultPadPx = 4;
   const padL = margins.left !== null ? margins.left / EMU_PER_PX : defaultPadPx;
   const padR = margins.right !== null ? margins.right / EMU_PER_PX : defaultPadPx;
@@ -4432,44 +4461,51 @@ const renderTableCellText = (
   const innerW = Math.max(0, cw - padL - padR);
   const innerH = Math.max(0, ch - padT - padB);
   if (innerW <= 0 || innerH <= 0) return '';
-  const lines = text.split('\n').slice(0, 8);
 
-  // Pure-SVG path: emit positioned <text> lines so a browser-free rasterizer
-  // shows cell text (foreignObject would blank out). Uses the 18pt table-cell
-  // default (per-run sizing is a later refinement); full styling needs a cell
-  // run model pptx-kit doesn't expose yet.
+  // Pure-SVG path: hand the layout model to the same engine shape text uses so
+  // a browser-free rasterizer gets wrapped, per-run-styled lines. The engine
+  // works in EMU (it divides by EMU_PER_PX internally), so project the px box
+  // back to EMU.
   if (ctx.mode === 'svg') {
-    const fontPx = 18 * PX_PER_PT;
-    const lineH = fontPx * 1.2;
-    const ascent = fontPx * 0.85;
-    const totalH = lines.length * lineH;
-    const topY =
-      vAnchor === 'top'
-        ? innerY
-        : vAnchor === 'bottom'
-          ? innerY + (innerH - totalH)
-          : innerY + (innerH - totalH) / 2;
-    const anchorX =
-      ta === 'center' ? innerX + innerW / 2 : ta === 'right' ? innerX + innerW : innerX;
-    const textAnchor = ta === 'center' ? 'middle' : ta === 'right' ? 'end' : 'start';
-    const family = substituteFamily(null);
-    return lines
-      .map((line, i) => {
-        if (!line.trim()) return '';
-        const by = topY + i * lineH + ascent;
-        return `<text x="${px(anchorX)}" y="${px(by)}" text-anchor="${textAnchor}" font-family="${family}" font-size="${fontPx}" fill="${color}" xml:space="preserve">${escapeXml(line)}</text>`;
-      })
-      .join('');
+    return buildAndLayoutSvgText({
+      pres,
+      shape,
+      theme,
+      paraData,
+      numberLabels: paraData.map(() => null),
+      autoFitScale: 1,
+      lineHeightScale: 1,
+      defaultPt: DEFAULT_BODY_PT,
+      themeFace,
+      defaultColor: color,
+      anchor: vAnchor,
+      wrap: true,
+      innerX: innerX * EMU_PER_PX,
+      innerY: innerY * EMU_PER_PX,
+      innerW: innerW * EMU_PER_PX,
+      innerH: innerH * EMU_PER_PX,
+      measure: ctx.measure,
+      // Cell-level vertical text (<a:tcPr vert>) isn't modeled yet; cells lay
+      // out horizontally, single-column.
+      vert: 'none',
+      columns: null,
+    });
   }
 
-  // foreignObject path (browser preview): wraps and aligns like PowerPoint.
-  const justify = ta === 'center' ? 'center' : ta === 'right' ? 'flex-end' : 'flex-start';
-  const vJustify = vAnchor === 'top' ? 'flex-start' : vAnchor === 'bottom' ? 'flex-end' : 'center';
-  const body = lines
-    .map((line) => `<div style="text-align:${ta}">${escapeXml(line)}</div>`)
+  // foreignObject path (browser preview): one <p> per paragraph, each run
+  // rendered through renderRun so the browser lays the styled text out.
+  const justify = vAnchor === 'top' ? 'flex-start' : vAnchor === 'bottom' ? 'flex-end' : 'center';
+  const familyFont = themeFace ? `${escapeXml(themeFace)}, ${DEFAULT_FONT}` : DEFAULT_FONT;
+  const body = paraData
+    .map((para) => {
+      const runHtml = para.runs
+        .map((run) => renderRun(run.text, run.fmt, theme, run.sizePt, run.fmt?.size === undefined))
+        .join('');
+      const textAlign = ALIGNMENT_TO_CSS[para.align] ?? 'left';
+      return `<p style="margin:0;padding:0;text-align:${textAlign};line-height:1.2">${runHtml || '&#8203;'}</p>`;
+    })
     .join('');
-  const cellFontPx = (18 * PX_PER_PT).toFixed(1);
-  return `<foreignObject x="${px(innerX)}" y="${px(innerY)}" width="${px(innerW)}" height="${px(innerH)}"><div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;flex-direction:column;justify-content:${vJustify};align-items:${justify};width:100%;height:100%;box-sizing:border-box;overflow:hidden;font-family:${DEFAULT_FONT};color:${color};font-size:${cellFontPx}px;line-height:1.2;word-break:break-word">${body}</div></foreignObject>`;
+  return `<foreignObject x="${px(innerX)}" y="${px(innerY)}" width="${px(innerW)}" height="${px(innerH)}"><div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;flex-direction:column;justify-content:${justify};width:100%;height:100%;box-sizing:border-box;overflow:hidden;font-family:${familyFont};color:${color};word-break:break-word">${body}</div></foreignObject>`;
 };
 
 const renderTable = (
@@ -4526,6 +4562,9 @@ const renderTable = (
   const headerFill = accent;
   const bandFill = mixHex(accent, '#FFFFFF', 0.92);
   const textColor = resolveColor('scheme:tx1', theme, '#000000');
+  // Default table-cell face is the theme's body (minor) font, the same default
+  // PowerPoint applies when a cell run carries no explicit typeface.
+  const tableThemeFace = getPresentationFonts(pres)?.minorLatin ?? null;
   const out: string[] = [];
   out.push(`<g${transform}>`);
   // Whole-table backdrop so cells with no explicit fill still
@@ -4641,14 +4680,29 @@ const renderTable = (
           `<line x1="${px(cx)}" y1="${px(cy + ch)}" x2="${px(cx + cw)}" y2="${px(cy + ch)}" stroke="${defaultColor}" stroke-width="0.4" opacity="0.6"/>`,
         );
 
-      const text = getTableCellText(cell as Parameters<typeof getTableCellText>[0]);
-      const align = getTableCellAlignment(cell as Parameters<typeof getTableCellAlignment>[0]);
+      const cellParagraphs = getTableCellParagraphs(
+        cell as Parameters<typeof getTableCellParagraphs>[0],
+      );
       // ECMA-376 default cell anchor is top ('t'), which is what PowerPoint /
       // LibreOffice render when `<a:tcPr anchor>` is absent.
       const vAnchor = getTableCellAnchor(typedCell) ?? 'top';
       const cellMargins = getTableCellMargins(typedCell);
       out.push(
-        renderTableCellText(text, cx, cy, cw, ch, align, cellTextColor, ctx, vAnchor, cellMargins),
+        renderTableCellText(
+          cellParagraphs,
+          cx,
+          cy,
+          cw,
+          ch,
+          cellTextColor,
+          pres,
+          shape,
+          theme,
+          tableThemeFace,
+          ctx,
+          vAnchor,
+          cellMargins,
+        ),
       );
     }
   }

--- a/src/api/fn/shape-paragraph.ts
+++ b/src/api/fn/shape-paragraph.ts
@@ -375,7 +375,14 @@ export interface ParagraphProperties {
   rtl: boolean | null;
 }
 
-const ALIGN_TOKEN_MAP: Record<string, ParagraphProperties['align']> = {
+/**
+ * Maps an OOXML `algn` token to the friendly `ParagraphAlignment` form the
+ * rest of the API speaks. Exported so the table-cell reader normalises the
+ * same way the shape-text cascade does.
+ *
+ * @internal
+ */
+export const ALIGN_TOKEN_MAP: Record<string, ParagraphProperties['align']> = {
   l: 'left',
   ctr: 'center',
   r: 'right',

--- a/src/api/fn/shape-runs.ts
+++ b/src/api/fn/shape-runs.ts
@@ -157,8 +157,20 @@ export type ShapeParagraphElement =
 export const getShapeParagraphElements = (
   shape: SlideShapeData,
   paragraphIndex: number,
+): ReadonlyArray<ShapeParagraphElement> =>
+  readParagraphElements(requireParagraph(shape, paragraphIndex));
+
+/**
+ * Walks a single `<a:p>` element and returns its inline children in
+ * document order. Shared by the shape-text reader above and the table-cell
+ * text reader: both use the identical DrawingML run/field/break grammar, so
+ * only the way the paragraph element is located differs.
+ *
+ * @internal
+ */
+export const readParagraphElements = (
+  paragraph: XmlElement,
 ): ReadonlyArray<ShapeParagraphElement> => {
-  const paragraph = requireParagraph(shape, paragraphIndex);
   const out: ShapeParagraphElement[] = [];
   const readT = (parent: XmlElement): string => {
     const tEl = firstChildElement(parent, NAME_A_T);

--- a/src/api/fn/tables.ts
+++ b/src/api/fn/tables.ts
@@ -39,6 +39,8 @@ import {
   type TableCellData,
 } from '../_internal-symbols.ts';
 import { commitSlideData, refreshSlideData } from './_helpers.ts';
+import { type ShapeParagraphElement, readParagraphElements } from './shape-runs.ts';
+import { ALIGN_TOKEN_MAP } from './shape-paragraph.ts';
 import { getPresentationTheme } from './package.ts';
 import { resolveDrawingColor } from './shapes.ts';
 import { getSlides } from './slide-query.ts';
@@ -820,6 +822,49 @@ export const getTableCellText = (cell: TableCellData): string => {
     lines.push(line);
   }
   return lines.join('\n');
+};
+
+/** One paragraph of a cell's text, with its alignment and inline elements. */
+export interface TableCellParagraph {
+  /**
+   * Horizontal alignment from `<a:pPr algn>`, or `null` when unset (the
+   * cell then inherits PowerPoint's left default).
+   */
+  readonly align: ParagraphAlignment | null;
+  /** Runs / fields / breaks in document order, with their literal `<a:rPr>` format. */
+  readonly elements: ReadonlyArray<ShapeParagraphElement>;
+}
+
+/**
+ * Reads a cell's text as structured paragraphs — each carrying its
+ * alignment and per-run format (`size`, `bold`, `italic`, `color`,
+ * `font`, …) — for renderers that need to reproduce styled cell text.
+ * `getTableCellText` is the flat-string counterpart when only the visible
+ * characters matter. Returns an empty array when the cell has no
+ * `<a:txBody>`.
+ *
+ * The cell's `<a:txBody>` uses the same DrawingML paragraph grammar as a
+ * shape's, so this shares `readParagraphElements` with
+ * `getShapeParagraphElements`. Table-style and theme-level defaults are not
+ * folded in here: explicit run properties win, and absent ones are left
+ * `undefined` for the caller to resolve.
+ */
+export const getTableCellParagraphs = (cell: TableCellData): ReadonlyArray<TableCellParagraph> => {
+  const txBody = firstChildElement(cell[CELL_ELEMENT], NAME_A_TX_BODY_TBL);
+  if (!txBody) return [];
+  const out: TableCellParagraph[] = [];
+  for (const p of txBody.children) {
+    if (p.kind !== 'element' || p.name.namespaceURI !== NS.dml || p.name.localName !== 'p')
+      continue;
+    const pPr = firstChildElement(p, qname('a', 'pPr', NS.dml));
+    const algn = pPr ? getAttrValue(pPr, qname('', 'algn', '')) : null;
+    // Normalise the raw OOXML token (`ctr`, `l`, …) to the friendly form the
+    // rest of the API uses, mirroring the shape-text alignment cascade. A
+    // token outside the map is malformed input and reads as unset.
+    const align: ParagraphAlignment | null = algn !== null ? (ALIGN_TOKEN_MAP[algn] ?? null) : null;
+    out.push({ align, elements: readParagraphElements(p) });
+  }
+  return out;
 };
 
 /** Sets a solid background color on a cell (`<a:tcPr><a:solidFill>`). */

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -379,6 +379,7 @@ export {
   getTableCellBorders,
   getTableCellFill,
   getTableCellMargins,
+  getTableCellParagraphs,
   getTableCellPosition,
   getTableCellSpan,
   getTableCellText,
@@ -523,6 +524,7 @@ export {
 
 export type { BulletStyle, ParagraphAlignment, TextFormat } from '../internal/drawingml/index.ts';
 export type { ParagraphProperties, ShapeParagraphElement } from './fn.ts';
+export type { TableCellParagraph } from './fn.ts';
 export type {
   PresetShape,
   TransitionEffect,

--- a/test/preview-table-text.test.ts
+++ b/test/preview-table-text.test.ts
@@ -1,0 +1,125 @@
+// Unit tests for table-cell text fidelity in `renderSlideToSvg`.
+//
+// Cell text is authored through the public API (`setTableCellTextFormat` /
+// `setTableCellAlignment`) and rendered in both text-layout modes, asserting
+// that per-cell run format, alignment, the unstyled default size, wrapping,
+// and the foreignObject path all reach the output.
+//
+// Import pattern follows test/preview-render-svg.test.ts: import from package
+// source directly so vitest resolves TypeScript.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  addSlide,
+  addSlideTable,
+  findSlideLayout,
+  getTableCell,
+  inches,
+  loadPresentation,
+  setTableCellAlignment,
+  setTableCellTextFormat,
+} from '../src/api/index.ts';
+import { renderSlideToSvg } from '../packages/preview/src/index.ts';
+import { attrsOf, countTags, textContentOf } from './lib/svg-query.ts';
+
+const fixturePath = fileURLToPath(new URL('./fixtures/minimal/blank.pptx', import.meta.url));
+
+const blankSlide = async () => {
+  const pres = await loadPresentation(await readFile(fixturePath));
+  const layout = findSlideLayout(pres, 'Blank');
+  if (!layout) throw new Error('Blank layout not found');
+  const slide = addSlide(pres, { layout });
+  return { pres, slide };
+};
+
+describe('table cell text rendering', () => {
+  it('svg mode: an explicitly formatted cell carries its size / weight / color per run', async () => {
+    const { pres, slide } = await blankSlide();
+    const table = addSlideTable(slide, {
+      x: inches(1),
+      y: inches(1),
+      w: inches(6),
+      h: inches(2),
+      rows: [['Styled', 'Plain']],
+    });
+    // 28 pt bold red on the first cell; the sibling stays unformatted.
+    setTableCellTextFormat(getTableCell(table, 0, 0), { size: 28, bold: true, color: '#CC0000' });
+
+    const svg = renderSlideToSvg(pres, slide, { textLayout: 'svg' });
+    // 28 pt → 28 * 96/72 = 37.33 px.
+    expect(svg).toContain('font-size="37.33"');
+    expect(svg).toContain('font-weight="700"');
+    expect(svg).toMatch(/fill="#[Cc][Cc]0+0+"/);
+    // Both cell texts reach the output.
+    const text = textContentOf(svg);
+    expect(text).toContain('Styled');
+    expect(text).toContain('Plain');
+  });
+
+  it('svg mode: an unformatted cell falls back to the 18 pt table-cell default', async () => {
+    const { pres, slide } = await blankSlide();
+    addSlideTable(slide, {
+      x: inches(1),
+      y: inches(1),
+      w: inches(6),
+      h: inches(2),
+      rows: [['Plain']],
+    });
+    const svg = renderSlideToSvg(pres, slide, { textLayout: 'svg' });
+    // 18 pt → 18 * 96/72 = 24 px, PowerPoint's default for a freshly
+    // inserted table cell (no explicit <a:rPr sz>).
+    expect(svg).toContain('font-size="24"');
+  });
+
+  it('svg mode: a centered cell renders its text with text-anchor="middle"', async () => {
+    const { pres, slide } = await blankSlide();
+    const table = addSlideTable(slide, {
+      x: inches(1),
+      y: inches(1),
+      w: inches(6),
+      h: inches(2),
+      rows: [['Centered']],
+    });
+    setTableCellAlignment(getTableCell(table, 0, 0), 'center');
+    const svg = renderSlideToSvg(pres, slide, { textLayout: 'svg' });
+    const anchors = attrsOf(svg, 'text').map((a) => a['text-anchor']);
+    expect(anchors).toContain('middle');
+  });
+
+  it('svg mode: long cell text wraps within the cell width across multiple lines', async () => {
+    const { pres, slide } = await blankSlide();
+    // A single narrow cell forces the long sentence to wrap.
+    addSlideTable(slide, {
+      x: inches(1),
+      y: inches(1),
+      w: inches(1.5),
+      h: inches(2),
+      rows: [['Wrapping cell text spans several lines here']],
+    });
+    const svg = renderSlideToSvg(pres, slide, { textLayout: 'svg' });
+    // One <text> element is emitted per laid-out line; wrapping yields >= 2.
+    expect(countTags(svg, 'text')).toBeGreaterThanOrEqual(2);
+  });
+
+  it('foreignObject mode: cell text is emitted inside a <foreignObject>', async () => {
+    const { pres, slide } = await blankSlide();
+    const table = addSlideTable(slide, {
+      x: inches(1),
+      y: inches(1),
+      w: inches(6),
+      h: inches(2),
+      rows: [['Styled', 'Plain']],
+    });
+    setTableCellTextFormat(getTableCell(table, 0, 0), { size: 28, bold: true, color: '#CC0000' });
+    const svg = renderSlideToSvg(pres, slide, { textLayout: 'foreignObject' });
+    expect(countTags(svg, 'foreignObject')).toBeGreaterThan(0);
+    const text = textContentOf(svg);
+    expect(text).toContain('Styled');
+    expect(text).toContain('Plain');
+    // The styled cell's run still carries its bold weight and red color.
+    expect(svg).toContain('font-weight:700');
+    expect(svg).toMatch(/color:#[Cc][Cc]0+0+/);
+  });
+});


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Lands W3 of `docs/template-and-preview-plan.md`: table cell text in `@pptx-kit/preview` now renders with its authored per-run formatting (size, bold, italic, color, font), paragraph alignment, wrapping, and cell anchor — through the same text pipeline shape text uses — instead of a fixed 18 pt.

## Motivation

Plan W3 (merged in #224): `10-tables` is the lowest-scoring fidelity sample and cell text formatting was called out in the renderer as "a later refinement". One text pipeline instead of two also removes a whole class of divergence.

## Changes

- `pptx-kit` (minor): new reader `getTableCellParagraphs(cell)` returning structured paragraphs (alignment + the same `ShapeParagraphElement` inline model shapes use). Run/field/break parsing is shared with `getShapeParagraphElements` via an internal helper rather than duplicated.
- `@pptx-kit/preview` (patch): cell text builds `ParaData` and delegates to the shared layout engine (svg mode) / `renderRun` (foreignObject mode). Cell margins and vertical anchor act as the text-box insets. Unstyled runs keep the 18 pt theme-minor default (the table builder authors no `sz`; PowerPoint's inserted-table default is 18 pt) so the existing fidelity baseline holds. Cell fills/borders/banding untouched.
- Documented limitations (code comments): built-in `<a:tblStyle>` text props are not modeled in core; `<a:tcPr vert>` cell-level vertical text still lays out horizontally.

## Testing

- New `test/preview-table-text.test.ts` (5 tests, authored via public API): per-cell size/weight/color in svg mode, 18 pt default for unstyled cells, center alignment → `text-anchor="middle"`, wrapping, foreignObject mode.
- Full suite: 1070 passed, 24 skipped. format/lint/typecheck (root + preview)/build all green.

## Breaking changes

None (additive API).

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and flagged it above. (changesets added; not breaking)
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, the PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)