### PR TITLE
feat: createPresentation returns an immediately-authorable deck

### DIFF
--- a/.changeset/create-presentation-authorable.md
+++ b/.changeset/create-presentation-authorable.md
@@ -1,0 +1,38 @@
+---
+'pptx-kit': minor
+---
+
+`createPresentation()` now returns an immediately-authorable deck
+
+Previously `createPresentation()` returned an OPC package with only the OPC
+defaults — no slide master, layouts, theme, or slide size — so
+`getSlideLayouts()` came back empty and `addSlide({ layout })` was
+impossible. From-scratch authoring (a headline feature in the README) did
+not actually work without loading a template file.
+
+`createPresentation()` now ships a slide master, the Office theme, and three
+layouts — `Blank`, `Title Slide`, and `Title and Content` — so you can go
+straight to `addSlide` / `addTitleSlide` / `addContentSlide` and `savePresentation`.
+Every emitted part is validated against the ECMA-376 XSDs in CI. The slide
+size defaults to 16:9 and is selectable: `createPresentation({ size: '4:3' })`.
+
+Also in this release (input-validation hardening at the authoring boundary):
+
+- `addSlideChart` now rejects a series `color` (and `pointColors` /
+  `trendline.color` / plot- and chart-area fills / axis & gridline colors)
+  that isn't an sRGB hex (`#RRGGBB` or `RRGGBB`) with a clear error, instead
+  of silently emitting an invalid `<a:srgbClr val="…"/>` that PowerPoint
+  dropped or repaired. Bare `RRGGBB` (no `#`) is accepted and normalized;
+  scheme tokens like `accent1` are correctly rejected, since charts emit
+  `srgbClr`.
+- `addSlideTable` with empty `rows: []` (or a row with no cells) now throws
+  an actionable `addSlideTable: …` error at the boundary rather than
+  producing a grid-less `<a:tbl>` that triggers PowerPoint's repair dialog.
+  (The error message previously named the old internal `addTable` path.)
+- `findSlideLayout`'s case-sensitive, locale-dependent name matching is now
+  documented in its JSDoc and the README, pointing readers to the
+  locale-stable `findSlideLayoutByType` and to `RegExp`/`i` for
+  case-insensitive name lookups. No behavior change.
+
+No breaking changes. `createPresentation()` keeps its zero-argument call
+signature; the new `{ size }` options object is optional.

