### PR TITLE
feat: model scatter, radar, and bubble charts (read + render)

### DIFF
--- a/.changeset/scatter-radar-bubble.md
+++ b/.changeset/scatter-radar-bubble.md
@@ -1,0 +1,14 @@
+---
+'pptx-kit': minor
+'@pptx-kit/preview': minor
+---
+
+feat: scatter, radar, and bubble charts are now modeled as their own
+`ChartKind`s instead of being folded into `line`. `ChartSeries` gains
+`xValues` (`<c:xVal>`) and `bubbleSizes` (`<c:bubbleSize>`); `ChartSpec`
+gains `scatterStyle`, `radarStyle`, `bubbleScale`, and
+`bubbleSizeRepresents`. Read + render only: the preview draws real
+scatter (two value axes + markers), radar (polar spokes/rings), and
+bubble (area-proportional circles) plots, and the write path now rejects
+these kinds loudly — previously a read-modify-write silently corrupted a
+scatter chart into a line chart.

--- a/packages/preview/src/render-slide.ts
+++ b/packages/preview/src/render-slide.ts
@@ -4181,6 +4181,286 @@ const renderPieChart = (
   return out.join('');
 };
 
+// ---------------------------------------------------------------------------
+// Scatter / radar / bubble plotters. Scatter and bubble plot xy(z) tuples
+// against two value axes (reusing `renderValueAxis`); radar is polar.
+
+// Padded [min, max] for a scatter / bubble value axis so extreme points
+// don't sit on the plot edge. Aligns the bounds to the niceTicks step.
+const scatterAxisBounds = (vals: ReadonlyArray<number>): { min: number; max: number } => {
+  let min = Infinity;
+  let max = -Infinity;
+  for (const v of vals) {
+    if (Number.isFinite(v)) {
+      if (v < min) min = v;
+      if (v > max) max = v;
+    }
+  }
+  if (!Number.isFinite(min)) return { min: 0, max: 1 };
+  if (min === max) return { min: min - 1, max: max + 1 };
+  const ticks = niceTicks(min, max);
+  const step = ticks.length >= 2 ? ticks[1]! - ticks[0]! : (max - min) / 4 || 1;
+  return { min: Math.floor(min / step) * step, max: Math.ceil(max / step) * step };
+};
+
+// Pairs a scatter / bubble series' x-channel (`xValues`, or the 1-based
+// index when absent) with its y-channel (`values`) and bubble size,
+// dropping points whose x or y is null / non-finite (PowerPoint skips
+// those too).
+const xyPoints = (series: ChartSeries): Array<{ x: number; y: number; size: number }> => {
+  const hasX = series.xValues !== undefined && series.xValues.length > 0;
+  const n = Math.max(series.xValues?.length ?? 0, series.values.length);
+  const out: Array<{ x: number; y: number; size: number }> = [];
+  for (let i = 0; i < n; i++) {
+    let x: number;
+    if (hasX) {
+      const xv = series.xValues![i];
+      if (xv === null || xv === undefined || !Number.isFinite(xv)) continue;
+      x = xv;
+    } else {
+      x = i + 1;
+    }
+    const y = series.values[i];
+    if (y === null || y === undefined || !Number.isFinite(y)) continue;
+    const sz = series.bubbleSizes?.[i];
+    out.push({ x, y, size: sz != null && Number.isFinite(sz) ? sz : 0 });
+  }
+  return out;
+};
+
+// Two value axes (x horizontal, y vertical) shared by scatter / bubble.
+// Honours the authored `<c:valAx><c:scaling>` min / max + numberFormat on
+// the y axis; the x axis is auto-scaled (our model carries only one
+// value-axis scaling block, which PowerPoint applies to the primary
+// (y) axis).
+const renderScatterAxes = (
+  f: ChartFrame,
+  spec: ChartSpec,
+  xB: { min: number; max: number },
+  yB: { min: number; max: number },
+): string => {
+  const yAxis: AxisSpec = {
+    orientation: 'vertical',
+    min: yB.min,
+    max: yB.max,
+    ...(spec.valueAxis?.numberFormat !== undefined
+      ? { numberFormat: spec.valueAxis.numberFormat }
+      : {}),
+  };
+  const xAxis: AxisSpec = { orientation: 'horizontal', min: xB.min, max: xB.max };
+  return renderValueAxis(f, yAxis) + renderValueAxis(f, xAxis);
+};
+
+const renderScatterChart = (
+  f: ChartFrame,
+  spec: ChartSpec,
+  colors: ReadonlyArray<string>,
+): string => {
+  const perSeries = spec.series.map((s) => xyPoints(s));
+  const allX: number[] = [];
+  const allY: number[] = [];
+  for (const pts of perSeries) {
+    for (const p of pts) {
+      allX.push(p.x);
+      allY.push(p.y);
+    }
+  }
+  if (allX.length === 0) return '';
+  const xB = scatterAxisBounds(allX);
+  const yB = scatterAxisBounds(allY);
+  if (spec.valueAxis?.min !== undefined) yB.min = spec.valueAxis.min;
+  if (spec.valueAxis?.max !== undefined) yB.max = spec.valueAxis.max;
+  const xRange = xB.max - xB.min || 1;
+  const yRange = yB.max - yB.min || 1;
+  const projX = (x: number): number => f.plotX + ((x - xB.min) / xRange) * f.plotW;
+  const projY = (y: number): number => f.plotY + f.plotH - ((y - yB.min) / yRange) * f.plotH;
+  const out: string[] = [renderScatterAxes(f, spec, xB, yB)];
+  // scatterStyle governs lines vs markers. Default (absent) = markers
+  // only, matching PowerPoint's stock "Scatter" subtype.
+  const style = spec.scatterStyle;
+  const showLine =
+    style === 'line' || style === 'lineMarker' || style === 'smooth' || style === 'smoothMarker';
+  const smooth = style === 'smooth' || style === 'smoothMarker';
+  const showMarker =
+    style === undefined || style === 'marker' || style === 'lineMarker' || style === 'smoothMarker';
+  for (let s = 0; s < spec.series.length; s++) {
+    const series = spec.series[s]!;
+    const pts = perSeries[s]!;
+    if (pts.length === 0) continue;
+    const color = series.color ?? colors[s % colors.length]!;
+    const proj: Array<[number, number]> = pts.map((p) => [projX(p.x), projY(p.y)]);
+    if (showLine && proj.length >= 2) {
+      const d =
+        smooth && proj.length > 2
+          ? smoothPath(proj)
+          : proj.map(([xp, yp], i) => `${i === 0 ? 'M' : 'L'}${px(xp)},${px(yp)}`).join(' ');
+      const lineWPx = series.lineWidthEmu ? Math.max(0.3, series.lineWidthEmu / EMU_PER_PX) : 1.5;
+      out.push(
+        `<path d="${d}" fill="none" stroke="${color}" stroke-width="${lineWPx.toFixed(2)}" stroke-linejoin="round" stroke-linecap="round"/>`,
+      );
+    }
+    // markerSymbol='none' always hides; an explicit symbol always shows
+    // (even under the line-only styles).
+    const sym = series.markerSymbol;
+    const drawMarker = sym === 'none' ? false : showMarker || (sym !== undefined && sym !== 'auto');
+    if (drawMarker) {
+      const r = Math.max(1.5, (series.markerSizePt ?? 5) * 0.5);
+      const glyph = sym && sym !== 'auto' && sym !== 'none' ? sym : 'circle';
+      for (const [xp, yp] of proj) out.push(seriesMarker(glyph, xp, yp, r, color));
+    }
+  }
+  return out.join('');
+};
+
+const renderBubbleChart = (
+  f: ChartFrame,
+  spec: ChartSpec,
+  colors: ReadonlyArray<string>,
+): string => {
+  const perSeries = spec.series.map((s) => xyPoints(s));
+  const allX: number[] = [];
+  const allY: number[] = [];
+  let maxSize = 0;
+  for (const pts of perSeries) {
+    for (const p of pts) {
+      allX.push(p.x);
+      allY.push(p.y);
+      if (p.size > maxSize) maxSize = p.size;
+    }
+  }
+  if (allX.length === 0) return '';
+  const xB = scatterAxisBounds(allX);
+  const yB = scatterAxisBounds(allY);
+  if (spec.valueAxis?.min !== undefined) yB.min = spec.valueAxis.min;
+  if (spec.valueAxis?.max !== undefined) yB.max = spec.valueAxis.max;
+  const xRange = xB.max - xB.min || 1;
+  const yRange = yB.max - yB.min || 1;
+  const projX = (x: number): number => f.plotX + ((x - xB.min) / xRange) * f.plotW;
+  const projY = (y: number): number => f.plotY + f.plotH - ((y - yB.min) / yRange) * f.plotH;
+  const out: string[] = [renderScatterAxes(f, spec, xB, yB)];
+  // The largest bubble's diameter is bubbleScale% (default 25%) of the
+  // plot's smaller dimension. Per-point radius scales with sqrt(size) for
+  // the default area mode (sizeRepresents='area'), linearly for 'width'.
+  const scaleFraction = spec.bubbleScale !== undefined ? spec.bubbleScale / 100 : 0.25;
+  const maxRadiusPx = Math.max(2, scaleFraction * Math.min(f.plotW, f.plotH) * 0.5);
+  const areaMode = (spec.bubbleSizeRepresents ?? 'area') === 'area';
+  const radiusFor = (size: number): number => {
+    if (maxSize <= 0 || size <= 0) return Math.max(1.5, maxRadiusPx * 0.15);
+    const frac = areaMode ? Math.sqrt(size / maxSize) : size / maxSize;
+    return Math.max(1.5, maxRadiusPx * frac);
+  };
+  for (let s = 0; s < spec.series.length; s++) {
+    const series = spec.series[s]!;
+    const pts = perSeries[s]!;
+    const color = series.color ?? colors[s % colors.length]!;
+    for (const p of pts) {
+      const cx = projX(p.x);
+      const cy = projY(p.y);
+      const r = radiusFor(p.size);
+      out.push(
+        `<circle cx="${px(cx)}" cy="${px(cy)}" r="${r.toFixed(2)}" fill="${color}" fill-opacity="0.55" stroke="${color}" stroke-width="0.75"/>`,
+      );
+    }
+  }
+  return out.join('');
+};
+
+const renderRadarChart = (
+  f: ChartFrame,
+  spec: ChartSpec,
+  colors: ReadonlyArray<string>,
+): string => {
+  const N = pointCount(spec);
+  if (N === 0 || spec.series.length === 0) return '';
+  // Rings start at 0 (or the authored min) and span to the data max (or
+  // the authored max).
+  let max = -Infinity;
+  let min = 0;
+  for (const sr of spec.series) {
+    for (const v of sr.values) {
+      if (v !== null && Number.isFinite(v) && v > max) max = v;
+    }
+  }
+  if (!Number.isFinite(max)) max = 1;
+  if (spec.valueAxis?.min !== undefined) min = spec.valueAxis.min;
+  if (spec.valueAxis?.max !== undefined) max = spec.valueAxis.max;
+  if (max <= min) max = min + 1;
+  const range = max - min;
+  const cx = f.plotX + f.plotW / 2;
+  const cy = f.plotY + f.plotH / 2;
+  // Leave a margin around the rim for the category labels.
+  const R = Math.max(4, Math.min(f.plotW, f.plotH) / 2 - 14);
+  const angleAt = (i: number): number => -Math.PI / 2 + (i * 2 * Math.PI) / N;
+  const out: string[] = [];
+  // Value rings (polygon gridlines) at each nice tick + a tick label on
+  // the top spoke.
+  for (const t of niceTicks(min, max)) {
+    if (t < min || t > max + 1e-9) continue;
+    const rr = ((t - min) / range) * R;
+    if (rr <= 0) continue;
+    const ring: string[] = [];
+    for (let i = 0; i < N; i++) {
+      const a = angleAt(i);
+      ring.push(`${px(cx + rr * Math.cos(a))},${px(cy + rr * Math.sin(a))}`);
+    }
+    out.push(
+      `<polygon points="${ring.join(' ')}" fill="none" stroke="#E5E7EB" stroke-width="0.5"/>`,
+    );
+    out.push(
+      `<text x="${px(cx + 3)}" y="${px(cy - rr)}" dominant-baseline="middle" font-family="sans-serif" font-size="8" fill="#9CA3AF">${escapeXml(formatTick(t))}</text>`,
+    );
+  }
+  // Spokes + category labels.
+  for (let i = 0; i < N; i++) {
+    const a = angleAt(i);
+    out.push(
+      `<line x1="${px(cx)}" y1="${px(cy)}" x2="${px(cx + R * Math.cos(a))}" y2="${px(cy + R * Math.sin(a))}" stroke="#D1D5DB" stroke-width="0.5"/>`,
+    );
+    const cat = spec.categories[i] ?? String(i + 1);
+    const lx = cx + (R + 8) * Math.cos(a);
+    const ly = cy + (R + 8) * Math.sin(a);
+    const cosA = Math.cos(a);
+    const anchor = Math.abs(cosA) < 0.3 ? 'middle' : cosA > 0 ? 'start' : 'end';
+    const label = cat.length > 12 ? `${cat.slice(0, 11)}…` : cat;
+    out.push(
+      `<text x="${px(lx)}" y="${px(ly)}" text-anchor="${anchor}" dominant-baseline="middle" ${axisTickAttrs(spec.categoryAxisLabelStyle)}>${escapeXml(label)}</text>`,
+    );
+  }
+  // Series polygons (closed). 'filled' fills the polygon at reduced
+  // opacity; 'marker' draws a point glyph at each vertex.
+  const filled = spec.radarStyle === 'filled';
+  const showMarker = spec.radarStyle === 'marker';
+  for (let s = 0; s < spec.series.length; s++) {
+    const series = spec.series[s]!;
+    const color = series.color ?? colors[s % colors.length]!;
+    const proj: Array<[number, number]> = [];
+    for (let i = 0; i < N; i++) {
+      const v = series.values[i];
+      if (v === null || v === undefined || !Number.isFinite(v)) continue;
+      const rr = ((v - min) / range) * R;
+      const a = angleAt(i);
+      proj.push([cx + rr * Math.cos(a), cy + rr * Math.sin(a)]);
+    }
+    if (proj.length < 2) continue;
+    const ptsStr = proj.map(([xp, yp]) => `${px(xp)},${px(yp)}`).join(' ');
+    const lineWPx = series.lineWidthEmu ? Math.max(0.3, series.lineWidthEmu / EMU_PER_PX) : 1.8;
+    out.push(
+      filled
+        ? `<polygon points="${ptsStr}" fill="${color}" fill-opacity="0.3" stroke="${color}" stroke-width="${lineWPx.toFixed(2)}" stroke-linejoin="round"/>`
+        : `<polygon points="${ptsStr}" fill="none" stroke="${color}" stroke-width="${lineWPx.toFixed(2)}" stroke-linejoin="round"/>`,
+    );
+    if (showMarker) {
+      const r = Math.max(1.5, (series.markerSizePt ?? 5) * 0.5);
+      const glyph =
+        series.markerSymbol && series.markerSymbol !== 'auto' && series.markerSymbol !== 'none'
+          ? series.markerSymbol
+          : 'circle';
+      for (const [xp, yp] of proj) out.push(seriesMarker(glyph, xp, yp, r, color));
+    }
+  }
+  return out.join('');
+};
+
 const renderChart = (
   shape: SlideShapeData,
   x: number,
@@ -4200,13 +4480,18 @@ const renderChart = (
   const colors = accentSequence(theme);
   const isCartesian =
     spec.kind === 'column' || spec.kind === 'bar' || spec.kind === 'line' || spec.kind === 'area';
+  // Scatter / bubble draw two value axes (handled inside their plotters)
+  // but still need the axis gutters; radar is polar and uses the full
+  // plot box. The shared category-axis block below stays gated on
+  // `isCartesian` so it doesn't run for the xy(z) kinds.
+  const hasAxes = isCartesian || spec.kind === 'scatter' || spec.kind === 'bubble';
   const f = layoutChart(
     x,
     y,
     w,
     h,
     !!spec.title,
-    isCartesian,
+    hasAxes,
     spec.titleOverlay ?? false,
     spec.legend?.overlay ?? false,
   );
@@ -4316,7 +4601,19 @@ const renderChart = (
     case 'doughnut':
       plot = renderPieChart(f, spec, colors, true);
       break;
+    case 'scatter':
+      plot = renderScatterChart(f, spec, colors);
+      break;
+    case 'radar':
+      plot = renderRadarChart(f, spec, colors);
+      break;
+    case 'bubble':
+      plot = renderBubbleChart(f, spec, colors);
+      break;
     default:
+      // stock / surface / 3D variants the reader still folds into a
+      // modeled kind never reach here; truly unmodeled kinds (resolved
+      // to `null` spec) are handled earlier. Anything left falls back.
       return null;
   }
 
@@ -5087,8 +5384,9 @@ const renderShape = (
     try {
       if (isChartShape(shape)) {
         // `isChartShape` was true but renderChart returned null —
-        // pptx-kit couldn't model this chart kind (3D bar, scatter,
-        // bubble, stock, radar, surface, of-pie all land here).
+        // pptx-kit couldn't model this chart kind. scatter / radar /
+        // bubble now render; what's left here is stock / surface / 3D /
+        // of-pie, which the reader still folds or drops.
         label = 'chart (unsupported kind)';
       } else if (isTableShape(shape)) {
         const t = getTableDimensions(shape);

--- a/src/api/fn/charts.ts
+++ b/src/api/fn/charts.ts
@@ -370,6 +370,11 @@ export const getShapeChartSeriesNames = (shape: SlideShapeData): ReadonlyArray<s
  * Returns the values for the named series on a chart shape, or
  * `null` when the shape isn't a chart, the kind isn't modeled, or
  * no series matches `seriesName`.
+ *
+ * For `scatter` / `bubble` charts the returned array is the series'
+ * y-channel (`<c:yVal>`); the paired x-channel and bubble sizes are on
+ * the full spec via `getShapeChartSpec` (`series[].xValues` /
+ * `series[].bubbleSizes`).
  */
 export const getShapeChartSeriesValues = (
   shape: SlideShapeData,
@@ -488,6 +493,9 @@ export const getPresentationChartKindCounts = (
     pie: 0,
     doughnut: 0,
     area: 0,
+    scatter: 0,
+    radar: 0,
+    bubble: 0,
   };
   for (const slide of getSlides(pres)) {
     for (const chart of getSlideCharts(slide)) {

--- a/src/internal/chartml/chart-builder.ts
+++ b/src/internal/chartml/chart-builder.ts
@@ -685,6 +685,17 @@ export const buildChartSpaceDoc = (spec: ChartSpec): XmlDocument => {
     case 'area':
       plotted = buildAreaChart(spec, sheet);
       break;
+    case 'scatter':
+    case 'radar':
+    case 'bubble':
+      // Read + render only (plan W4): the builder can't serialize the
+      // xy(z) tuple channels these kinds need, so reject rather than
+      // silently emit a malformed or wrong-kind chart. `readChartSpec`
+      // surfaces these kinds, but `addSlideChart` / `setChartSpec` won't
+      // write them.
+      throw new Error(
+        `chart kind '${spec.kind}' is read-only; authoring scatter / radar / bubble charts is not yet supported`,
+      );
     default: {
       const exhaustive: never = spec.kind;
       throw new Error(`unsupported chart kind: ${String(exhaustive)}`);

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -77,16 +77,14 @@ const KIND_MAP: ReadonlyArray<PlottedKindMap> = [
   { localName: 'doughnutChart', kind: 'doughnut' },
   { localName: 'areaChart', kind: 'area' },
   { localName: 'area3DChart', kind: 'area' },
-  // Scatter / bubble carry xy / xyz tuples per series rather than
-  // numeric channels against shared categories. We degrade to line
-  // so the y-axis numbers + connecting strokes show up; the x-axis
-  // collapses to index positions. Better than the "unsupported kind"
-  // placeholder by a wide margin for the common single-series case.
-  { localName: 'scatterChart', kind: 'line' },
-  { localName: 'bubbleChart', kind: 'line' },
-  // Radar collapses to a vertical line chart — the legend + axis
-  // numbers are still readable.
-  { localName: 'radarChart', kind: 'line' },
+  // Scatter / bubble carry xy / xyz tuples per series (`<c:xVal>` /
+  // `<c:yVal>` / `<c:bubbleSize>`) rather than numeric channels against
+  // shared categories; radar uses cat+val like line. All three are
+  // modeled as their own kind (read + render only — the builder rejects
+  // them, see chart-builder.ts).
+  { localName: 'scatterChart', kind: 'scatter' },
+  { localName: 'bubbleChart', kind: 'bubble' },
+  { localName: 'radarChart', kind: 'radar' },
   // Stock charts: open / high / low / close as a four-line plot.
   { localName: 'stockChart', kind: 'line' },
   // Surface degrades to a column chart so the data table is visible.
@@ -624,14 +622,17 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
       }
     }
     let valEl = firstChildElement(ser, NAME_VAL);
-    // Scatter / bubble charts carry numeric data on <c:yVal> rather
-    // than <c:val>; surface those so the line-chart degradation has
-    // something to plot. Bubble's <c:bubbleSize> is ignored — we
-    // don't have a per-point sizing channel yet.
+    // Scatter / bubble carry their y-channel on <c:yVal> rather than
+    // <c:val>; their x-channel is <c:xVal> and bubble's per-point size
+    // is <c:bubbleSize>. Radar / line use <c:val> against shared cats.
     if (!valEl) {
       valEl = firstChildElement(ser, qname('c', 'yVal', NS_C));
     }
     const values = valEl !== null ? readNumRef(valEl) : null;
+    const xValEl = firstChildElement(ser, qname('c', 'xVal', NS_C));
+    const xValues = xValEl !== null ? readNumRef(xValEl) : null;
+    const bubbleSizeEl = firstChildElement(ser, qname('c', 'bubbleSize', NS_C));
+    const bubbleSizes = bubbleSizeEl !== null ? readNumRef(bubbleSizeEl) : null;
     const color = readSeriesColor(ser);
     const { lineWidthEmu, lineDash } = readSeriesLineProps(ser);
     const { markerSymbol, markerSizePt } = readSeriesMarker(ser);
@@ -679,6 +680,8 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     series.push({
       name,
       values: values ?? [],
+      ...(xValues !== null ? { xValues } : {}),
+      ...(bubbleSizes !== null ? { bubbleSizes } : {}),
       ...(color !== undefined ? { color } : {}),
       ...(lineWidthEmu !== undefined ? { lineWidthEmu } : {}),
       ...(lineDash !== undefined ? { lineDash } : {}),
@@ -1263,6 +1266,52 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     }
   }
 
+  // Scatter / radar / bubble sub-type + bubble sizing, all read from the
+  // plotted-kind element.
+  let scatterStyle: ChartSpec['scatterStyle'];
+  let radarStyle: ChartSpec['radarStyle'];
+  let bubbleScale: number | undefined;
+  let bubbleSizeRepresents: ChartSpec['bubbleSizeRepresents'];
+  if (kind === 'scatter') {
+    const el = firstChildElement(plotted, qname('c', 'scatterStyle', NS_C));
+    if (el) {
+      const v = getAttrValue(el, ATTR_VAL);
+      if (
+        v === 'none' ||
+        v === 'line' ||
+        v === 'lineMarker' ||
+        v === 'marker' ||
+        v === 'smooth' ||
+        v === 'smoothMarker'
+      ) {
+        scatterStyle = v;
+      }
+    }
+  } else if (kind === 'radar') {
+    const el = firstChildElement(plotted, qname('c', 'radarStyle', NS_C));
+    if (el) {
+      const v = getAttrValue(el, ATTR_VAL);
+      if (v === 'standard' || v === 'marker' || v === 'filled') radarStyle = v;
+    }
+  } else if (kind === 'bubble') {
+    const bsEl = firstChildElement(plotted, qname('c', 'bubbleScale', NS_C));
+    if (bsEl) {
+      const v = getAttrValue(bsEl, ATTR_VAL);
+      if (v !== null) {
+        const n = Number.parseInt(v, 10);
+        // ST_BubbleScale spans 0..300; clamp out-of-range author values.
+        if (Number.isFinite(n) && n >= 0) bubbleScale = Math.min(300, n);
+      }
+    }
+    const srEl = firstChildElement(plotted, qname('c', 'sizeRepresents', NS_C));
+    if (srEl) {
+      const v = getAttrValue(srEl, ATTR_VAL);
+      // ST_SizeRepresents tokens are 'area' and 'w'; surface 'w' as 'width'.
+      if (v === 'area') bubbleSizeRepresents = 'area';
+      else if (v === 'w') bubbleSizeRepresents = 'width';
+    }
+  }
+
   return {
     kind,
     categories,
@@ -1328,5 +1377,9 @@ export const readChartSpec = (root: XmlElement): ChartSpec | null => {
     ...(valueAxisCrossBetween !== undefined ? { valueAxisCrossBetween } : {}),
     ...(firstSliceAngleDeg !== undefined ? { firstSliceAngleDeg } : {}),
     ...(holeSizePct !== undefined ? { holeSizePct } : {}),
+    ...(scatterStyle !== undefined ? { scatterStyle } : {}),
+    ...(radarStyle !== undefined ? { radarStyle } : {}),
+    ...(bubbleScale !== undefined ? { bubbleScale } : {}),
+    ...(bubbleSizeRepresents !== undefined ? { bubbleSizeRepresents } : {}),
   };
 };

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -1,13 +1,26 @@
 // Chart authoring types.
 //
-// Minimum-viable chart surface: one or more named series of numeric
-// values plotted against shared string categories. Sufficient for the
-// three most-requested chart types — bar, line, pie — and structured so
-// that scatter / area / radar can extend it later without breaking the
-// public shape.
+// One or more named series of numeric values plotted against shared
+// string categories (bar / column / line / pie / doughnut / area), plus
+// the xy(z)-tuple kinds (scatter / radar / bubble) the reader and preview
+// model. Authoring is supported for the category kinds only; the xy(z)
+// kinds are read + render only (see `chart-builder.ts`).
 
-/** Chart type tokens we support today. */
-export type ChartKind = 'bar' | 'column' | 'line' | 'pie' | 'doughnut' | 'area';
+/**
+ * Chart type tokens. `bar` / `column` / `line` / `pie` / `doughnut` /
+ * `area` are authorable; `scatter` / `radar` / `bubble` are read +
+ * render only — the builder rejects them (see `buildChartSpaceDoc`).
+ */
+export type ChartKind =
+  | 'bar'
+  | 'column'
+  | 'line'
+  | 'pie'
+  | 'doughnut'
+  | 'area'
+  | 'scatter'
+  | 'radar'
+  | 'bubble';
 
 /** One labelled series of numeric values. */
 export interface ChartSeries {
@@ -17,8 +30,25 @@ export interface ChartSeries {
    * Numeric values, one per category. `null` slots become empty cells in
    * the embedded workbook (PowerPoint draws them as a gap). Lengths
    * shorter than the category count are right-padded with `null`.
+   *
+   * For `scatter` / `bubble` kinds there are no categories: `values`
+   * holds the series' y-channel (`<c:yVal>`), paired positionally with
+   * `xValues`. For `radar` it behaves like `line` (values per category).
    */
   readonly values: ReadonlyArray<number | null>;
+  /**
+   * X-channel values for `scatter` / `bubble` series (`<c:xVal>`), paired
+   * positionally with `values`. Absent for every other kind, where
+   * `values` is plotted against the shared `categories`.
+   */
+  readonly xValues?: ReadonlyArray<number | null>;
+  /**
+   * Per-point bubble sizes for `bubble` series (`<c:bubbleSize>`), paired
+   * positionally with `xValues` / `values`. The renderer scales each
+   * bubble's area (or width, per `ChartSpec.bubbleSizeRepresents`) to
+   * this magnitude. Absent for non-bubble kinds.
+   */
+  readonly bubbleSizes?: ReadonlyArray<number | null>;
   /** Optional `#RRGGBB` fill override. Defaults to the theme's accent palette. */
   readonly color?: string;
   /**
@@ -599,4 +629,36 @@ export interface ChartSpec {
    * Mirrors `<c:holeSize val="…"/>`. Default 50.
    */
   readonly holeSizePct?: number;
+  /**
+   * Scatter sub-type from `<c:scatterChart><c:scatterStyle val="…"/>`
+   * (ECMA-376 ST_ScatterStyle). Governs whether the renderer connects
+   * points with straight / smoothed lines and whether it draws markers:
+   *
+   *   - `'marker'` (and the renderer's default when absent) — markers only
+   *   - `'line'` / `'smooth'` — connecting line only
+   *   - `'lineMarker'` / `'smoothMarker'` — line + markers
+   *   - `'none'` — neither
+   */
+  readonly scatterStyle?: 'none' | 'line' | 'lineMarker' | 'marker' | 'smooth' | 'smoothMarker';
+  /**
+   * Radar sub-type from `<c:radarChart><c:radarStyle val="…"/>`
+   * (ECMA-376 ST_RadarStyle): `'standard'` (polyline only), `'marker'`
+   * (polyline + point markers), or `'filled'` (the polygon is filled at
+   * reduced opacity).
+   */
+  readonly radarStyle?: 'standard' | 'marker' | 'filled';
+  /**
+   * Bubble-size scale percentage from `<c:bubbleChart><c:bubbleScale
+   * val="N"/>` (0..300, PowerPoint default 100). Scales every bubble's
+   * rendered radius proportionally.
+   */
+  readonly bubbleScale?: number;
+  /**
+   * Whether a bubble's `<c:bubbleSize>` maps to the bubble's area or its
+   * width — `<c:bubbleChart><c:sizeRepresents val="area|w"/>` (ECMA-376
+   * ST_SizeRepresents; the `'w'` token is surfaced as `'width'`).
+   * PowerPoint's default is `'area'`, so radius scales with `sqrt(size)`;
+   * `'width'` scales radius linearly with size.
+   */
+  readonly bubbleSizeRepresents?: 'area' | 'width';
 }

--- a/test/fn-chart-reader-extras.test.ts
+++ b/test/fn-chart-reader-extras.test.ts
@@ -272,3 +272,148 @@ describe('chart reader: extras', () => {
     expect(spec.varyColors).toBe(true);
   });
 });
+
+describe('chart reader: scatter / radar / bubble', () => {
+  it('detects scatter, reads xy tuples + scatterStyle', () => {
+    const xml = wrap(`
+      <c:plotArea>
+        <c:layout/>
+        <c:scatterChart>
+          <c:scatterStyle val="lineMarker"/>
+          <c:ser>
+            <c:idx val="0"/>
+            <c:order val="0"/>
+            <c:tx><c:strLit><c:pt idx="0"><c:v>S1</c:v></c:pt></c:strLit></c:tx>
+            <c:xVal>
+              <c:numLit>
+                <c:pt idx="0"><c:v>1</c:v></c:pt>
+                <c:pt idx="1"><c:v>2</c:v></c:pt>
+                <c:pt idx="2"><c:v>3</c:v></c:pt>
+              </c:numLit>
+            </c:xVal>
+            <c:yVal>
+              <c:numLit>
+                <c:pt idx="0"><c:v>10</c:v></c:pt>
+                <c:pt idx="1"><c:v>20</c:v></c:pt>
+                <c:pt idx="2"><c:v>15</c:v></c:pt>
+              </c:numLit>
+            </c:yVal>
+          </c:ser>
+          <c:axId val="1"/>
+          <c:axId val="2"/>
+        </c:scatterChart>
+        <c:valAx><c:axId val="1"/><c:crossAx val="2"/></c:valAx>
+        <c:valAx><c:axId val="2"/><c:crossAx val="1"/></c:valAx>
+      </c:plotArea>
+    `);
+    const spec = readChartSpec(parseXml(xml).root)!;
+    expect(spec.kind).toBe('scatter');
+    expect(spec.scatterStyle).toBe('lineMarker');
+    // For scatter, `values` is the y-channel; `xValues` the paired x.
+    expect(spec.series[0]!.xValues).toEqual([1, 2, 3]);
+    expect(spec.series[0]!.values).toEqual([10, 20, 15]);
+  });
+
+  it('detects bubble, reads bubbleSize + bubbleScale + sizeRepresents', () => {
+    const xml = wrap(`
+      <c:plotArea>
+        <c:layout/>
+        <c:bubbleChart>
+          <c:ser>
+            <c:idx val="0"/>
+            <c:order val="0"/>
+            <c:tx><c:strLit><c:pt idx="0"><c:v>B1</c:v></c:pt></c:strLit></c:tx>
+            <c:xVal>
+              <c:numLit><c:pt idx="0"><c:v>1</c:v></c:pt><c:pt idx="1"><c:v>2</c:v></c:pt></c:numLit>
+            </c:xVal>
+            <c:yVal>
+              <c:numLit><c:pt idx="0"><c:v>10</c:v></c:pt><c:pt idx="1"><c:v>20</c:v></c:pt></c:numLit>
+            </c:yVal>
+            <c:bubbleSize>
+              <c:numLit><c:pt idx="0"><c:v>4</c:v></c:pt><c:pt idx="1"><c:v>9</c:v></c:pt></c:numLit>
+            </c:bubbleSize>
+          </c:ser>
+          <c:bubbleScale val="80"/>
+          <c:sizeRepresents val="area"/>
+          <c:axId val="1"/>
+          <c:axId val="2"/>
+        </c:bubbleChart>
+        <c:valAx><c:axId val="1"/><c:crossAx val="2"/></c:valAx>
+        <c:valAx><c:axId val="2"/><c:crossAx val="1"/></c:valAx>
+      </c:plotArea>
+    `);
+    const spec = readChartSpec(parseXml(xml).root)!;
+    expect(spec.kind).toBe('bubble');
+    expect(spec.bubbleScale).toBe(80);
+    expect(spec.bubbleSizeRepresents).toBe('area');
+    expect(spec.series[0]!.xValues).toEqual([1, 2]);
+    expect(spec.series[0]!.values).toEqual([10, 20]);
+    expect(spec.series[0]!.bubbleSizes).toEqual([4, 9]);
+  });
+
+  it("maps sizeRepresents='w' to 'width'", () => {
+    const xml = wrap(`
+      <c:plotArea>
+        <c:layout/>
+        <c:bubbleChart>
+          <c:ser>
+            <c:idx val="0"/>
+            <c:order val="0"/>
+            <c:tx><c:strLit><c:pt idx="0"><c:v>B</c:v></c:pt></c:strLit></c:tx>
+            <c:yVal><c:numLit><c:pt idx="0"><c:v>1</c:v></c:pt></c:numLit></c:yVal>
+            <c:bubbleSize><c:numLit><c:pt idx="0"><c:v>1</c:v></c:pt></c:numLit></c:bubbleSize>
+          </c:ser>
+          <c:sizeRepresents val="w"/>
+          <c:axId val="1"/>
+          <c:axId val="2"/>
+        </c:bubbleChart>
+        <c:valAx><c:axId val="1"/><c:crossAx val="2"/></c:valAx>
+        <c:valAx><c:axId val="2"/><c:crossAx val="1"/></c:valAx>
+      </c:plotArea>
+    `);
+    const spec = readChartSpec(parseXml(xml).root)!;
+    expect(spec.bubbleSizeRepresents).toBe('width');
+  });
+
+  it('detects radar, reads cat/val + radarStyle', () => {
+    const xml = wrap(`
+      <c:plotArea>
+        <c:layout/>
+        <c:radarChart>
+          <c:radarStyle val="filled"/>
+          <c:ser>
+            <c:idx val="0"/>
+            <c:order val="0"/>
+            <c:tx><c:strLit><c:pt idx="0"><c:v>R1</c:v></c:pt></c:strLit></c:tx>
+            <c:cat>
+              <c:strLit>
+                <c:pt idx="0"><c:v>A</c:v></c:pt>
+                <c:pt idx="1"><c:v>B</c:v></c:pt>
+                <c:pt idx="2"><c:v>C</c:v></c:pt>
+              </c:strLit>
+            </c:cat>
+            <c:val>
+              <c:numLit>
+                <c:pt idx="0"><c:v>3</c:v></c:pt>
+                <c:pt idx="1"><c:v>5</c:v></c:pt>
+                <c:pt idx="2"><c:v>2</c:v></c:pt>
+              </c:numLit>
+            </c:val>
+          </c:ser>
+          <c:axId val="1"/>
+          <c:axId val="2"/>
+        </c:radarChart>
+        <c:catAx><c:axId val="1"/><c:crossAx val="2"/></c:catAx>
+        <c:valAx><c:axId val="2"/><c:crossAx val="1"/></c:valAx>
+      </c:plotArea>
+    `);
+    const spec = readChartSpec(parseXml(xml).root)!;
+    expect(spec.kind).toBe('radar');
+    expect(spec.radarStyle).toBe('filled');
+    expect(spec.categories).toEqual(['A', 'B', 'C']);
+    expect(spec.series[0]!.values).toEqual([3, 5, 2]);
+    // Radar carries no x-channel / bubble sizes.
+    expect(spec.series[0]!.xValues).toBeUndefined();
+    expect(spec.series[0]!.bubbleSizes).toBeUndefined();
+  });
+});

--- a/test/fn-chart-update.test.ts
+++ b/test/fn-chart-update.test.ts
@@ -103,4 +103,46 @@ describe('fn API: setChartSpec', () => {
       ),
     ).toThrow(/not a chart/);
   });
+
+  // scatter / radar / bubble are read + render only (plan W4). The builder
+  // can't serialize their xy(z) tuple channels, so both write paths reject
+  // them with a clear error rather than silently emitting a wrong-kind
+  // chart. The previous behavior folded these into `line`, which would have
+  // round-tripped a scatter chart into a corrupt line chart.
+  it('addSlideChart rejects scatter / radar / bubble kinds', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    for (const kind of ['scatter', 'radar', 'bubble'] as const) {
+      expect(() =>
+        addSlideChart(slide, {
+          x: inches(0),
+          y: inches(0),
+          w: inches(4),
+          h: inches(3),
+          spec: { kind, categories: [], series: [{ name: 'S', values: [1], xValues: [1] }] },
+        }),
+      ).toThrow(/read-only/);
+    }
+  });
+
+  it('setChartSpec rejects switching an existing chart to scatter', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(4),
+      h: inches(3),
+      spec: { kind: 'column', categories: ['A'], series: [{ name: 'S', values: [1] }] },
+    });
+    const reloaded = await loadPresentation(await savePresentation(pres));
+    const chart = getSlideCharts(getSlides(reloaded)[0]!)[0]!;
+    expect(() =>
+      setChartSpec(chart, {
+        kind: 'scatter',
+        categories: [],
+        series: [{ name: 'S', values: [1, 2], xValues: [1, 2] }],
+      }),
+    ).toThrow(/read-only/);
+  });
 });

