### PR TITLE
docs: capability text reflects the completed preview workstreams

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,12 @@ never silently strip parts it doesn't model. That's the L1 contract.
 
 When NOT to use this:
 
-- You want to **render** PPTX to pixels / PDF in the browser. Use a renderer
-  (e.g. `pptx2html`, server-side LibreOffice headless). `pptx-kit` writes
-  PPTX, it does not paint it.
+- You need a **pixel-perfect** PPTX rendering (print, archival). The
+  companion [`pptx-kit-preview`](packages/preview) package renders slides to
+  SVG in the browser and to PNG on the server — its closeness to LibreOffice
+  is measured per slide and gated in CI (`site/fidelity`) — but it is a
+  high-fidelity preview, not a spec-complete paint engine. For
+  pixel-authoritative output, use PowerPoint itself or LibreOffice headless.
 - You need a thin DSL for one-off "report" slides and do not care about
   schema validity. A simpler library will be lighter.
 - You want to convert PPTX to another format (Keynote, ODP). Out of scope

--- a/packages/preview/README.md
+++ b/packages/preview/README.md
@@ -68,12 +68,17 @@ glyphs and the result is deterministic (no system fonts).
 
 ## Fidelity
 
-This is an approximation, not a spec-complete PowerPoint renderer. Preset
-geometry, fills, strokes, rotation, images, charts, tables, and template
-(layout/master) decoration render; custom geometry, SmartArt, and effects are
-partial or fall back to labelled placeholders. Per-slide closeness to a
-LibreOffice baseline is tracked by the fidelity harness in the monorepo
-(`site/fidelity`).
+This is a high-fidelity preview, not a spec-complete PowerPoint renderer.
+Preset and custom geometry, solid/gradient/pattern/image fills (including the
+placeholder layout/master cascade), strokes, rotation, effects (shadow, glow,
+soft edge, reflection), images with adjustments, charts (column, bar, line,
+area, pie, doughnut, scatter, radar, bubble), tables with per-run cell text,
+vertical and multi-column text in both text-layout modes, picture bullets, and
+template (layout/master) decoration all render. SmartArt, animations, 3D, and
+EMF/WMF fall back to labelled placeholders carrying a machine-readable marker
+(below). Per-slide closeness to a LibreOffice baseline is measured and gated
+in CI by the fidelity harness in the monorepo (`site/fidelity`) — mean
+fg-SSIM ≈ 0.78 across the corpus, with the residual gaps documented there.
 
 ### Fallback markers
 

--- a/site/src/routes/playground/+page.svelte
+++ b/site/src/routes/playground/+page.svelte
@@ -199,10 +199,10 @@
     <a href="{base}/docs/getting-started">Getting started</a>.
   </p>
   <p class="caveat">
-    <strong>Approximate.</strong> Shape geometry is reconstructed from the preset name; theme /
-    placeholder inheritance, gradient / pattern / picture fills, custom geometry, charts, tables
-    and SmartArt show as labelled fallbacks. PowerPoint or LibreOffice will render the file
-    correctly.
+    <strong>High-fidelity preview.</strong> Preset and custom geometry, theme / placeholder
+    inheritance, gradient / pattern / picture fills, effects, charts, and tables render;
+    SmartArt, animations, and 3D show as labelled fallbacks. PowerPoint or LibreOffice
+    remains the pixel-authoritative renderer.
   </p>
 
   <div


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Documentation-only refresh after W1–W5 of `docs/template-and-preview-plan.md` landed: the root README's "When NOT to use this" now points at `pptx-kit-preview` instead of external renderers, the preview README's fidelity section lists what actually renders today (custom geometry, scatter/radar/bubble charts, per-run table text, vertical/column text, reflection, picture bullets, cascade gradients) with the measured fg-SSIM, and the playground caveat stops claiming charts/tables are labelled fallbacks.

## Motivation

CLAUDE.md: "If the README says 'use X for Y' but the library also accepts Z, the docs are lying." All three texts predated the preview workstreams.

## Changes

- `README.md`, `packages/preview/README.md`, playground caveat copy. No code.

## Testing

- `pnpm format:check` clean; no code paths affected.

## Breaking changes

None

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change. (N/A — docs only)
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and flagged it above. (N/A)
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, the PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)