### PR TITLE
chore: rename @pptx-kit/preview to pptx-kit-preview

### DIFF
--- a/.changeset/custom-geometry.md
+++ b/.changeset/custom-geometry.md
@@ -1,6 +1,6 @@
 ---
 'pptx-kit': minor
-'@pptx-kit/preview': minor
+'pptx-kit-preview': minor
 ---
 
 feat: read custom geometry. New `getShapeCustomGeometry(shape)` returns a

--- a/.changeset/effects-fills-polish.md
+++ b/.changeset/effects-fills-polish.md
@@ -1,6 +1,6 @@
 ---
 'pptx-kit': minor
-'@pptx-kit/preview': minor
+'pptx-kit-preview': minor
 ---
 
 feat: effects & fills polish. The reflection effect (`a:reflection`) now

--- a/.changeset/extract-preview-package.md
+++ b/.changeset/extract-preview-package.md
@@ -3,9 +3,9 @@
 ---
 
 chore(site): the preview renderer moved out of the site into a dedicated
-`@pptx-kit/preview` workspace package. The playground and REPL now import
-`renderSlideToSvg` from `@pptx-kit/preview`, and the fidelity harness renders
-through `@pptx-kit/preview/node` (`renderSlideToRgba`). No change to what the
+`pptx-kit-preview` workspace package. The playground and REPL now import
+`renderSlideToSvg` from `pptx-kit-preview`, and the fidelity harness renders
+through `pptx-kit-preview/node` (`renderSlideToRgba`). No change to what the
 site renders — this is a structural extraction so the Node "slide → image"
 capability lives behind a clean, reusable module boundary (SVG in the browser,
 PNG/RGBA in Node via resvg, no browser binary).

--- a/.changeset/preview-svg-vertical-columns.md
+++ b/.changeset/preview-svg-vertical-columns.md
@@ -1,5 +1,5 @@
 ---