--- a/test/fn-get-presentation-chart-kind-counts.test.ts
+++ b/test/fn-get-presentation-chart-kind-counts.test.ts
@@ -26,6 +26,9 @@ describe('fn API: getPresentationChartKindCounts', () => {
       pie: 0,
       doughnut: 0,
       area: 0,
+      scatter: 0,
+      radar: 0,
+      bubble: 0,
     });
   });
 
@@ -60,6 +63,9 @@ describe('fn API: getPresentationChartKindCounts', () => {
       pie: 1,
       doughnut: 0,
       area: 0,
+      scatter: 0,
+      radar: 0,
+      bubble: 0,
     });
   });
 
@@ -75,7 +81,7 @@ describe('fn API: getPresentationChartKindCounts', () => {
     });
     const counts = getPresentationChartKindCounts(pres);
     expect(Object.keys(counts).sort()).toEqual(
-      ['area', 'bar', 'column', 'doughnut', 'line', 'pie'].sort(),
+      ['area', 'bar', 'bubble', 'column', 'doughnut', 'line', 'pie', 'radar', 'scatter'].sort(),
     );
     expect(counts.line).toBe(1);
   });

--- a/test/preview-render-svg.test.ts
+++ b/test/preview-render-svg.test.ts
@@ -312,6 +312,133 @@ describe('renderSlideToSvg', () => {
     const opts = { textLayout: 'svg' as const };
     expect(renderSlideToSvg(pres, slide, opts)).toBe(renderSlideToSvg(pres, slide, opts));
   });
