### PR TITLE
ci: stop format-gating the generated CHANGELOGs

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -11,6 +11,8 @@
   "arrowParens": "always",
   "bracketSpacing": true,
   "ignorePatterns": [
+    "CHANGELOG.md",
+    "packages/*/CHANGELOG.md",
     "dist/**",
     "coverage/**",
     "node_modules/**",


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Adds `CHANGELOG.md` / `packages/*/CHANGELOG.md` to oxfmt's `ignorePatterns`. The changesets release bot regenerates these files in a shape oxfmt rewrites (blank lines inside list items), so every PR branched after a release fails the `Format check` gate until someone reformats the bot's output by hand — it already broke the gate twice today (fixed manually in #234, recurred with release #235, currently failing #237).

## Motivation

Generated files don't belong in a format gate; the gate exists for code humans write.

## Changes

- `.oxfmtrc.json`: two new ignore patterns. No code.

## Testing

- `pnpm format:check` passes locally on a checkout containing the bot-generated CHANGELOG (it previously failed).

## Breaking changes

None

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change. (N/A — CI config)
- [x] I have added or updated documentation where user-visible behavior changed. (N/A)
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and flagged it above. (N/A)
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, the PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)