-'@pptx-kit/preview': minor
+'pptx-kit-preview': minor
 ---
 
 feat(preview): vertical text (`vert`, `vert270`, `eaVert`, `mongolianVert`,

--- a/.changeset/preview-table-text.md
+++ b/.changeset/preview-table-text.md
@@ -1,5 +1,5 @@
 ---
-'@pptx-kit/preview': patch
+'pptx-kit-preview': patch
 ---
 
 fix(preview): table cell text now renders with its real per-run formatting —

--- a/.changeset/scatter-radar-bubble.md
+++ b/.changeset/scatter-radar-bubble.md
@@ -1,6 +1,6 @@
 ---
 'pptx-kit': minor
-'@pptx-kit/preview': minor
+'pptx-kit-preview': minor
 ---
 
 feat: scatter, radar, and bubble charts are now modeled as their own

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,14 +53,14 @@ jobs:
       - name: Build
         run: pnpm build
 
-      # The @pptx-kit/preview companion package type-checks and builds against
+      # The pptx-kit-preview companion package type-checks and builds against
       # pptx-kit's emitted types, so these run after the root build. It's a
       # separate workspace package with its own tsconfig / tsup config.
       - name: Type check preview package
-        run: pnpm --filter @pptx-kit/preview typecheck
+        run: pnpm --filter pptx-kit-preview typecheck
 
       - name: Build preview package
-        run: pnpm --filter @pptx-kit/preview build
+        run: pnpm --filter pptx-kit-preview build
 
   # Multi-version test matrix. Adapt the matrix to the runtimes the project
   # supports. Drop versions that are past their EOL date.
@@ -84,7 +84,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
 
-  # Measures how closely @pptx-kit/preview's SVG renderer matches LibreOffice's
+  # Measures how closely pptx-kit-preview's SVG renderer matches LibreOffice's
   # output for each generated sample slide, and gates on a committed baseline.
   fidelity:
     name: Preview fidelity
@@ -96,7 +96,7 @@ jobs:
       # ground truth = LibreOffice PDF export rasterized by pdftoppm.
       # --no-install-recommends skips LibreOffice's font packages, so install
       # the metric-compatible families explicitly — they're the same ones
-      # @pptx-kit/preview bundles (Carlito≈Calibri, Caladea≈Cambria,
+      # pptx-kit-preview bundles (Carlito≈Calibri, Caladea≈Cambria,
       # Liberation≈Arial/Times/Courier). Without them LibreOffice falls back
       # to whatever fontconfig scrapes up and every text slide's fg-SSIM
       # collapses to ~0.
@@ -118,7 +118,7 @@ jobs:
         run: pnpm build
 
       - name: Build preview package
-        run: pnpm --filter @pptx-kit/preview build
+        run: pnpm --filter pptx-kit-preview build
 
       - name: Generate sample PPTX files
         run: pnpm samples

--- a/docs/template-and-preview-plan.md
+++ b/docs/template-and-preview-plan.md
@@ -8,7 +8,7 @@ This document is the execution plan for pptx-kit's two product goals beyond
 1. **Template-to-deck** — produce a _new_ presentation from an existing
    template or an existing presentation, not just mutate one in place.
 2. **Preview** — render any supported presentation faithfully in **both the
-   browser and the server (Node)** via `@pptx-kit/preview`.
+   browser and the server (Node)** via `pptx-kit-preview`.
 
 Each workstream below has a concrete deliverable, a test obligation, and an
 acceptance criterion. The plan is ordered so that every step is independently
@@ -33,7 +33,7 @@ real template, builds a _new_ deck (keep masters/layouts/theme, drop the
 template's slides, add fresh ones), and asserts the output is schema-valid,
 opens round-trip clean, and renders.
 
-### Preview (`@pptx-kit/preview`)
+### Preview (`pptx-kit-preview`)
 
 Two entry points exist today:
 
@@ -75,7 +75,7 @@ The goal is met when **all** of the following hold:
 
 1. **Template-to-deck**: an E2E test (`test/e2e-template-to-deck.test.ts`)
    builds a new deck from a template fixture, and the output passes schema
-   validation, round-trips structurally, and renders via `@pptx-kit/preview`
+   validation, round-trips structurally, and renders via `pptx-kit-preview`
    without fallback markers for supported features.
 2. **Runtime parity**: for every supported feature, the SVG/server text path
    produces the same layout decisions as the browser path (same line breaks,

--- a/packages/preview/README.md
+++ b/packages/preview/README.md
@@ -1,4 +1,4 @@
-# @pptx-kit/preview
+# pptx-kit-preview
 
 Preview renderer for [`pptx-kit`](https://github.com/baseballyama/pptx-kit).
 Turns a `pptx-kit` slide model into an **SVG** (browser + Node) or rasterizes
@@ -21,10 +21,10 @@ lays text out as pure SVG `<text>` (no `<foreignObject>`) and paints it with
 
 ## Entry points
 
-| Import                   | Runtime        | Use                                                 |
-| ------------------------ | -------------- | --------------------------------------------------- |
-| `@pptx-kit/preview`      | browser + Node | `renderSlideToSvg` → an SVG string                  |
-| `@pptx-kit/preview/node` | Node only      | `renderSlideToImage` / `renderSlideToRgba` → pixels |
+| Import                  | Runtime        | Use                                                 |
+| ----------------------- | -------------- | --------------------------------------------------- |
+| `pptx-kit-preview`      | browser + Node | `renderSlideToSvg` → an SVG string                  |
+| `pptx-kit-preview/node` | Node only      | `renderSlideToImage` / `renderSlideToRgba` → pixels |
 
 The browser entry pulls in **no** Node built-ins (no `node:fs`, resvg, or
 fontkit), so it bundles cleanly for the web.
@@ -34,7 +34,7 @@ fontkit), so it bundles cleanly for the web.
 ### SVG (browser or Node)
 
 ```ts
-import { renderSlideToSvg } from '@pptx-kit/preview';
+import { renderSlideToSvg } from 'pptx-kit-preview';
 import { loadPresentation, getSlides } from 'pptx-kit';
 
 const pres = await loadPresentation(bytes);
@@ -45,7 +45,7 @@ const svg = renderSlideToSvg(pres, getSlides(pres)[0]);
 ### PNG / RGBA (Node, no browser)
 
 ```ts
-import { renderSlideToImage, renderSlideToRgba } from '@pptx-kit/preview/node';
+import { renderSlideToImage, renderSlideToRgba } from 'pptx-kit-preview/node';
 import { loadPresentationFile, getSlides } from 'pptx-kit/node';
 
 const pres = await loadPresentationFile('deck.pptx');

--- a/packages/preview/package.json
+++ b/packages/preview/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pptx-kit/preview",
+  "name": "pptx-kit-preview",
   "version": "0.1.0",
   "description": "Experimental preview renderer for pptx-kit: render a slide to SVG (browser + Node) or rasterize it to a PNG/RGBA image in Node, with no browser binary.",
   "keywords": [

--- a/packages/preview/src/index.ts
+++ b/packages/preview/src/index.ts
@@ -1,8 +1,8 @@
-// `@pptx-kit/preview` — browser-safe entry.
+// `pptx-kit-preview` — browser-safe entry.
 //
 // Renders a pptx-kit slide model to an SVG string. This module pulls in NO
 // Node built-ins (no `node:fs`, no resvg, no fontkit), so it bundles for the
-// browser. For Node rasterization to PNG/RGBA, import `@pptx-kit/preview/node`.
+// browser. For Node rasterization to PNG/RGBA, import `pptx-kit-preview/node`.
 //
 // `renderSlideToSvg` is the canonical preview entry. By default it lays text
 // out with `<foreignObject>` (the browser measures + wraps), which is correct

--- a/packages/preview/src/node.ts
+++ b/packages/preview/src/node.ts
@@ -1,4 +1,4 @@
-// `@pptx-kit/preview/node` — Node entry: rasterize a slide to a PNG or raw
+// `pptx-kit-preview/node` — Node entry: rasterize a slide to a PNG or raw
 // RGBA image, with no browser binary.
 //
 // Pipeline: `renderSlideToSvg(..., { textLayout: 'svg', measureText })` lays

--- a/packages/preview/tsconfig.json
+++ b/packages/preview/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "// note": "Standalone tsconfig for @pptx-kit/preview. The root vitest also imports text-layout.ts from here and resolves this config (a clean one) instead of walking up to site/tsconfig.json, which extends the svelte-kit-generated ./.svelte-kit/tsconfig.json that only exists after `svelte-kit sync`.",
+  "// note": "Standalone tsconfig for pptx-kit-preview. The root vitest also imports text-layout.ts from here and resolves this config (a clean one) instead of walking up to site/tsconfig.json, which extends the svelte-kit-generated ./.svelte-kit/tsconfig.json that only exists after `svelte-kit sync`.",
   "// ignoreDeprecations": "tsup's dts build injects `baseUrl` into its synthesized tsconfig, which TS 6 deprecates (TS5101). Drop once tsup stops injecting it (required anyway before TS 7 removes baseUrl).",
   "compilerOptions": {
     "ignoreDeprecations": "6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,9 +77,6 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2
     devDependencies:
-      '@pptx-kit/preview':
-        specifier: workspace:*
-        version: link:../packages/preview
       '@sveltejs/adapter-static':
         specifier: ^3.0.10
         version: 3.0.10(@sveltejs/kit@2.65.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(tsx@4.22.4)))(svelte@5.56.3)(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(tsx@4.22.4)))
@@ -101,6 +98,9 @@ importers:
       pptx-kit:
         specifier: workspace:*
         version: link:..
+      pptx-kit-preview:
+        specifier: workspace:*
+        version: link:../packages/preview
       shiki:
         specifier: ^4.2.0
         version: 4.2.0

--- a/site/fidelity/README.md
+++ b/site/fidelity/README.md
@@ -1,6 +1,6 @@
 # Preview fidelity harness
 
-Measures how close pptx-kit's preview renderer (the `@pptx-kit/preview`
+Measures how close pptx-kit's preview renderer (the `pptx-kit-preview`
 package) is to a real presentation engine, **as a number per slide** — the
 measurement spine from the preview-fidelity roadmap. Without it, "make the
 preview perfect" is unfalsifiable eyeballing.
@@ -8,10 +8,10 @@ preview perfect" is unfalsifiable eyeballing.
 ```
 ground truth (LibreOffice / PowerPoint)           →  PDF  →  PPM  ┐
                                                                   ├─→  SSIM + diff  →  report
-@pptx-kit/preview/node · renderSlideToRgba(width)  →  SVG → resvg → RGBA  ┘
+pptx-kit-preview/node · renderSlideToRgba(width)  →  SVG → resvg → RGBA  ┘
 ```
 
-`renderSlideToRgba` (from `@pptx-kit/preview/node`) lays text out as pure SVG
+`renderSlideToRgba` (from `pptx-kit-preview/node`) lays text out as pure SVG
 `<text>` (no `<foreignObject>`) using a fontkit measurer, so resvg can
 rasterize it without a browser. The measurer, resvg's `fontFiles`, and
 LibreOffice all use the same bundled substitute fonts (in the package's
@@ -61,7 +61,7 @@ libreoffice`; Debian/CI `apt-get install libreoffice`. Override the binary
 - The diff image is the ground truth for _what_ is wrong; fg-SSIM tells you
   _which_ slides to look at.
 - The metric core (`image.ts`, `ssim.ts`, `ppm.ts`, `png.ts`) and the layout
-  engine (`@pptx-kit/preview`'s `packages/preview/src/text-layout.ts`) are
+  engine (`pptx-kit-preview`'s `packages/preview/src/text-layout.ts`) are
   unit-tested in `test/fidelity-metric.test.ts` / `test/text-layout.test.ts`
   and run in CI without any external renderer.
 
@@ -70,7 +70,7 @@ libreoffice`; Debian/CI `apt-get install libreoffice`. Override the binary
 LibreOffice / GDI place the baseline at the font's `usWinAscent` and size the
 line box as `usWinAscent + usWinDescent` (no extra gap) unless the font sets the
 OS/2 `USE_TYPO_METRICS` bit, in which case the `sTypo*` metrics + `typoLineGap`
-apply. The measurer (`@pptx-kit/preview`'s `measure.ts`) mirrors this; using
+apply. The measurer (`pptx-kit-preview`'s `measure.ts`) mirrors this; using
 fontkit's hhea `.ascent` instead misplaces the baseline by ~12px at 44pt.
 
 **Center / bottom anchoring** carries one extra wrinkle: LibreOffice/PowerPoint

--- a/site/fidelity/render-ours.ts
+++ b/site/fidelity/render-ours.ts
@@ -1,10 +1,10 @@
 // Render every slide of a .pptx with pptx-kit's own previewer and rasterize it
 // to pixels — no browser. The whole SVG→resvg→RGBA pipeline now lives in
-// `@pptx-kit/preview/node`; the harness only feeds it a deck and a width.
+// `pptx-kit-preview/node`; the harness only feeds it a deck and a width.
 
 import { getSlides, getSlideSize, type PresentationData } from 'pptx-kit';
 import { loadPresentationFile } from 'pptx-kit/node';
-import { renderSlideToRgba } from '@pptx-kit/preview/node';
+import { renderSlideToRgba } from 'pptx-kit-preview/node';
 import type { RgbaImage } from './image.ts';
 
 export interface RenderedSlide {

--- a/site/package.json
+++ b/site/package.json
@@ -19,7 +19,6 @@
     "codemirror": "^6.0.2"
   },
   "devDependencies": {
-    "@pptx-kit/preview": "workspace:*",
     "@sveltejs/adapter-static": "^3.0.10",
     "@sveltejs/kit": "^2.65.0",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
@@ -27,6 +26,7 @@
     "mdsvex": "^0.12.7",
     "pagefind": "^1.5.2",
     "pptx-kit": "workspace:*",
+    "pptx-kit-preview": "workspace:*",
     "shiki": "^4.2.0",
     "svelte": "^5.56.3",
     "svelte-check": "^4.6.0",

--- a/site/src/routes/playground/+page.svelte
+++ b/site/src/routes/playground/+page.svelte
@@ -38,7 +38,7 @@
     savePresentation,
     slideHasAnimations,
   } from 'pptx-kit';
-  import { renderSlideToSvg } from '@pptx-kit/preview';
+  import { renderSlideToSvg } from 'pptx-kit-preview';
 
   type SlideSnapshot = {
     index: number;

--- a/site/src/routes/repl/+page.svelte
+++ b/site/src/routes/repl/+page.svelte
@@ -2,7 +2,7 @@
   import { base } from '$app/paths';
   import { onMount } from 'svelte';
   import * as kit from 'pptx-kit';
-  import { renderSlideToSvg } from '@pptx-kit/preview';
+  import { renderSlideToSvg } from 'pptx-kit-preview';
   import { EditorState } from '@codemirror/state';
   import { EditorView, basicSetup } from 'codemirror';
   import { javascript } from '@codemirror/lang-javascript';

--- a/src/api/_internal-symbols.ts
+++ b/src/api/_internal-symbols.ts
@@ -7,7 +7,7 @@
 // so the keys are identical across separately-bundled copies of this module.
 // The public entry (`pptx-kit` → dist/index.js) and the Node entry
 // (`pptx-kit/node` → dist/node.js) are distinct bundles, each with its own
-// copy of this file; companion packages (e.g. `@pptx-kit/preview`) hold a
+// copy of this file; companion packages (e.g. `pptx-kit-preview`) hold a
 // third. With plain `Symbol` a handle built by one bundle is opaque to every
 // other — `getSlides(loadPresentationFile(...))` would read `undefined` and
 // crash. The `pptx-kit.` namespace keeps the registry keys collision-free.

--- a/test/internal-handle-identity.test.ts
+++ b/test/internal-handle-identity.test.ts
@@ -2,7 +2,7 @@
 // registry (`Symbol.for`), not be minted with plain `Symbol`. The library
 // ships as two separate bundles — `pptx-kit` (dist/index.js) and
 // `pptx-kit/node` (dist/node.js) — and companion packages (e.g.
-// `@pptx-kit/preview`) bundle a third copy of the reader code. A handle built
+// `pptx-kit-preview`) bundle a third copy of the reader code. A handle built
 // by one bundle is only readable by another if they agree on these keys; plain
 // `Symbol` mints a fresh key per bundle, so e.g. `getSlides` (index bundle)
 // would read `undefined` off a presentation from `loadPresentationFile` (node

--- a/test/preview-node-raster.test.ts
+++ b/test/preview-node-raster.test.ts
@@ -1,4 +1,4 @@
-// Smoke tests for the Node rasterization path (`@pptx-kit/preview/node`).
+// Smoke tests for the Node rasterization path (`pptx-kit-preview/node`).
 //
 // The pipeline: renderSlideToSvg (svg text mode) → resvg → PNG / RGBA.
 // We verify dimensions, the PNG magic bytes, that the output is not entirely


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Renames the preview package from `@pptx-kit/preview` to `pptx-kit-preview` before its first publish, so both packages live unscoped under one npm account instead of splitting ownership between the personal account (`pptx-kit`) and a separate `@pptx-kit` organization.

## Motivation

Publishing a scoped package requires the `@pptx-kit` npm organization, which would make package management two-headed (personal account + org) for no benefit at the current two-package scale. Neither package is on npm yet (both names were just reserved as `0.0.0` placeholders), so the rename is free now and breaking later.

## Changes

- `pptx-kit-preview` replaces `@pptx-kit/preview` everywhere: package manifest, site/test/fidelity imports, CI `--filter` targets, docs, and the 6 pending changesets that reference the package (required for `changeset version` to keep resolving).
- `pnpm-lock.yaml` importer key updated via `pnpm install`.

## Testing

- Full local CI equivalent on the branch: format / lint / typecheck (root + preview) / `pnpm build` + preview build (ESM + DTS) all pass; `pnpm test` 1088 passed; `site` svelte-check 0 errors.
- `rg '@pptx-kit'` finds no remaining source references.

## Breaking changes

None (the scoped name was never published).

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)