+
+  // scatter / radar / bubble have no public authoring API (read + render
+  // only — plan W4). To exercise their plotters we build a deck with a
+  // throwaway bar chart, then swap the chart part's XML via the internal
+  // OPC zip layer (the same hook the fallback test above uses).
+  const renderInjectedChart = async (chartXml: string): Promise<string> => {
+    const { pres, slide } = await blankSlide();
+    addSlideChart(slide, {
+      spec: { kind: 'bar', categories: ['A'], series: [{ name: 'S', values: [1] }] },
+      x: inches(1),
+      y: inches(1),
+      w: inches(6),
+      h: inches(4),
+    });
+    const bytes = await savePresentation(pres);
+    const { entries } = readZip(bytes);
+    const enc = new TextEncoder();
+    const modified = entries.map((e) =>
+      e.name.includes('charts/chart') ? { name: e.name, data: enc.encode(chartXml) } : e,
+    );
+    const pres2 = await loadPresentation(writeZip(modified));
+    return renderSlideToSvg(pres2, getSlides(pres2)[0]!);
+  };
+
+  const chartSpaceXml = (chart: string): string =>
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+              xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <c:chart>
+    <c:title><c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>XY Demo</a:t></a:r></a:p></c:rich></c:tx></c:title>
+    ${chart}
+    <c:legend><c:legendPos val="b"/></c:legend>
+  </c:chart>
+</c:chartSpace>`;
+
+  const scatterPlotArea = (scatterStyle: string): string =>
+    chartSpaceXml(`
+    <c:plotArea>
+      <c:layout/>
+      <c:scatterChart>
+        <c:scatterStyle val="${scatterStyle}"/>
+        <c:ser>
+          <c:idx val="0"/><c:order val="0"/>
+          <c:tx><c:strLit><c:pt idx="0"><c:v>Alpha</c:v></c:pt></c:strLit></c:tx>
+          <c:xVal><c:numLit><c:pt idx="0"><c:v>1</c:v></c:pt><c:pt idx="1"><c:v>2</c:v></c:pt><c:pt idx="2"><c:v>3</c:v></c:pt></c:numLit></c:xVal>
+          <c:yVal><c:numLit><c:pt idx="0"><c:v>10</c:v></c:pt><c:pt idx="1"><c:v>30</c:v></c:pt><c:pt idx="2"><c:v>20</c:v></c:pt></c:numLit></c:yVal>
+        </c:ser>
+        <c:axId val="1"/><c:axId val="2"/>
+      </c:scatterChart>
+      <c:valAx><c:axId val="1"/><c:crossAx val="2"/></c:valAx>
+      <c:valAx><c:axId val="2"/><c:crossAx val="1"/></c:valAx>
+    </c:plotArea>`);
+
+  it('scatter (marker style): point markers, no connecting line, no fallback, legend present', async () => {
+    const svg = await renderInjectedChart(scatterPlotArea('marker'));
+    expect(svg).not.toContain('data-pptx-fallback="chart"');
+    // One <circle> per data point (3); markers only means no plot <path>.
+    expect(countTags(svg, 'circle')).toBeGreaterThanOrEqual(3);
+    expect(countTags(svg, 'path')).toBe(0);
+    expect(svg).toContain('Alpha');
+  });
+
+  it('scatter (lineMarker style): adds a connecting <path> over the markers', async () => {
+    const markerOnly = await renderInjectedChart(scatterPlotArea('marker'));
+    const lineMarker = await renderInjectedChart(scatterPlotArea('lineMarker'));
+    expect(countTags(lineMarker, 'circle')).toBeGreaterThanOrEqual(3);
+    // The connecting polyline is the only <path> source on this slide.
+    expect(countTags(lineMarker, 'path')).toBeGreaterThan(countTags(markerOnly, 'path'));
+  });
+
+  it('radar (filled): closed series polygon filled at reduced opacity, no fallback', async () => {
+    const svg = await renderInjectedChart(
+      chartSpaceXml(`
+      <c:plotArea>
+        <c:layout/>
+        <c:radarChart>
+          <c:radarStyle val="filled"/>
+          <c:ser>
+            <c:idx val="0"/><c:order val="0"/>
+            <c:tx><c:strLit><c:pt idx="0"><c:v>Alpha</c:v></c:pt></c:strLit></c:tx>
+            <c:cat><c:strLit><c:pt idx="0"><c:v>A</c:v></c:pt><c:pt idx="1"><c:v>B</c:v></c:pt><c:pt idx="2"><c:v>C</c:v></c:pt></c:strLit></c:cat>
+            <c:val><c:numLit><c:pt idx="0"><c:v>3</c:v></c:pt><c:pt idx="1"><c:v>5</c:v></c:pt><c:pt idx="2"><c:v>2</c:v></c:pt></c:numLit></c:val>
+          </c:ser>
+          <c:axId val="1"/><c:axId val="2"/>
+        </c:radarChart>
+        <c:catAx><c:axId val="1"/><c:crossAx val="2"/></c:catAx>
+        <c:valAx><c:axId val="2"/><c:crossAx val="1"/></c:valAx>
+      </c:plotArea>`),
+    );
+    expect(svg).not.toContain('data-pptx-fallback="chart"');
+    // Rings + the closed series polygon are all <polygon>.
+    expect(countTags(svg, 'polygon')).toBeGreaterThan(0);
+    expect(svg).toContain('fill-opacity="0.3"');
+    expect(svg).toContain('Alpha');
+  });
+
+  it('bubble: per-point circles with different radii, no fallback', async () => {
+    const svg = await renderInjectedChart(
+      chartSpaceXml(`
+      <c:plotArea>
+        <c:layout/>
+        <c:bubbleChart>
+          <c:ser>
+            <c:idx val="0"/><c:order val="0"/>
+            <c:tx><c:strLit><c:pt idx="0"><c:v>Alpha</c:v></c:pt></c:strLit></c:tx>
+            <c:xVal><c:numLit><c:pt idx="0"><c:v>1</c:v></c:pt><c:pt idx="1"><c:v>2</c:v></c:pt><c:pt idx="2"><c:v>3</c:v></c:pt></c:numLit></c:xVal>
+            <c:yVal><c:numLit><c:pt idx="0"><c:v>10</c:v></c:pt><c:pt idx="1"><c:v>20</c:v></c:pt><c:pt idx="2"><c:v>15</c:v></c:pt></c:numLit></c:yVal>
+            <c:bubbleSize><c:numLit><c:pt idx="0"><c:v>1</c:v></c:pt><c:pt idx="1"><c:v>9</c:v></c:pt><c:pt idx="2"><c:v>4</c:v></c:pt></c:numLit></c:bubbleSize>
+          </c:ser>
+          <c:bubbleScale val="100"/>
+          <c:sizeRepresents val="area"/>
+          <c:axId val="1"/><c:axId val="2"/>
+        </c:bubbleChart>
+        <c:valAx><c:axId val="1"/><c:crossAx val="2"/></c:valAx>
+        <c:valAx><c:axId val="2"/><c:crossAx val="1"/></c:valAx>
+      </c:plotArea>`),
+    );
+    expect(svg).not.toContain('data-pptx-fallback="chart"');
+    const radii = attrsOf(svg, 'circle')
+      .map((a) => a['r'])
+      .filter((r): r is string => r !== undefined);
+    expect(radii.length).toBeGreaterThanOrEqual(3);
+    // Area-proportional sizing (sizes 1 / 9 / 4) must yield distinct radii.
+    expect(new Set(radii).size).toBeGreaterThan(1);
+    expect(svg).toContain('Alpha');
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Lands W4 of `docs/template-and-preview-plan.md`: scatter, radar, and bubble charts become first-class `ChartKind`s (read + render). The preview draws real plots for all three instead of a line-chart approximation, and the write path now rejects these kinds loudly instead of silently corrupting them into line charts on read-modify-write.

## Motivation

Plan W4 (merged in #224). The old line-folding had a correctness hazard beyond rendering: `getShapeChartSpec` → `setChartSpec` round-trip rewrote a scatter chart as a line chart with index-position x-values.

## Changes

- `pptx-kit` (minor):
  - `ChartKind` gains `'scatter' | 'radar' | 'bubble'`.
  - `ChartSeries` gains optional `xValues` (`<c:xVal>`) and `bubbleSizes` (`<c:bubbleSize>`); `values` stays the y-channel for scatter/bubble (documented).
  - `ChartSpec` gains `scatterStyle`, `radarStyle`, `bubbleScale`, `bubbleSizeRepresents` (enum tokens verified against the ECMA-376 `dml-chart.xsd`).
  - `addSlideChart` / `setChartSpec` throw `chart kind '…' is read-only` for these kinds — authoring is explicitly out of scope.
- `@pptx-kit/preview` (minor): dedicated plotters reusing the shared chart chrome — scatter (two value axes, per-series markers, connecting path only for line/smooth scatterStyles), radar (equal-angle spokes, polygon rings, closed series polygons, `filled` at 0.3 opacity), bubble (largest diameter = `bubbleScale`% of plot's smaller dimension, radius ∝ √size in area mode). No more `data-pptx-fallback="chart"` for these kinds.

## Testing

- +4 reader tests (xy tuples, bubble size/scale, `w`→`width`, radar styles), +2 write-rejection tests, +4 renderer tests (zip-layer chart injection; geometry + no-fallback + legend assertions).
- 1 existing test updated: `fn-get-presentation-chart-kind-counts` — the `Record<ChartKind, number>` histogram now carries the three new zero-count keys (additive shape change, not a behavior change).
- Full suite: 1080 passed, 24 skipped. format/lint/typecheck (root + preview)/build/tree-shake (57.1 KB minimal, within bound) all green.

## Breaking changes

None. (Charts of these kinds previously read back as `kind: 'line'`; they now read as their real kind — that is the documented approximation being replaced by the correct value, and the histogram/record shape change is additive.)

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and flagged it above. (changesets added; not breaking)
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, the PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)