--- a/README.md
+++ b/README.md
@@ -135,6 +135,42 @@ replaceTokensInPresentation(pres, { name: 'Alice', event: 'Re:Invent', date: '20
 const out = await savePresentation(pres);
 ```
 
+### Build a deck from scratch (no template file)
+
+`createPresentation()` returns an immediately-authorable deck — a slide
+master, the Office theme, and three layouts (`Blank`, `Title Slide`,
+`Title and Content`) — with no slides yet. No `.pptx` template needed.
+
+```ts
+import {
+  addContentSlide,
+  addTitleSlide,
+  createPresentation,
+  findSlideLayoutByType,
+  addSlide,
+  findSlidePlaceholder,
+  savePresentation,
+  setShapeText,
+} from 'pptx-kit';
+
+// Defaults to 16:9; pass { size: '4:3' } for the classic ratio.
+const pres = createPresentation();
+
+// Sugar helpers pick the right layout by its locale-stable type token.
+addTitleSlide(pres, 'Q3 Business Review');
+addContentSlide(pres, { title: 'Agenda', body: 'Highlights and risks' });
+
+// Or bind a layout explicitly. Prefer findSlideLayoutByType — it matches
+// the `type` token (`'title'`, `'obj'`, `'blank'`), which is stable
+// across PowerPoint UI languages. findSlideLayout(pres, 'Blank') matches
+// the user-visible name, which is case-sensitive and localized.
+const titleLayout = findSlideLayoutByType(pres, 'title')!;
+const slide = addSlide(pres, { layout: titleLayout });
+setShapeText(findSlidePlaceholder(slide, 'ctrTitle')!, 'Authored with pptx-kit');
+
+const out: Uint8Array = await savePresentation(pres);
+```
+
 ### Build a deck from a blank template
 
 ```ts
@@ -292,40 +328,40 @@ for (const i of issues) console.error(i.severity, i.message);
 Each row lists the free-function entry points. Read/write pairs are
 shown together.
 
-| Capability           | API                                                                                                                                                                                                                                                     |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Load / save          | `loadPresentation(input)`, `savePresentation(pres)`, `loadPresentationFile(path)` (node), `savePresentationToFile(pres, path)` (node)                                                                                                                   |
-| Create               | `createPresentation()`                                                                                                                                                                                                                                  |
-| Slide CRUD           | `getSlides`, `getSlideAt`, `getSlideIndex`, `addSlide`, `removeSlide`, `moveSlide`, `duplicateSlide`, `clearSlideShapes`                                                                                                                                |
-| Slide layout         | `getSlideLayouts`, `findSlideLayout`, `getSlideLayout(slide)`, `setSlideLayout(slide, layout)`, `getSlideLayoutName`, `getSlideLayoutType`                                                                                                              |
-| Slide metadata       | `getSlideTitle` / `setSlideTitle`, `getSlideSize` / `setSlideSize`, `isSlideHidden` / `setSlideHidden`, `getSlideText`                                                                                                                                  |
-| Slide sections       | `getSlideSections`, `setSlideSections` (p14 sectionLst)                                                                                                                                                                                                 |
-| Placeholders         | `findSlidePlaceholder(slide, 'title' \| 'body' \| ...)`                                                                                                                                                                                                 |
-| Token / text replace | `replaceTokensInPresentation`, `replaceTokensInSlide`, `replaceTextInPresentation`, `replaceTextInSlide`                                                                                                                                                |
-| Background           | `getSlideBackground` / `setSlideBackground` / `clearSlideBackground`                                                                                                                                                                                    |
-| Notes                | `getSlideNotes` / `setSlideNotes`                                                                                                                                                                                                                       |
-| Transitions          | `getSlideTransition` / `setSlideTransition` / `clearSlideTransition`                                                                                                                                                                                    |
-| Animations           | `getShapeAnimation` / `setShapeAnimation` (`fadeIn` / `fadeOut` / `appear` / `disappear`), `clearSlideAnimations`                                                                                                                                       |
-| Comments             | `addSlideComment`, `getSlideComments`, `removeSlideComment`, `getCommentAuthors`, `getCommentText` / `getCommentAuthor` / `getCommentPosition`                                                                                                          |
-| Shape authoring      | `addSlideTextBox`, `addSlideShape`, `addSlideLine`, `addSlideTable`, `addSlideImage`, `addSlideChart`                                                                                                                                                   |
-| Shape lookup         | `findShapeByName`, `findShapesByName`, `findShapesByKind`, `findShapeInPresentation`, `getAllShapes`, `getSlideShapes`                                                                                                                                  |
-| Shape text           | `setShapeText`, `setShapeBullets`, `setShapeAlignment`, `setShapeTextFormat`, `setShapeHyperlink` / `getShapeHyperlink`                                                                                                                                 |
-| Per-paragraph        | `setParagraphAlignment` / `getParagraphAlignment`, `setParagraphLevel` / `getParagraphLevel`, `setParagraphBullet` / `getParagraphBullet`                                                                                                               |
-| Per-run text         | `setShapeRunText` / `getShapeRunText`, `setShapeRunFormat` / `getShapeRunFormat`, `getShapeParagraphCount`, `getShapeRunCount`                                                                                                                          |
-| Text frame           | `setShapeTextAnchor` / `getShapeTextAnchor`, `setShapeTextMargins` / `getShapeTextMargins`                                                                                                                                                              |
-| Fill                 | `setShapeFill` / `getShapeFill`, `setShapeGradientFill`, `setShapePatternFill`, `setShapeImageFill`, `setShapeNoFill`, `clearShapeFill`                                                                                                                 |
-| Stroke               | `setShapeStroke` / `getShapeStroke`, `setShapeStrokeDash` / `getShapeStrokeDash`, `setShapeStrokeArrow` / `getShapeStrokeArrow`, `…NoStroke`                                                                                                            |
-| Effects              | `setShapeShadow` / `setShapeGlow` / `getShapeEffect`, `clearShapeEffects`                                                                                                                                                                               |
-| Geometry             | `setShapePosition`, `setShapeSize`, `setShapeRotation`, `setShapeFlip`, `setShapeBounds` / `getShapeBounds`                                                                                                                                             |
-| Pictures             | `setShapeImage`, `setShapeImageCrop` / `getShapeImageCrop`, `setShapeImageOpacity` / `getShapeImageOpacity`, `setShapeImageBrightness`, `…Contrast`                                                                                                     |
-| Z-order              | `bringShapeToFront`, `sendShapeToBack`, `bringShapeForward`, `sendShapeBackward`                                                                                                                                                                        |
-| Click actions        | `setShapeClickAction` / `getShapeClickAction` (`url` / `slide` / `nextSlide` / `prevSlide` / `firstSlide` / `lastSlide`)                                                                                                                                |
-| Shape removal        | `removeShape`                                                                                                                                                                                                                                           |
-| Tables               | `getTableCell` / `getTableCells`, `setTableCellText` / `getTableCellText`, `setTableCellFill` / `clearTableCellFill`, `setTableCellAlignment`, `setTableCellTextFormat`, `insertTableRow` / `removeTableRow`, `insertTableColumn` / `removeTableColumn` |
-| Charts               | `addSlideChart`, `getSlideCharts`, `setChartSpec` — kinds: `bar`, `column`, `line`, `pie`, `doughnut`, `area`                                                                                                                                           |
-| Theme                | `getPresentationTheme` — color scheme (`accent1`..`accent6`, `dark1`, `light1`, `hyperlink`, ...)                                                                                                                                                       |
-| Validation           | `validatePresentation(pres)` — invariant checks, returns `ValidationIssue[]`                                                                                                                                                                            |
-| Units                | `inches(n)`, `cm(n)`, `mm(n)`, `pt(n)`, `emu(n)` — return branded `Emu` numbers                                                                                                                                                                         |
+| Capability           | API                                                                                                                                                                                                                                                                                     |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Load / save          | `loadPresentation(input)`, `savePresentation(pres)`, `loadPresentationFile(path)` (node), `savePresentationToFile(pres, path)` (node)                                                                                                                                                   |
+| Create               | `createPresentation({ size?: '16:9' \| '4:3' })` — blank deck with master + theme + `Blank` / `Title Slide` / `Title and Content` layouts                                                                                                                                               |
+| Slide CRUD           | `getSlides`, `getSlideAt`, `getSlideIndex`, `addSlide`, `removeSlide`, `moveSlide`, `duplicateSlide`, `clearSlideShapes`                                                                                                                                                                |
+| Slide layout         | `getSlideLayouts`, `findSlideLayout` (by name — case-sensitive, exact; pass a `RegExp` for case-insensitive), `findSlideLayoutByType` (by locale-stable `type` token — preferred), `getSlideLayout(slide)`, `setSlideLayout(slide, layout)`, `getSlideLayoutName`, `getSlideLayoutType` |
+| Slide metadata       | `getSlideTitle` / `setSlideTitle`, `getSlideSize` / `setSlideSize`, `isSlideHidden` / `setSlideHidden`, `getSlideText`                                                                                                                                                                  |
+| Slide sections       | `getSlideSections`, `setSlideSections` (p14 sectionLst)                                                                                                                                                                                                                                 |
+| Placeholders         | `findSlidePlaceholder(slide, 'title' \| 'body' \| ...)`                                                                                                                                                                                                                                 |
+| Token / text replace | `replaceTokensInPresentation`, `replaceTokensInSlide`, `replaceTextInPresentation`, `replaceTextInSlide`                                                                                                                                                                                |
+| Background           | `getSlideBackground` / `setSlideBackground` / `clearSlideBackground`                                                                                                                                                                                                                    |
+| Notes                | `getSlideNotes` / `setSlideNotes`                                                                                                                                                                                                                                                       |
+| Transitions          | `getSlideTransition` / `setSlideTransition` / `clearSlideTransition`                                                                                                                                                                                                                    |
+| Animations           | `getShapeAnimation` / `setShapeAnimation` (`fadeIn` / `fadeOut` / `appear` / `disappear`), `clearSlideAnimations`                                                                                                                                                                       |
+| Comments             | `addSlideComment`, `getSlideComments`, `removeSlideComment`, `getCommentAuthors`, `getCommentText` / `getCommentAuthor` / `getCommentPosition`                                                                                                                                          |
+| Shape authoring      | `addSlideTextBox`, `addSlideShape`, `addSlideLine`, `addSlideTable`, `addSlideImage`, `addSlideChart`                                                                                                                                                                                   |
+| Shape lookup         | `findShapeByName`, `findShapesByName`, `findShapesByKind`, `findShapeInPresentation`, `getAllShapes`, `getSlideShapes`                                                                                                                                                                  |
+| Shape text           | `setShapeText`, `setShapeBullets`, `setShapeAlignment`, `setShapeTextFormat`, `setShapeHyperlink` / `getShapeHyperlink`                                                                                                                                                                 |
+| Per-paragraph        | `setParagraphAlignment` / `getParagraphAlignment`, `setParagraphLevel` / `getParagraphLevel`, `setParagraphBullet` / `getParagraphBullet`                                                                                                                                               |
+| Per-run text         | `setShapeRunText` / `getShapeRunText`, `setShapeRunFormat` / `getShapeRunFormat`, `getShapeParagraphCount`, `getShapeRunCount`                                                                                                                                                          |
+| Text frame           | `setShapeTextAnchor` / `getShapeTextAnchor`, `setShapeTextMargins` / `getShapeTextMargins`                                                                                                                                                                                              |
+| Fill                 | `setShapeFill` / `getShapeFill`, `setShapeGradientFill`, `setShapePatternFill`, `setShapeImageFill`, `setShapeNoFill`, `clearShapeFill`                                                                                                                                                 |
+| Stroke               | `setShapeStroke` / `getShapeStroke`, `setShapeStrokeDash` / `getShapeStrokeDash`, `setShapeStrokeArrow` / `getShapeStrokeArrow`, `…NoStroke`                                                                                                                                            |
+| Effects              | `setShapeShadow` / `setShapeGlow` / `getShapeEffect`, `clearShapeEffects`                                                                                                                                                                                                               |
+| Geometry             | `setShapePosition`, `setShapeSize`, `setShapeRotation`, `setShapeFlip`, `setShapeBounds` / `getShapeBounds`                                                                                                                                                                             |
+| Pictures             | `setShapeImage`, `setShapeImageCrop` / `getShapeImageCrop`, `setShapeImageOpacity` / `getShapeImageOpacity`, `setShapeImageBrightness`, `…Contrast`                                                                                                                                     |
+| Z-order              | `bringShapeToFront`, `sendShapeToBack`, `bringShapeForward`, `sendShapeBackward`                                                                                                                                                                                                        |
+| Click actions        | `setShapeClickAction` / `getShapeClickAction` (`url` / `slide` / `nextSlide` / `prevSlide` / `firstSlide` / `lastSlide`)                                                                                                                                                                |
+| Shape removal        | `removeShape`                                                                                                                                                                                                                                                                           |
+| Tables               | `getTableCell` / `getTableCells`, `setTableCellText` / `getTableCellText`, `setTableCellFill` / `clearTableCellFill`, `setTableCellAlignment`, `setTableCellTextFormat`, `insertTableRow` / `removeTableRow`, `insertTableColumn` / `removeTableColumn`                                 |
+| Charts               | `addSlideChart`, `getSlideCharts`, `setChartSpec` — kinds: `bar`, `column`, `line`, `pie`, `doughnut`, `area`                                                                                                                                                                           |
+| Theme                | `getPresentationTheme` — color scheme (`accent1`..`accent6`, `dark1`, `light1`, `hyperlink`, ...)                                                                                                                                                                                       |
+| Validation           | `validatePresentation(pres)` — invariant checks, returns `ValidationIssue[]`                                                                                                                                                                                                            |
+| Units                | `inches(n)`, `cm(n)`, `mm(n)`, `pt(n)`, `emu(n)` — return branded `Emu` numbers                                                                                                                                                                                                         |
 
 ## Compatibility
 

--- a/src/api/fn/charts.ts
+++ b/src/api/fn/charts.ts
@@ -9,6 +9,7 @@ import {
   resolveTarget,
 } from '../../internal/opc/index.ts';
 import type { OpcPackage } from '../../internal/parts/index.ts';
+import { parseSrgbHex } from '../../internal/drawingml/index.ts';
 import { REL_TYPES } from '../../internal/presentationml/index.ts';
 import {
   type ChartKind,
@@ -121,6 +122,48 @@ const buildChartGraphicFrame = (opts: {
   return elem(NAME_GRAPHIC_FRAME, { children: [nvGraphicFramePr, xfrm, graphic] });
 };
 
+// The chart builder emits every authored color as `<a:srgbClr>`, so chart
+// colors must be sRGB hex (`#RRGGBB` or `RRGGBB`) — scheme tokens like
+// `accent1` are not valid here. Without this gate an invalid string was
+// written verbatim into `val="…"`, producing a chart PowerPoint silently
+// dropped (or repaired). Validate at the authoring boundary so callers get
+// a clear error instead of a broken deck. The `#` prefix is optional; the
+// builder normalizes it.
+const checkChartColor = (value: string | null | undefined, label: string): void => {
+  if (value === null || value === undefined) return;
+  if (parseSrgbHex(value) === null) {
+    throw new Error(
+      `${label}: invalid chart color ${JSON.stringify(value)} — expected an sRGB hex like "#4472C4" or "4472C4"`,
+    );
+  }
+};
+
+const validateChartSpecColors = (spec: ChartSpec): void => {
+  checkChartColor(spec.plotAreaFill, 'addSlideChart: plotAreaFill');
+  checkChartColor(spec.plotAreaStrokeColor, 'addSlideChart: plotAreaStrokeColor');
+  checkChartColor(spec.chartAreaFill, 'addSlideChart: chartAreaFill');
+  checkChartColor(spec.chartAreaStrokeColor, 'addSlideChart: chartAreaStrokeColor');
+  checkChartColor(spec.valueAxisMajorGridlineColor, 'addSlideChart: valueAxisMajorGridlineColor');
+  checkChartColor(spec.valueAxisMinorGridlineColor, 'addSlideChart: valueAxisMinorGridlineColor');
+  checkChartColor(
+    spec.categoryAxisMajorGridlineColor,
+    'addSlideChart: categoryAxisMajorGridlineColor',
+  );
+  checkChartColor(
+    spec.categoryAxisMinorGridlineColor,
+    'addSlideChart: categoryAxisMinorGridlineColor',
+  );
+  checkChartColor(spec.valueAxisLineColor, 'addSlideChart: valueAxisLineColor');
+  checkChartColor(spec.categoryAxisLineColor, 'addSlideChart: categoryAxisLineColor');
+  spec.series.forEach((series, i) => {
+    checkChartColor(series.color, `addSlideChart: series[${i}].color`);
+    checkChartColor(series.trendline?.color, `addSlideChart: series[${i}].trendline.color`);
+    series.pointColors?.forEach((c, j) => {
+      checkChartColor(c, `addSlideChart: series[${i}].pointColors[${j}]`);
+    });
+  });
+};
+
 /**
  * Adds a chart to the slide. Returns the new shape handle (kind
  * `graphicFrame`). Supported chart kinds today: `bar`, `column`,
@@ -153,6 +196,7 @@ export const addSlideChart = (
     name?: string;
   },
 ): SlideShapeData => {
+  validateChartSpecColors(opts.spec);
   const pkg = slide[INTERNAL_PACKAGE];
   const chartN = allocateChartIndex(pkg);
   const chartPartName = partName(`/ppt/charts/chart${chartN}.xml`);
@@ -280,6 +324,7 @@ export const resolveChartPartName = (
  * fresh data."
  */
 export const setChartSpec = (chart: SlideChartData, spec: ChartSpec): void => {
+  validateChartSpecColors(spec);
   const slide = chart.shape[SHAPE_SLIDE];
   const pkg = slide[INTERNAL_PACKAGE];
   const resolved = resolveChartPartName(slide, chart.shape);

--- a/src/api/fn/layouts.ts
+++ b/src/api/fn/layouts.ts
@@ -104,6 +104,15 @@ export const getSlideLayoutPlaceholders = (
  * or `null` if none does. Accepts a literal string (exact equality)
  * or a `RegExp` for pattern matches — useful when template providers
  * suffix versions onto names (`'Title and Content v2'`).
+ *
+ * String matching is **case-sensitive** and exact: `findSlideLayout(pres,
+ * 'Blank')` matches a layout named `"Blank"` but not `"blank"`. The
+ * user-visible name is also locale-dependent (a deck authored in a
+ * non-English PowerPoint localizes `"Blank"`), so prefer
+ * {@link findSlideLayoutByType} — which matches the locale-stable
+ * `<p:sldLayout type="…">` token (`'blank'`, `'title'`, `'obj'`, …) —
+ * when you need a robust lookup. Pass a `RegExp` with the `i` flag here
+ * for a case-insensitive name match.
  */
 export const findSlideLayout = (
   pres: PresentationData,

--- a/src/api/fn/package-io.ts
+++ b/src/api/fn/package-io.ts
@@ -1,6 +1,6 @@
 // Presentation I/O: load, save, and create.
 
-import { OpcPackage } from '../../internal/parts/index.ts';
+import { type BlankDeckAspect, OpcPackage, buildBlankDeck } from '../../internal/parts/index.ts';
 import { INTERNAL_PACKAGE, type PresentationData } from '../_internal-symbols.ts';
 
 /**
@@ -30,12 +30,26 @@ export const loadPresentation = async (input: PresentationInput): Promise<Presen
   return { [INTERNAL_PACKAGE]: pkg, _slidesCache: null };
 };
 
+/** Slide-canvas aspect ratio for {@link createPresentation}. */
+export type PresentationSize = '16:9' | '4:3';
+
 /**
- * Creates a fresh, empty `PresentationData`. The result is NOT yet a
- * valid PPTX — it carries only the OPC defaults.
+ * Creates a fresh, immediately-authorable `PresentationData`.
+ *
+ * The returned deck carries a slide master, the Office theme, and three
+ * slide layouts — `'Blank'`, `'Title Slide'`, and `'Title and Content'` —
+ * but no slides yet. Add one with {@link addSlide} (or the
+ * `addBlankSlide` / `addTitleSlide` / `addContentSlide` helpers), then
+ * `savePresentation` to emit a `.pptx` that opens cleanly in PowerPoint,
+ * Keynote, Google Slides, and LibreOffice.
+ *
+ * @param options.size Slide aspect ratio. `'16:9'` (12192000×6858000 EMU,
+ *   PowerPoint's modern default) or `'4:3'` (9144000×6858000). Defaults to
+ *   `'16:9'`.
  */
-export const createPresentation = (): PresentationData => {
-  const pkg = OpcPackage.empty();
+export const createPresentation = (options: { size?: PresentationSize } = {}): PresentationData => {
+  const aspect: BlankDeckAspect = options.size ?? '16:9';
+  const pkg = buildBlankDeck(aspect);
   return { [INTERNAL_PACKAGE]: pkg, _slidesCache: null };
 };
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -21,7 +21,7 @@ export type {
   CommentPosition,
   SlideComment,
 } from '../internal/presentationml/index.ts';
-export type { PresentationInput, SlideSize } from './fn.ts';
+export type { PresentationInput, PresentationSize, SlideSize } from './fn.ts';
 export { SLIDE_SIZE_4_3, SLIDE_SIZE_16_9, SLIDE_SIZE_16_10 } from './fn.ts';
 export type { ImageFormat } from '../internal/opc/index.ts';
 export type {

--- a/src/internal/drawingml/color.ts
+++ b/src/internal/drawingml/color.ts
@@ -45,6 +45,18 @@ export const parseColor = (value: string): ParsedColor | null => {
 };
 
 /**
+ * Parses an sRGB hex color (`#RRGGBB` or `RRGGBB`), returning the
+ * normalized uppercase 6-digit hex (no `#`). Returns `null` for anything
+ * that isn't a 6-digit hex — including scheme tokens, which sRGB-only
+ * contexts (e.g. chart series fills) must reject rather than silently
+ * emit as an invalid `<a:srgbClr val="accent1"/>`.
+ */
+export const parseSrgbHex = (value: string): string | null => {
+  const hex = value.startsWith('#') ? value.slice(1) : value;
+  return /^[0-9A-Fa-f]{6}$/.test(hex) ? hex.toUpperCase() : null;
+};
+
+/**
  * Returns the `<a:srgbClr>` or `<a:schemeClr>` element for `value`.
  * Throws on unrecognized colors.
  */

--- a/src/internal/drawingml/index.ts
+++ b/src/internal/drawingml/index.ts
@@ -15,7 +15,7 @@ export {
 export type { TextFormat } from './text-format.ts';
 export { applyFormatToAllRuns, applyRunFormat } from './text-format.ts';
 export type { ParsedColor } from './color.ts';
-export { buildColorElement, parseColor } from './color.ts';
+export { buildColorElement, parseColor, parseSrgbHex } from './color.ts';
 export type {
   GradientFillOptions,
   GradientStop,

--- a/src/internal/parts/blank-deck.ts
+++ b/src/internal/parts/blank-deck.ts
@@ -1,0 +1,157 @@
+// Minimal "blank deck" scaffolding for `createPresentation`.
+//
+// PowerPoint cannot author a slide without a slide master, at least one
+// slide layout, a theme, and a slide size — `addSlide({ layout })` reads
+// the layout's placeholders, and the layout inherits geometry / text
+// styles from the master + theme. An OPC package with only the OPC
+// defaults (what `OpcPackage.empty()` produces) has none of that, so
+// `getSlideLayouts()` returns `[]` and from-scratch authoring is
+// impossible.
+//
+// This module emits the smallest set of parts that yields an
+// immediately-authorable deck: a single master, a theme, and three
+// layouts (Blank / Title Slide / Title and Content). The XML is held as
+// string templates rather than built through the DrawingML element
+// builders because these parts are static boilerplate — there is exactly
+// one canonical Office master/theme and reproducing it byte-for-byte
+// through builders would be far more code for zero flexibility. The
+// strings are validated against the ECMA-376 XSDs in
+// `test/fn-create-presentation.test.ts`.
+//
+// Tree-shaking: this module is imported only by `createPresentation`, so
+// the load+save / template-editing paths never pull it in. Keep it that
+// way — do not import it from any read or template-edit module.
+
+import { partName } from '../opc/index.ts';
+import { OpcPackage } from './package.ts';
+
+/** Slide canvas aspect ratio. `'16:9'` is the PowerPoint 2013+ default. */
+export type BlankDeckAspect = '16:9' | '4:3';
+
+// Slide canvas dimensions in EMU. 914400 EMU = 1 inch.
+const SLIDE_SIZE: Record<BlankDeckAspect, { cx: number; cy: number; type: string }> = {
+  '16:9': { cx: 12192000, cy: 6858000, type: 'screen16x9' },
+  '4:3': { cx: 9144000, cy: 6858000, type: 'screen4x3' },
+};
+
+const RELS_CONTENT_TYPE = 'application/vnd.openxmlformats-package.relationships+xml';
+const PRESENTATION_CONTENT_TYPE =
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml';
+const PRES_PROPS_CONTENT_TYPE =
+  'application/vnd.openxmlformats-officedocument.presentationml.presProps+xml';
+const VIEW_PROPS_CONTENT_TYPE =
+  'application/vnd.openxmlformats-officedocument.presentationml.viewProps+xml';
+const SLIDE_MASTER_CONTENT_TYPE =
+  'application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml';
+const SLIDE_LAYOUT_CONTENT_TYPE =
+  'application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml';
+const THEME_CONTENT_TYPE = 'application/vnd.openxmlformats-officedocument.theme+xml';
+const CORE_PROPS_CONTENT_TYPE = 'application/vnd.openxmlformats-package.core-properties+xml';
+const EXTENDED_PROPS_CONTENT_TYPE =
+  'application/vnd.openxmlformats-officedocument.extended-properties+xml';
+
+const XML_DECL = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\r\n';
+
+const RT = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const RT_PACKAGE = 'http://schemas.openxmlformats.org/package/2006/relationships';
+
+// --- Theme ----------------------------------------------------------------
+// The canonical Office theme. DrawingML requires a complete fmtScheme
+// (3 fill / 3 line / 3 effect styles + 2 bg fills) and a full clrScheme;
+// trimming any of it fails XSD validation, so this is reproduced verbatim
+// from a PowerPoint-authored deck (test/fixtures/minimal/blank.pptx).
+const THEME_XML = `${XML_DECL}<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" name="Office Theme"><a:themeElements><a:clrScheme name="Office"><a:dk1><a:sysClr val="windowText" lastClr="000000"/></a:dk1><a:lt1><a:sysClr val="window" lastClr="FFFFFF"/></a:lt1><a:dk2><a:srgbClr val="1F497D"/></a:dk2><a:lt2><a:srgbClr val="EEECE1"/></a:lt2><a:accent1><a:srgbClr val="4F81BD"/></a:accent1><a:accent2><a:srgbClr val="C0504D"/></a:accent2><a:accent3><a:srgbClr val="9BBB59"/></a:accent3><a:accent4><a:srgbClr val="8064A2"/></a:accent4><a:accent5><a:srgbClr val="4BACC6"/></a:accent5><a:accent6><a:srgbClr val="F79646"/></a:accent6><a:hlink><a:srgbClr val="0000FF"/></a:hlink><a:folHlink><a:srgbClr val="800080"/></a:folHlink></a:clrScheme><a:fontScheme name="Office"><a:majorFont><a:latin typeface="Calibri"/><a:ea typeface=""/><a:cs typeface=""/></a:majorFont><a:minorFont><a:latin typeface="Calibri"/><a:ea typeface=""/><a:cs typeface=""/></a:minorFont></a:fontScheme><a:fmtScheme name="Office"><a:fillStyleLst><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:gradFill rotWithShape="1"><a:gsLst><a:gs pos="0"><a:schemeClr val="phClr"><a:tint val="50000"/><a:satMod val="300000"/></a:schemeClr></a:gs><a:gs pos="35000"><a:schemeClr val="phClr"><a:tint val="37000"/><a:satMod val="300000"/></a:schemeClr></a:gs><a:gs pos="100000"><a:schemeClr val="phClr"><a:tint val="15000"/><a:satMod val="350000"/></a:schemeClr></a:gs></a:gsLst><a:lin ang="16200000" scaled="1"/></a:gradFill><a:gradFill rotWithShape="1"><a:gsLst><a:gs pos="0"><a:schemeClr val="phClr"><a:tint val="100000"/><a:shade val="100000"/><a:satMod val="130000"/></a:schemeClr></a:gs><a:gs pos="100000"><a:schemeClr val="phClr"><a:tint val="50000"/><a:shade val="100000"/><a:satMod val="350000"/></a:schemeClr></a:gs></a:gsLst><a:lin ang="16200000" scaled="0"/></a:gradFill></a:fillStyleLst><a:lnStyleLst><a:ln w="9525" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="phClr"><a:shade val="95000"/><a:satMod val="105000"/></a:schemeClr></a:solidFill><a:prstDash val="solid"/></a:ln><a:ln w="25400" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:prstDash val="solid"/></a:ln><a:ln w="38100" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:prstDash val="solid"/></a:ln></a:lnStyleLst><a:effectStyleLst><a:effectStyle><a:effectLst><a:outerShdw blurRad="40000" dist="20000" dir="5400000" rotWithShape="0"><a:srgbClr val="000000"><a:alpha val="38000"/></a:srgbClr></a:outerShdw></a:effectLst></a:effectStyle><a:effectStyle><a:effectLst><a:outerShdw blurRad="40000" dist="23000" dir="5400000" rotWithShape="0"><a:srgbClr val="000000"><a:alpha val="35000"/></a:srgbClr></a:outerShdw></a:effectLst></a:effectStyle><a:effectStyle><a:effectLst><a:outerShdw blurRad="40000" dist="23000" dir="5400000" rotWithShape="0"><a:srgbClr val="000000"><a:alpha val="35000"/></a:srgbClr></a:outerShdw></a:effectLst><a:scene3d><a:camera prst="orthographicFront"><a:rot lat="0" lon="0" rev="0"/></a:camera><a:lightRig rig="threePt" dir="t"><a:rot lat="0" lon="0" rev="1200000"/></a:lightRig></a:scene3d><a:sp3d><a:bevelT w="63500" h="25400"/></a:sp3d></a:effectStyle></a:effectStyleLst><a:bgFillStyleLst><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:gradFill rotWithShape="1"><a:gsLst><a:gs pos="0"><a:schemeClr val="phClr"><a:tint val="40000"/><a:satMod val="350000"/></a:schemeClr></a:gs><a:gs pos="40000"><a:schemeClr val="phClr"><a:tint val="45000"/><a:shade val="99000"/><a:satMod val="350000"/></a:schemeClr></a:gs><a:gs pos="100000"><a:schemeClr val="phClr"><a:shade val="20000"/><a:satMod val="255000"/></a:schemeClr></a:gs></a:gsLst><a:path path="circle"><a:fillToRect l="50000" t="-80000" r="50000" b="180000"/></a:path></a:gradFill><a:gradFill rotWithShape="1"><a:gsLst><a:gs pos="0"><a:schemeClr val="phClr"><a:tint val="80000"/><a:satMod val="300000"/></a:schemeClr></a:gs><a:gs pos="100000"><a:schemeClr val="phClr"><a:shade val="30000"/><a:satMod val="200000"/></a:schemeClr></a:gs></a:gsLst><a:path path="circle"><a:fillToRect l="50000" t="50000" r="50000" b="50000"/></a:path></a:gradFill></a:bgFillStyleLst></a:fmtScheme></a:themeElements><a:objectDefaults/><a:extraClrSchemeLst/></a:theme>`;
+
+// --- Slide master ---------------------------------------------------------
+// Title + body placeholders, the standard colour map, a pointer to each
+// shipped layout, and the canonical txStyles block (title / body / other).
+// txStyles is reproduced verbatim because slides inherit their default run
+// sizes / bullets from here.
+const SLIDE_MASTER_XML = `${XML_DECL}<p:sldMaster xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:cSld><p:bg><p:bgRef idx="1001"><a:schemeClr val="bg1"/></p:bgRef></p:bg><p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/><a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr><p:sp><p:nvSpPr><p:cNvPr id="2" name="Title Placeholder 1"/><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr><p:nvPr><p:ph type="title"/></p:nvPr></p:nvSpPr><p:spPr><a:xfrm><a:off x="457200" y="274638"/><a:ext cx="8229600" cy="1143000"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr><p:txBody><a:bodyPr vert="horz" lIns="91440" tIns="45720" rIns="91440" bIns="45720" rtlCol="0" anchor="ctr"><a:normAutofit/></a:bodyPr><a:lstStyle/><a:p><a:r><a:rPr lang="en-US" smtClean="0"/><a:t>Click to edit Master title style</a:t></a:r><a:endParaRPr lang="en-US"/></a:p></p:txBody></p:sp><p:sp><p:nvSpPr><p:cNvPr id="3" name="Text Placeholder 2"/><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr><p:nvPr><p:ph type="body" idx="1"/></p:nvPr></p:nvSpPr><p:spPr><a:xfrm><a:off x="457200" y="1600200"/><a:ext cx="8229600" cy="4525963"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr><p:txBody><a:bodyPr vert="horz" lIns="91440" tIns="45720" rIns="91440" bIns="45720" rtlCol="0"><a:normAutofit/></a:bodyPr><a:lstStyle/><a:p><a:pPr lvl="0"/><a:r><a:rPr lang="en-US" smtClean="0"/><a:t>Click to edit Master text styles</a:t></a:r></a:p></p:txBody></p:sp></p:spTree></p:cSld><p:clrMap bg1="lt1" tx1="dk1" bg2="lt2" tx2="dk2" accent1="accent1" accent2="accent2" accent3="accent3" accent4="accent4" accent5="accent5" accent6="accent6" hlink="hlink" folHlink="folHlink"/><p:sldLayoutIdLst><p:sldLayoutId id="2147483649" r:id="rId1"/><p:sldLayoutId id="2147483650" r:id="rId2"/><p:sldLayoutId id="2147483651" r:id="rId3"/></p:sldLayoutIdLst><p:txStyles><p:titleStyle><a:lvl1pPr algn="ctr" defTabSz="457200" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:spcBef><a:spcPct val="0"/></a:spcBef><a:buNone/><a:defRPr sz="4400" kern="1200"><a:solidFill><a:schemeClr val="tx1"/></a:solidFill><a:latin typeface="+mj-lt"/><a:ea typeface="+mj-ea"/><a:cs typeface="+mj-cs"/></a:defRPr></a:lvl1pPr></p:titleStyle><p:bodyStyle><a:lvl1pPr marL="342900" indent="-342900" algn="l" defTabSz="457200" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:spcBef><a:spcPct val="20000"/></a:spcBef><a:buFont typeface="Arial"/><a:buChar char="•"/><a:defRPr sz="3200" kern="1200"><a:solidFill><a:schemeClr val="tx1"/></a:solidFill><a:latin typeface="+mn-lt"/><a:ea typeface="+mn-ea"/><a:cs typeface="+mn-cs"/></a:defRPr></a:lvl1pPr><a:lvl2pPr marL="742950" indent="-285750" algn="l" defTabSz="457200" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:spcBef><a:spcPct val="20000"/></a:spcBef><a:buFont typeface="Arial"/><a:buChar char="–"/><a:defRPr sz="2800" kern="1200"><a:solidFill><a:schemeClr val="tx1"/></a:solidFill><a:latin typeface="+mn-lt"/><a:ea typeface="+mn-ea"/><a:cs typeface="+mn-cs"/></a:defRPr></a:lvl2pPr><a:lvl3pPr marL="1143000" indent="-228600" algn="l" defTabSz="457200" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:spcBef><a:spcPct val="20000"/></a:spcBef><a:buFont typeface="Arial"/><a:buChar char="•"/><a:defRPr sz="2400" kern="1200"><a:solidFill><a:schemeClr val="tx1"/></a:solidFill><a:latin typeface="+mn-lt"/><a:ea typeface="+mn-ea"/><a:cs typeface="+mn-cs"/></a:defRPr></a:lvl3pPr><a:lvl4pPr marL="1600200" indent="-228600" algn="l" defTabSz="457200" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:spcBef><a:spcPct val="20000"/></a:spcBef><a:buFont typeface="Arial"/><a:buChar char="–"/><a:defRPr sz="2000" kern="1200"><a:solidFill><a:schemeClr val="tx1"/></a:solidFill><a:latin typeface="+mn-lt"/><a:ea typeface="+mn-ea"/><a:cs typeface="+mn-cs"/></a:defRPr></a:lvl4pPr><a:lvl5pPr marL="2057400" indent="-228600" algn="l" defTabSz="457200" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:spcBef><a:spcPct val="20000"/></a:spcBef><a:buFont typeface="Arial"/><a:buChar char="»"/><a:defRPr sz="2000" kern="1200"><a:solidFill><a:schemeClr val="tx1"/></a:solidFill><a:latin typeface="+mn-lt"/><a:ea typeface="+mn-ea"/><a:cs typeface="+mn-cs"/></a:defRPr></a:lvl5pPr></p:bodyStyle><p:otherStyle><a:defPPr><a:defRPr lang="en-US"/></a:defPPr><a:lvl1pPr marL="0" algn="l" defTabSz="457200" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="tx1"/></a:solidFill><a:latin typeface="+mn-lt"/><a:ea typeface="+mn-ea"/><a:cs typeface="+mn-cs"/></a:defRPr></a:lvl1pPr></p:otherStyle></p:txStyles></p:sldMaster>`;
+
+// --- Layouts --------------------------------------------------------------
+// Each layout wraps the same `<p:cSld>` grammar as a slide. `addSlide`
+// clones the `<p:ph>` placeholders found here into the new slide, so the
+// placeholder set on each layout is what slide authors get to fill in.
+
+// Blank — no placeholders. `addSlide({ layout: Blank })` yields an empty
+// canvas for free-form text boxes / shapes / images.
+const LAYOUT_BLANK_XML = `${XML_DECL}<p:sldLayout xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" type="blank" preserve="1"><p:cSld name="Blank"><p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/><a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr></p:spTree></p:cSld><p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr></p:sldLayout>`;
+
+// Title Slide — centered title + subtitle, the canonical opener.
+const LAYOUT_TITLE_XML = `${XML_DECL}<p:sldLayout xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" type="title" preserve="1"><p:cSld name="Title Slide"><p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/><a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr><p:sp><p:nvSpPr><p:cNvPr id="2" name="Title 1"/><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr><p:nvPr><p:ph type="ctrTitle"/></p:nvPr></p:nvSpPr><p:spPr><a:xfrm><a:off x="685800" y="2130425"/><a:ext cx="7772400" cy="1470025"/></a:xfrm></p:spPr><p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:rPr lang="en-US" smtClean="0"/><a:t>Click to edit Master title style</a:t></a:r><a:endParaRPr lang="en-US"/></a:p></p:txBody></p:sp><p:sp><p:nvSpPr><p:cNvPr id="3" name="Subtitle 2"/><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr><p:nvPr><p:ph type="subTitle" idx="1"/></p:nvPr></p:nvSpPr><p:spPr><a:xfrm><a:off x="1371600" y="3886200"/><a:ext cx="6400800" cy="1752600"/></a:xfrm></p:spPr><p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:rPr lang="en-US" smtClean="0"/><a:t>Click to edit Master subtitle style</a:t></a:r><a:endParaRPr lang="en-US"/></a:p></p:txBody></p:sp></p:spTree></p:cSld><p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr></p:sldLayout>`;
+
+// Title and Content — title + a single body content placeholder.
+const LAYOUT_OBJ_XML = `${XML_DECL}<p:sldLayout xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" type="obj" preserve="1"><p:cSld name="Title and Content"><p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/><a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr><p:sp><p:nvSpPr><p:cNvPr id="2" name="Title 1"/><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr><p:nvPr><p:ph type="title"/></p:nvPr></p:nvSpPr><p:spPr/><p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:rPr lang="en-US" smtClean="0"/><a:t>Click to edit Master title style</a:t></a:r><a:endParaRPr lang="en-US"/></a:p></p:txBody></p:sp><p:sp><p:nvSpPr><p:cNvPr id="3" name="Content Placeholder 2"/><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr><p:nvPr><p:ph idx="1"/></p:nvPr></p:nvSpPr><p:spPr/><p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:pPr lvl="0"/><a:r><a:rPr lang="en-US" smtClean="0"/><a:t>Click to edit Master text styles</a:t></a:r></a:p></p:txBody></p:sp></p:spTree></p:cSld><p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr></p:sldLayout>`;
+
+// --- Presentation ---------------------------------------------------------
+const buildPresentationXml = (size: { cx: number; cy: number; type: string }): string =>
+  `${XML_DECL}<p:presentation xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" saveSubsetFonts="1"><p:sldMasterIdLst><p:sldMasterId id="2147483648" r:id="rId1"/></p:sldMasterIdLst><p:sldSz cx="${size.cx}" cy="${size.cy}" type="${size.type}"/><p:notesSz cx="6858000" cy="9144000"/></p:presentation>`;
+
+const PRES_PROPS_XML = `${XML_DECL}<p:presentationPr xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"/>`;
+
+const VIEW_PROPS_XML = `${XML_DECL}<p:viewPr xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"/>`;
+
+const CORE_PROPS_XML = `${XML_DECL}<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dcmitype="http://purl.org/dc/dcmitype/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><dc:title></dc:title><dc:creator>pptx-kit</dc:creator><cp:lastModifiedBy>pptx-kit</cp:lastModifiedBy></cp:coreProperties>`;
+
+const EXTENDED_PROPS_XML = `${XML_DECL}<Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties" xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes"><Application>pptx-kit</Application></Properties>`;
+
+// --- .rels ----------------------------------------------------------------
+const ROOT_RELS_XML = `${XML_DECL}<Relationships xmlns="${RT_PACKAGE}"><Relationship Id="rId1" Type="${RT}/officeDocument" Target="ppt/presentation.xml"/><Relationship Id="rId2" Type="${RT_PACKAGE}/metadata/core-properties" Target="docProps/core.xml"/><Relationship Id="rId3" Type="${RT}/extended-properties" Target="docProps/app.xml"/></Relationships>`;
+
+// Presentation rels: master + theme + presProps + viewProps. The master's
+// rId1 must match the `<p:sldMasterId r:id="rId1">` in presentation.xml.
+const PRES_RELS_XML = `${XML_DECL}<Relationships xmlns="${RT_PACKAGE}"><Relationship Id="rId1" Type="${RT}/slideMaster" Target="slideMasters/slideMaster1.xml"/><Relationship Id="rId2" Type="${RT}/theme" Target="theme/theme1.xml"/><Relationship Id="rId3" Type="${RT}/presProps" Target="presProps.xml"/><Relationship Id="rId4" Type="${RT}/viewProps" Target="viewProps.xml"/></Relationships>`;
+
+// Master rels: one slideLayout per shipped layout (matching the master's
+// `<p:sldLayoutIdLst>` rIds) + the theme.
+const MASTER_RELS_XML = `${XML_DECL}<Relationships xmlns="${RT_PACKAGE}"><Relationship Id="rId1" Type="${RT}/slideLayout" Target="../slideLayouts/slideLayout1.xml"/><Relationship Id="rId2" Type="${RT}/slideLayout" Target="../slideLayouts/slideLayout2.xml"/><Relationship Id="rId3" Type="${RT}/slideLayout" Target="../slideLayouts/slideLayout3.xml"/><Relationship Id="rId4" Type="${RT}/theme" Target="../theme/theme1.xml"/></Relationships>`;
+
+// Each layout points back at the single master.
+const LAYOUT_RELS_XML = `${XML_DECL}<Relationships xmlns="${RT_PACKAGE}"><Relationship Id="rId1" Type="${RT}/slideMaster" Target="../slideMasters/slideMaster1.xml"/></Relationships>`;
+
+const TEXT_ENCODER = new TextEncoder();
+const encode = (s: string): Uint8Array => TEXT_ENCODER.encode(s);
+
+/**
+ * Builds an OPC package for an immediately-authorable blank deck: one
+ * slide master, the Office theme, three layouts (Blank / Title Slide /
+ * Title and Content), and the chosen slide size. The deck has no slides
+ * yet — call `addSlide({ layout })` (or `addBlankSlide` / `addTitleSlide`
+ * / `addContentSlide`) to add one.
+ */
+export const buildBlankDeck = (aspect: BlankDeckAspect): OpcPackage => {
+  const pkg = OpcPackage.empty();
+  const size = SLIDE_SIZE[aspect];
+
+  // Register the Content_Types overrides for every XML part we add. The
+  // `.rels` Default is already present from `OpcPackage.empty()`; the
+  // parts below need explicit overrides because their content types are
+  // not extension defaults.
+  const add = (name: string, contentType: string, xml: string): void => {
+    pkg.addPart(partName(name), contentType, encode(xml));
+  };
+  const addRels = (name: string, xml: string): void => {
+    pkg.addPart(partName(name), RELS_CONTENT_TYPE, encode(xml));
+  };
+
+  add('/ppt/presentation.xml', PRESENTATION_CONTENT_TYPE, buildPresentationXml(size));
+  add('/ppt/presProps.xml', PRES_PROPS_CONTENT_TYPE, PRES_PROPS_XML);
+  add('/ppt/viewProps.xml', VIEW_PROPS_CONTENT_TYPE, VIEW_PROPS_XML);
+  add('/ppt/theme/theme1.xml', THEME_CONTENT_TYPE, THEME_XML);
+  add('/ppt/slideMasters/slideMaster1.xml', SLIDE_MASTER_CONTENT_TYPE, SLIDE_MASTER_XML);
+  add('/ppt/slideLayouts/slideLayout1.xml', SLIDE_LAYOUT_CONTENT_TYPE, LAYOUT_BLANK_XML);
+  add('/ppt/slideLayouts/slideLayout2.xml', SLIDE_LAYOUT_CONTENT_TYPE, LAYOUT_TITLE_XML);
+  add('/ppt/slideLayouts/slideLayout3.xml', SLIDE_LAYOUT_CONTENT_TYPE, LAYOUT_OBJ_XML);
+  add('/docProps/core.xml', CORE_PROPS_CONTENT_TYPE, CORE_PROPS_XML);
+  add('/docProps/app.xml', EXTENDED_PROPS_CONTENT_TYPE, EXTENDED_PROPS_XML);
+
+  addRels('/_rels/.rels', ROOT_RELS_XML);
+  addRels('/ppt/_rels/presentation.xml.rels', PRES_RELS_XML);
+  addRels('/ppt/slideMasters/_rels/slideMaster1.xml.rels', MASTER_RELS_XML);
+  addRels('/ppt/slideLayouts/_rels/slideLayout1.xml.rels', LAYOUT_RELS_XML);
+  addRels('/ppt/slideLayouts/_rels/slideLayout2.xml.rels', LAYOUT_RELS_XML);
+  addRels('/ppt/slideLayouts/_rels/slideLayout3.xml.rels', LAYOUT_RELS_XML);
+
+  return pkg;
+};

--- a/src/internal/parts/index.ts
+++ b/src/internal/parts/index.ts
@@ -3,3 +3,5 @@
 
 export type { Part } from './package.ts';
 export { OpcPackage } from './package.ts';
+export type { BlankDeckAspect } from './blank-deck.ts';
+export { buildBlankDeck } from './blank-deck.ts';

--- a/src/internal/presentationml/table-builder.ts
+++ b/src/internal/presentationml/table-builder.ts
@@ -110,27 +110,33 @@ const equalShares = (total: number, n: number): number[] => {
 
 export const buildTable = (opts: TableOptions): XmlElement => {
   const rows = opts.rows;
-  if (rows.length === 0) throw new Error('addTable: at least one row is required');
+  // Empty rows (or a row with no cells) would emit an `<a:tbl>` with no
+  // grid — XML PowerPoint rejects with a repair dialog. Fail loudly at the
+  // authoring boundary instead. Errors name the public `addSlideTable`
+  // entry point (this builder's sole caller) so the message is actionable.
+  if (rows.length === 0) throw new Error('addSlideTable: at least one row is required');
   const colCount = rows[0]?.length ?? 0;
-  if (colCount === 0) throw new Error('addTable: at least one column is required');
+  if (colCount === 0) throw new Error('addSlideTable: at least one column is required');
   for (let i = 0; i < rows.length; i++) {
     const r = rows[i];
-    if (!r) throw new Error(`addTable: row ${i} is missing`);
+    if (!r) throw new Error(`addSlideTable: row ${i} is missing`);
     if (r.length !== colCount) {
       throw new Error(
-        `addTable: row ${i} has ${r.length} cells; expected ${colCount} to match row 0`,
+        `addSlideTable: row ${i} has ${r.length} cells; expected ${colCount} to match row 0`,
       );
     }
   }
 
   const colWidths = opts.colWidths ?? equalShares(opts.w, colCount);
   if (colWidths.length !== colCount) {
-    throw new Error(`addTable: colWidths has ${colWidths.length} entries; expected ${colCount}`);
+    throw new Error(
+      `addSlideTable: colWidths has ${colWidths.length} entries; expected ${colCount}`,
+    );
   }
   const rowHeights = opts.rowHeights ?? equalShares(opts.h, rows.length);
   if (rowHeights.length !== rows.length) {
     throw new Error(
-      `addTable: rowHeights has ${rowHeights.length} entries; expected ${rows.length}`,
+      `addSlideTable: rowHeights has ${rowHeights.length} entries; expected ${rows.length}`,
     );
   }
 

--- a/test/fn-authoring-input-validation.test.ts
+++ b/test/fn-authoring-input-validation.test.ts
@@ -1,0 +1,172 @@
+// Authoring-boundary input validation for charts, tables, and layout lookup.
+//
+// Regression coverage for the issues surfaced integrating pptx-kit into a
+// downstream app:
+//   - chart series colors that aren't sRGB hex were silently emitted as
+//     invalid `<a:srgbClr val="…"/>` (PowerPoint dropped/repaired them);
+//   - `addSlideTable` with empty `rows: []` produced a table with no grid;
+//   - `findSlideLayout` name matching is case-sensitive (documented, not
+//     changed — this test pins the behavior so it doesn't drift).
+
+import { describe, expect, it } from 'vitest';
+import {
+  addBlankSlide,
+  addSlideChart,
+  addSlideTable,
+  createPresentation,
+  findSlideLayout,
+  findSlideLayoutByType,
+  getSlideShapes,
+  inches,
+  type ChartSpec,
+} from '../src/api/index.ts';
+
+const columnSpec = (color: string): ChartSpec => ({
+  kind: 'column',
+  categories: ['A', 'B'],
+  series: [{ name: 'S', values: [1, 2], color }],
+});
+
+describe('addSlideChart: series color validation', () => {
+  it('rejects a non-hex color with a clear, actionable error', () => {
+    const pres = createPresentation();
+    const slide = addBlankSlide(pres);
+    expect(() =>
+      addSlideChart(slide, {
+        x: inches(1),
+        y: inches(1),
+        w: inches(4),
+        h: inches(3),
+        spec: columnSpec('red'),
+      }),
+    ).toThrow(/series\[0\]\.color: invalid chart color "red" — expected an sRGB hex/);
+  });
+
+  it('rejects a malformed hex (wrong length / non-hex digits)', () => {
+    const pres = createPresentation();
+    const slide = addBlankSlide(pres);
+    for (const bad of ['#FFF', '#GGGGGG', 'rgb(0,0,0)', '#12345']) {
+      expect(() =>
+        addSlideChart(slide, {
+          x: inches(1),
+          y: inches(1),
+          w: inches(4),
+          h: inches(3),
+          spec: columnSpec(bad),
+        }),
+      ).toThrow(/invalid chart color/);
+    }
+  });
+
+  it('rejects scheme tokens — charts emit srgbClr, not schemeClr', () => {
+    const pres = createPresentation();
+    const slide = addBlankSlide(pres);
+    expect(() =>
+      addSlideChart(slide, {
+        x: inches(1),
+        y: inches(1),
+        w: inches(4),
+        h: inches(3),
+        spec: columnSpec('accent1'),
+      }),
+    ).toThrow(/invalid chart color/);
+  });
+
+  it('accepts both #RRGGBB and bare RRGGBB', () => {
+    const pres = createPresentation();
+    const slide = addBlankSlide(pres);
+    expect(() =>
+      addSlideChart(slide, {
+        x: inches(1),
+        y: inches(1),
+        w: inches(4),
+        h: inches(3),
+        spec: columnSpec('#4472C4'),
+      }),
+    ).not.toThrow();
+    expect(() =>
+      addSlideChart(slide, {
+        x: inches(1),
+        y: inches(1),
+        w: inches(4),
+        h: inches(3),
+        spec: columnSpec('4472C4'),
+      }),
+    ).not.toThrow();
+  });
+
+  it('validates pointColors and trendline.color too', () => {
+    const pres = createPresentation();
+    const slide = addBlankSlide(pres);
+    expect(() =>
+      addSlideChart(slide, {
+        x: inches(1),
+        y: inches(1),
+        w: inches(4),
+        h: inches(3),
+        spec: {
+          kind: 'pie',
+          categories: ['A', 'B'],
+          series: [{ name: 'S', values: [1, 2], pointColors: ['#FF0000', 'notacolor'] }],
+        },
+      }),
+    ).toThrow(/pointColors\[1\]/);
+  });
+});
+
+describe('addSlideTable: empty rows validation', () => {
+  it('throws an actionable error on empty rows instead of emitting broken XML', () => {
+    const pres = createPresentation();
+    const slide = addBlankSlide(pres);
+    const before = getSlideShapes(slide).length;
+    expect(() =>
+      addSlideTable(slide, { x: inches(1), y: inches(1), w: inches(4), h: inches(2), rows: [] }),
+    ).toThrow(/addSlideTable: at least one row is required/);
+    // The slide must be untouched — no half-built table shape appended.
+    expect(getSlideShapes(slide).length).toBe(before);
+  });
+
+  it('throws on a row with no cells', () => {
+    const pres = createPresentation();
+    const slide = addBlankSlide(pres);
+    expect(() =>
+      addSlideTable(slide, { x: inches(1), y: inches(1), w: inches(4), h: inches(2), rows: [[]] }),
+    ).toThrow(/addSlideTable: at least one column is required/);
+  });
+
+  it('still builds a normal table when rows are non-empty', () => {
+    const pres = createPresentation();
+    const slide = addBlankSlide(pres);
+    const before = getSlideShapes(slide).length;
+    addSlideTable(slide, {
+      x: inches(1),
+      y: inches(1),
+      w: inches(4),
+      h: inches(2),
+      rows: [
+        ['H1', 'H2'],
+        ['a', 'b'],
+      ],
+    });
+    expect(getSlideShapes(slide).length).toBe(before + 1);
+  });
+});
+
+describe('findSlideLayout: documented case sensitivity', () => {
+  it('matches the exact, case-sensitive user-visible name', () => {
+    const pres = createPresentation();
+    expect(findSlideLayout(pres, 'Blank')).not.toBeNull();
+    // Case mismatch does NOT match (this is the documented behavior).
+    expect(findSlideLayout(pres, 'blank')).toBeNull();
+  });
+
+  it('a case-insensitive RegExp bridges the gap', () => {
+    const pres = createPresentation();
+    expect(findSlideLayout(pres, /^blank$/i)).not.toBeNull();
+  });
+
+  it('findSlideLayoutByType matches the locale-stable token regardless of name case', () => {
+    const pres = createPresentation();
+    expect(findSlideLayoutByType(pres, 'blank')).not.toBeNull();
+  });
+});

--- a/test/fn-create-presentation.test.ts
+++ b/test/fn-create-presentation.test.ts
@@ -1,0 +1,173 @@
+// createPresentation — from-scratch authoring.
+//
+// Verifies that `createPresentation()` returns an immediately-authorable
+// deck (master + theme + layouts + slide size), that every emitted XML
+// part is schema-valid, and that a full author→save→load round-trip
+// preserves slides, text, and charts.
+
+import { describe, expect, it } from 'vitest';
+import {
+  addBlankSlide,
+  addContentSlide,
+  addSlide,
+  addSlideChart,
+  addSlideTextBox,
+  createPresentation,
+  findSlideLayout,
+  findSlideLayoutByType,
+  findSlidePlaceholder,
+  getShapeKind,
+  getShapeText,
+  getSlideCharts,
+  getSlideLayoutName,
+  getSlideLayouts,
+  getSlideShapes,
+  getSlideSize,
+  getSlides,
+  getSlideText,
+  inches,
+  loadPresentation,
+  readPackagePart,
+  savePresentation,
+  setShapeText,
+  validatePresentation,
+} from '../src/api/index.ts';
+import {
+  expectSchemaValid,
+  isSchemaValidationAvailable,
+  type SchemaKind,
+} from './lib/expect-schema-valid.ts';
+
+const decoder = new TextDecoder();
+
+describe('fn API: createPresentation', () => {
+  it('returns a deck with master-backed layouts ready for addSlide', () => {
+    const pres = createPresentation();
+    const layouts = getSlideLayouts(pres);
+    expect(layouts.length).toBeGreaterThan(0);
+
+    const names = layouts.map((l) => getSlideLayoutName(l)).sort();
+    expect(names).toEqual(['Blank', 'Title Slide', 'Title and Content']);
+
+    // The spec-token lookups the deck helpers rely on must resolve.
+    expect(findSlideLayoutByType(pres, 'blank')).not.toBeNull();
+    expect(findSlideLayoutByType(pres, 'title')).not.toBeNull();
+    expect(findSlideLayoutByType(pres, 'obj')).not.toBeNull();
+  });
+
+  it("defaults the slide size to 16:9 (PowerPoint's modern default)", () => {
+    const pres = createPresentation();
+    const size = getSlideSize(pres);
+    expect(size).not.toBeNull();
+    expect(size).toMatchObject({ width: 12192000, height: 6858000, type: 'screen16x9' });
+  });
+
+  it('honours the 4:3 size option', () => {
+    const pres = createPresentation({ size: '4:3' });
+    expect(getSlideSize(pres)).toMatchObject({
+      width: 9144000,
+      height: 6858000,
+      type: 'screen4x3',
+    });
+  });
+
+  it('starts with no slides and passes the invariant validator', () => {
+    const pres = createPresentation();
+    expect(getSlides(pres).length).toBe(0);
+    expect(validatePresentation(pres)).toEqual([]);
+  });
+
+  it('round-trips a from-scratch deck: addSlide → text → chart → save → load', async () => {
+    const pres = createPresentation();
+
+    // Title slide via explicit layout + placeholder text.
+    const titleLayout = findSlideLayout(pres, 'Title Slide')!;
+    const titleSlide = addSlide(pres, { layout: titleLayout });
+    const ctrTitle = findSlidePlaceholder(titleSlide, 'ctrTitle')!;
+    setShapeText(ctrTitle, 'pptx-kit from scratch');
+
+    // Content slide via the sugar helper.
+    addContentSlide(pres, { title: 'Agenda', body: 'First item' });
+
+    // Blank slide hosting a free-form text box + a chart.
+    const blankSlide = addBlankSlide(pres);
+    addSlideTextBox(blankSlide, {
+      x: inches(1),
+      y: inches(1),
+      w: inches(8),
+      h: inches(1),
+      text: 'Free-form text box',
+    });
+    const chartShape = addSlideChart(blankSlide, {
+      x: inches(1),
+      y: inches(2.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'column',
+        categories: ['Q1', 'Q2', 'Q3'],
+        series: [{ name: 'Revenue', values: [10, 20, 15] }],
+      },
+    });
+    expect(getShapeKind(chartShape)).toBe('graphicFrame');
+
+    expect(getSlides(pres).length).toBe(3);
+    expect(validatePresentation(pres)).toEqual([]);
+
+    // Save and reload — every authored fact must survive the trip.
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+
+    const slides = getSlides(reloaded);
+    expect(slides.length).toBe(3);
+    expect(getSlideLayouts(reloaded).length).toBe(3);
+
+    expect(getSlideText(slides[0]!)).toContain('pptx-kit from scratch');
+    expect(getSlideText(slides[1]!)).toContain('Agenda');
+    expect(getSlideText(slides[1]!)).toContain('First item');
+    expect(getSlideText(slides[2]!)).toContain('Free-form text box');
+
+    const charts = getSlideCharts(slides[2]!);
+    expect(charts.length).toBe(1);
+    expect(charts[0]!.spec?.kind).toBe('column');
+    expect(charts[0]!.spec?.series[0]?.name).toBe('Revenue');
+
+    // The reloaded title placeholder still reads back its text.
+    const reloadedTitle = findSlidePlaceholder(slides[0]!, 'ctrTitle');
+    expect(reloadedTitle).not.toBeNull();
+    expect(getShapeText(reloadedTitle!)).toBe('pptx-kit from scratch');
+  });
+
+  it('adds a slide for every shipped layout without throwing', () => {
+    const pres = createPresentation();
+    for (const layout of getSlideLayouts(pres)) {
+      const slide = addSlide(pres, { layout });
+      // Each new slide must at least carry the slide-root group.
+      expect(getSlideShapes(slide).length).toBeGreaterThanOrEqual(0);
+    }
+    expect(getSlides(pres).length).toBe(3);
+    expect(validatePresentation(pres)).toEqual([]);
+  });
+
+  it.runIf(isSchemaValidationAvailable())(
+    'emits schema-valid XML for every part of the blank deck',
+    async () => {
+      const pres = createPresentation();
+      const bytes = await savePresentation(pres);
+      const loaded = await loadPresentation(bytes);
+
+      const validate = (partPath: string, kind: SchemaKind): void => {
+        const raw = readPackagePart(loaded, partPath);
+        expect(raw, `missing part ${partPath}`).not.toBeNull();
+        expectSchemaValid(decoder.decode(raw!), kind);
+      };
+
+      validate('/ppt/presentation.xml', 'pml');
+      validate('/ppt/slideMasters/slideMaster1.xml', 'pml');
+      validate('/ppt/slideLayouts/slideLayout1.xml', 'pml');
+      validate('/ppt/slideLayouts/slideLayout2.xml', 'pml');
+      validate('/ppt/slideLayouts/slideLayout3.xml', 'pml');
+      validate('/ppt/theme/theme1.xml', 'dml');
+    },
+  );
+});


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

`createPresentation()` previously returned an OPC package with only the OPC defaults — no slide master, layouts, theme, or slide size — so `getSlideLayouts()` came back empty and `addSlide({ layout })` was impossible. The README's headline "author from scratch" path did not actually work without first loading a template `.pptx`. This was surfaced integrating pptx-kit into a downstream app (flyle-nexus). This PR makes `createPresentation()` return an immediately-authorable deck and hardens three authoring-boundary input-validation gaps found in the same integration.

## Motivation

Downstream integration (flyle-nexus) tried the from-scratch authoring flow promised by the README and hit a wall: `createPresentation()` → `getSlideLayouts()` returned `[]`, so `addSlide({ layout })` could not be used at all. The same integration also hit three smaller authoring papercuts (chart series colors silently dropped, empty-table-rows producing a corrupt deck, and confusion over `findSlideLayout` case sensitivity).

Closes #<!-- no tracking issue; opened from downstream integration feedback -->

## Changes

- **`createPresentation({ size?: '16:9' | '4:3' })`** now ships a slide master, the Office theme, and three layouts — `Blank`, `Title Slide`, `Title and Content`. You can go straight to `addSlide` / `addTitleSlide` / `addContentSlide` and `savePresentation`. Slide size defaults to **16:9** (PowerPoint's modern default) and is selectable via `{ size: '4:3' }`. New exported type `PresentationSize`. The scaffolding lives in `src/internal/parts/blank-deck.ts`, imported **only** by `createPresentation`, so the minimal load+save bundle is unchanged (tree-shaken out).
- **`addSlideChart` / `setChartSpec`** now reject any chart color that isn't an sRGB hex (`#RRGGBB` or `RRGGBB`) — `series.color`, `pointColors`, `trendline.color`, plot/chart-area fills, and axis/gridline/line colors — with a clear, field-named error, instead of silently emitting an invalid `<a:srgbClr val="…"/>` that PowerPoint dropped or repaired. Bare `RRGGBB` is accepted and normalized; scheme tokens (`accent1`) are correctly rejected because charts emit `srgbClr`, not `schemeClr`. New internal `parseSrgbHex` helper.
- **`addSlideTable`** with empty `rows: []` (or a row with no cells) throws an actionable `addSlideTable: …` error (the message previously named the old internal `addTable` path). The grid-less-`<a:tbl>` → PowerPoint-repair-dialog case is closed at the boundary.
- **`findSlideLayout`** case-sensitive, locale-dependent name matching is now documented in its JSDoc and the README, pointing readers to the locale-stable `findSlideLayoutByType` and to `RegExp`/`i` for case-insensitive name lookups. No behavior change.

## Testing

- `test/fn-create-presentation.test.ts` — new E2E: `createPresentation → addSlide → text + chart → save → load round-trip`, layout/size assertions, "add a slide for every shipped layout", and **schema validation of every emitted part against the ECMA-376 XSDs** (xmllint).
- `test/fn-authoring-input-validation.test.ts` — new: chart color rejection/acceptance (hash-optional, scheme-token rejection, pointColors/trendline), empty-table-rows rejection (and that no half-built shape is appended), and pinned `findSlideLayout` case-sensitivity behavior.
- Each new test fails without the corresponding change.
- Full gate run locally, all green:
  - `pnpm format:check && pnpm lint && pnpm typecheck && pnpm build && pnpm test`
  - **1117 passed**, 24 skipped (sample-gen / perf-bench, env-gated).
  - Size gates: minimal load+save bundle **57,331 B** (< 75,000), full fn-API bundle **120,200 B** (< 250,000).

Reproduce: `node_modules/.bin/vitest run test/fn-create-presentation.test.ts test/fn-authoring-input-validation.test.ts test/tree-shake.test.ts`

## Breaking changes

None. `createPresentation()` keeps its zero-argument call signature; the `{ size }` options object is optional and defaults to 16:9. The previous `createPresentation()` return value was never a valid PPTX (could not be authored or saved into a working deck), so no working caller relied on the old empty-package behavior. Shipped as a `minor` changeset.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
