### PR TITLE
feat: chart label fonts, table cell merging, and image fit option

### DIFF
--- a/.changeset/chart-font-table-merge-image-fit.md
+++ b/.changeset/chart-font-table-merge-image-fit.md
@@ -1,0 +1,29 @@
+---
+'pptx-kit': minor
+---
+
+Chart label fonts, table cell merging, and aspect-ratio-preserving image placement
+
+**`ChartTextStyle.font`** — chart titles, axis titles, axis tick labels,
+legends, and data labels now accept a font face
+(`titleStyle: { font: 'Yu Gothic' }`). The builder writes both
+`<a:latin typeface>` and `<a:ea typeface>` so CJK families render
+correctly in PowerPoint, and `getSlideCharts` / `getShapeChartSpec` read
+the face back for round-trips. Works through both `addSlideChart` and
+`setChartSpec`. (The SVG preview keeps its fixed substitution font set —
+authored chart faces affect the emitted PPTX, not the preview raster.)
+
+**`mergeTableCells(table, { row, col, rowSpan, colSpan })`** — the write
+counterpart to `getTableCellSpan`. Merges a rectangular block into its
+top-left anchor, emitting `gridSpan` / `rowSpan` on the anchor and
+`hMerge` / `vMerge` on the covered cells per ECMA-376 §21.1.3.18.
+Out-of-range blocks, 1×1 blocks, and overlaps with existing merges are
+rejected with descriptive errors before anything is mutated.
+
+**`fit: 'contain'` on `addSlideImage` / `setShapeImage`** — preserve the
+image's aspect ratio instead of stretching to the target box. `'contain'`
+inscribes and centers the image (natural size read from the PNG / JPEG
+header); other formats fall back to the default `'fill'` (the existing
+stretch behavior) rather than erroring. On `setShapeImage`,
+`fit: 'contain'` re-fits the replacement image inside the picture's
+current box.

--- a/src/api/fn/shape-authoring.ts
+++ b/src/api/fn/shape-authoring.ts
@@ -9,7 +9,9 @@ import {
   type ImageFormat,
   nextRelId,
   partName,
+  readImagePixelSize,
 } from '../../internal/opc/index.ts';
+import { type ImageFit, fitImageRect } from './shape-image.ts';
 import {
   REL_TYPES,
   type PresetShape,
@@ -153,11 +155,18 @@ export const addSlideTable = (
  * rel, and appends a `<p:pic>` element to the slide's `<p:spTree>`.
  *
  * Format is detected from magic bytes; pass `opts.format` to override.
+ *
+ * `opts.fit` controls how the image fills the `w × h` box. `'fill'` (the
+ * default) stretches to the exact box, ignoring aspect ratio. `'contain'`
+ * scales the image to fit inside the box preserving its aspect ratio and
+ * centers it — measured from the PNG / JPEG header. For other formats (or
+ * an unreadable header) `'contain'` falls back to `'fill'` rather than
+ * erroring, since the natural size is unknown.
  */
 export const addSlideImage = (
   slide: SlideData,
   bytes: Uint8Array,
-  opts: { x: Emu; y: Emu; w: Emu; h: Emu; format?: ImageFormat; name?: string },
+  opts: { x: Emu; y: Emu; w: Emu; h: Emu; format?: ImageFormat; name?: string; fit?: ImageFit },
 ): SlideShapeData => {
   const pkg = slide[INTERNAL_PACKAGE];
   const format = opts.format ?? detectImageFormat(bytes);
@@ -196,14 +205,19 @@ export const addSlideImage = (
   });
   pkg.setRels(slide[SLIDE_PART_NAME], rels);
 
+  const rect = fitImageRect(
+    { x: opts.x, y: opts.y, w: opts.w, h: opts.h },
+    opts.fit ?? 'fill',
+    readImagePixelSize(bytes),
+  );
   const pic = buildPicture({
     id: nextShapeId(slide),
     ...(opts.name !== undefined ? { name: opts.name } : {}),
     rEmbed: newRId,
-    x: opts.x,
-    y: opts.y,
-    w: opts.w,
-    h: opts.h,
+    x: rect.x,
+    y: rect.y,
+    w: rect.w,
+    h: rect.h,
   });
   return appendAndReturnNewShape(slide, pic);
 };

--- a/src/api/fn/shape-image.ts
+++ b/src/api/fn/shape-image.ts
@@ -1,14 +1,17 @@
 // Shape image replacement.
 
 import { getPictureEmbedRId } from '../../internal/drawingml/index.ts';
+import { readPosition, readSize, setPosition, setSize } from '../../internal/drawingml/index.ts';
 import {
   type ImageFormat,
   contentTypeForFormat,
   detectImageFormat,
   extensionForFormat,
   partName,
+  readImagePixelSize,
   resolveTarget,
 } from '../../internal/opc/index.ts';
+import type { Emu } from '../units.ts';
 import {
   INTERNAL_PACKAGE,
   SHAPE_ELEMENT,
@@ -17,18 +20,57 @@ import {
   SLIDE_PART_NAME,
   type SlideShapeData,
 } from '../_internal-symbols.ts';
+import { commitSlideData, refreshSlideData } from './_helpers.ts';
 // ---------------------------------------------------------------------------
+
+/**
+ * How an image fills its target box:
+ *
+ *   - `'fill'` — stretch to the exact `w × h`, ignoring aspect ratio
+ *     (the historical behavior, and the default for back-compat).
+ *   - `'contain'` — scale to fit inside the box preserving aspect ratio,
+ *     then center the result. The box's empty margins stay transparent.
+ */
+export type ImageFit = 'fill' | 'contain';
+
+/**
+ * Computes the placed rectangle for an image inside a `(x, y, w, h)` box.
+ *
+ * For `'contain'` the image is scaled by the smaller of the two axis
+ * ratios so it fits entirely, then centered in the leftover space. When
+ * the natural size is unknown (non-PNG/JPEG, or an unreadable header)
+ * `naturalSize` is `null` and we fall back to `'fill'` — callers pass the
+ * raw bytes; measuring is best-effort, not a hard requirement.
+ */
+export const fitImageRect = (
+  box: { x: Emu; y: Emu; w: Emu; h: Emu },
+  fit: ImageFit,
+  naturalSize: { width: number; height: number } | null,
+): { x: Emu; y: Emu; w: Emu; h: Emu } => {
+  if (fit === 'fill' || naturalSize === null) return box;
+  const scale = Math.min(box.w / naturalSize.width, box.h / naturalSize.height);
+  const w = Math.round(naturalSize.width * scale);
+  const h = Math.round(naturalSize.height * scale);
+  const x = box.x + Math.round((box.w - w) / 2);
+  const y = box.y + Math.round((box.h - h) / 2);
+  return { x: x as Emu, y: y as Emu, w: w as Emu, h: h as Emu };
+};
 
 /**
  * Replaces a picture's media with `bytes`. Same-format replacements
  * write in place; cross-format replacements allocate a new media part
- * and repoint the rel. The original geometry — crop, sizing, transform —
- * is preserved.
+ * and repoint the rel. The geometry — crop, transform — is preserved.
+ *
+ * Pass `options.fit: 'contain'` to re-fit the picture's extent to the
+ * replacement image's aspect ratio, inscribed and centered in the shape's
+ * current `(off, ext)` box. The default `'fill'` leaves the extent as-is
+ * (the historical behavior). When the new image's natural size can't be
+ * measured (non-PNG/JPEG), `'contain'` is a no-op rather than an error.
  */
 export const setShapeImage = (
   shape: SlideShapeData,
   bytes: Uint8Array,
-  options: { format?: ImageFormat } = {},
+  options: { format?: ImageFormat; fit?: ImageFit } = {},
 ): void => {
   if (shape[SHAPE_SNAPSHOT].kind !== 'picture') {
     throw new Error(
@@ -65,26 +107,46 @@ export const setShapeImage = (
     if (!part) throw new Error(`media part missing: ${mediaName}`);
     part.data = bytes;
     part.contentType = newContentType;
-    return;
+  } else {
+    let nextN = 1;
+    const mediaPathRegex = /^\/ppt\/media\/image(\d+)\./;
+    for (const p of pkg.parts) {
+      const m = p.name.match(mediaPathRegex);
+      if (m?.[1] !== undefined) {
+        const num = Number.parseInt(m[1], 10);
+        if (Number.isFinite(num) && num >= nextN) nextN = num + 1;
+      }
+    }
+    const newPartName = partName(`/ppt/media/image${nextN}.${newExtension}`);
+    const hasDefault = pkg.contentTypes.defaults.some(
+      (d) => d.extension.toLowerCase() === newExtension,
+    );
+    if (!hasDefault) {
+      pkg.contentTypes.defaults.push({ extension: newExtension, contentType: newContentType });
+    }
+    pkg.addPart(newPartName, newContentType, bytes);
+    rel.target = `../media/image${nextN}.${newExtension}`;
+    pkg.setRels(slide[SLIDE_PART_NAME], rels);
   }
 
-  let nextN = 1;
-  const mediaPathRegex = /^\/ppt\/media\/image(\d+)\./;
-  for (const p of pkg.parts) {
-    const m = p.name.match(mediaPathRegex);
-    if (m?.[1] !== undefined) {
-      const num = Number.parseInt(m[1], 10);
-      if (Number.isFinite(num) && num >= nextN) nextN = num + 1;
+  // 'contain' re-fits the picture's extent to the new image's aspect ratio
+  // inside the shape's current box; 'fill' (the default) leaves geometry as
+  // PowerPoint had it. Natural size is best-effort — unreadable headers
+  // leave the box unchanged.
+  if (options.fit === 'contain') {
+    const pos = readPosition(shape[SHAPE_ELEMENT], 'picture');
+    const size = readSize(shape[SHAPE_ELEMENT], 'picture');
+    const natural = readImagePixelSize(bytes);
+    if (pos !== null && size !== null && natural !== null) {
+      const fitted = fitImageRect(
+        { x: pos.x as Emu, y: pos.y as Emu, w: size.w as Emu, h: size.h as Emu },
+        'contain',
+        natural,
+      );
+      setPosition(shape[SHAPE_ELEMENT], 'picture', fitted.x, fitted.y);
+      setSize(shape[SHAPE_ELEMENT], 'picture', fitted.w, fitted.h);
+      commitSlideData(slide);
+      refreshSlideData(slide);
     }
   }
-  const newPartName = partName(`/ppt/media/image${nextN}.${newExtension}`);
-  const hasDefault = pkg.contentTypes.defaults.some(
-    (d) => d.extension.toLowerCase() === newExtension,
-  );
-  if (!hasDefault) {
-    pkg.contentTypes.defaults.push({ extension: newExtension, contentType: newContentType });
-  }
-  pkg.addPart(newPartName, newContentType, bytes);
-  rel.target = `../media/image${nextN}.${newExtension}`;
-  pkg.setRels(slide[SLIDE_PART_NAME], rels);
 };

--- a/src/api/fn/tables.ts
+++ b/src/api/fn/tables.ts
@@ -503,6 +503,128 @@ export const getTableCellSpan = (
   };
 };
 
+const ATTR_GRID_SPAN = qname('', 'gridSpan', '');
+const ATTR_ROW_SPAN = qname('', 'rowSpan', '');
+const ATTR_H_MERGE = qname('', 'hMerge', '');
+const ATTR_V_MERGE = qname('', 'vMerge', '');
+
+const setSpanAttr = (tc: XmlElement, name: ReturnType<typeof qname>, value: string): void => {
+  tc.attrs = tc.attrs.filter(
+    (a) => !(a.name.namespaceURI === '' && a.name.localName === name.localName),
+  );
+  tc.attrs.push(attr(name, value));
+};
+
+/** A cell already carries a merge marker / multi-cell span. */
+const cellIsMergedAlready = (tc: XmlElement): boolean => {
+  const gs = getAttrValue(tc, ATTR_GRID_SPAN);
+  const rs = getAttrValue(tc, ATTR_ROW_SPAN);
+  const hm = getAttrValue(tc, ATTR_H_MERGE);
+  const vm = getAttrValue(tc, ATTR_V_MERGE);
+  return (
+    (gs !== null && Number.parseInt(gs, 10) > 1) ||
+    (rs !== null && Number.parseInt(rs, 10) > 1) ||
+    hm === '1' ||
+    hm === 'true' ||
+    vm === '1' ||
+    vm === 'true'
+  );
+};
+
+/**
+ * Merges a rectangular block of table cells into a single visual cell.
+ *
+ * The block's top-left cell `(row, col)` becomes the anchor and carries
+ * `gridSpan` (= `colSpan`) / `rowSpan`; the cells it covers are marked
+ * `hMerge` / `vMerge` per ECMA-376 §21.1.3.18 (`CT_TableCell`) so the
+ * grid stays rectangular while PowerPoint paints only the anchor. This
+ * is the write counterpart to {@link getTableCellSpan}.
+ *
+ * Constraints, enforced loudly (these are authoring-boundary inputs):
+ *
+ *   - `rowSpan` / `colSpan` must be ≥ 1, and at least one must be > 1
+ *     (a 1×1 "merge" is a no-op the caller didn't mean).
+ *   - The block must lie fully inside the table grid.
+ *   - No cell in the block may already participate in another merge —
+ *     overlapping merges corrupt the grid and trip PowerPoint's repair
+ *     dialog. Split the existing merge first.
+ *
+ * The anchor cell's text is preserved; covered cells keep their own
+ * `<a:txBody>` in the XML (PowerPoint ignores it while the merge marker
+ * is set) so the operation stays losslessly reversible.
+ */
+export const mergeTableCells = (
+  table: SlideShapeData,
+  block: {
+    readonly row: number;
+    readonly col: number;
+    readonly rowSpan: number;
+    readonly colSpan: number;
+  },
+): void => {
+  const { row, col, rowSpan, colSpan } = block;
+  if (!Number.isInteger(rowSpan) || !Number.isInteger(colSpan) || rowSpan < 1 || colSpan < 1) {
+    throw new RangeError(
+      `mergeTableCells: rowSpan / colSpan must be integers ≥ 1 (got ${rowSpan} × ${colSpan})`,
+    );
+  }
+  if (rowSpan === 1 && colSpan === 1) {
+    throw new RangeError('mergeTableCells: a 1×1 block is not a merge');
+  }
+  if (!Number.isInteger(row) || !Number.isInteger(col) || row < 0 || col < 0) {
+    throw new RangeError(
+      `mergeTableCells: row / col must be non-negative integers (got ${row}, ${col})`,
+    );
+  }
+
+  const cells = getTableCells(table);
+  const lastRow = row + rowSpan - 1;
+  const lastCol = col + colSpan - 1;
+  if (lastRow >= cells.length) {
+    throw new RangeError(
+      `mergeTableCells: block rows ${row}..${lastRow} exceed table height ${cells.length}`,
+    );
+  }
+  for (let r = row; r <= lastRow; r++) {
+    const rowCellsArr = cells[r]!;
+    if (lastCol >= rowCellsArr.length) {
+      throw new RangeError(
+        `mergeTableCells: block cols ${col}..${lastCol} exceed row ${r} width ${rowCellsArr.length}`,
+      );
+    }
+  }
+
+  // Reject overlaps with any pre-existing merge before mutating anything,
+  // so a rejected call leaves the table untouched.
+  for (let r = row; r <= lastRow; r++) {
+    for (let c = col; c <= lastCol; c++) {
+      if (cellIsMergedAlready(cells[r]![c]![CELL_ELEMENT])) {
+        throw new Error(
+          `mergeTableCells: cell (${r}, ${c}) is already part of a merge; split it before re-merging`,
+        );
+      }
+    }
+  }
+
+  for (let r = row; r <= lastRow; r++) {
+    for (let c = col; c <= lastCol; c++) {
+      const tc = cells[r]![c]![CELL_ELEMENT];
+      if (r === row && c === col) {
+        if (colSpan > 1) setSpanAttr(tc, ATTR_GRID_SPAN, String(colSpan));
+        if (rowSpan > 1) setSpanAttr(tc, ATTR_ROW_SPAN, String(rowSpan));
+        continue;
+      }
+      // Covered cells: a column offset from the anchor sets hMerge; a row
+      // offset sets vMerge. The bottom-right block carries both.
+      if (c > col) setSpanAttr(tc, ATTR_H_MERGE, '1');
+      if (r > row) setSpanAttr(tc, ATTR_V_MERGE, '1');
+    }
+  }
+
+  commitSlideData(table[SHAPE_SLIDE]);
+  refreshSlideData(table[SHAPE_SLIDE]);
+};
+
 /**
  * One side of a cell's border, as read from `<a:tcPr><a:ln{L|R|T|B}>`.
  * `widthEmu` is the line width in EMU; `color` is `#RRGGBB` or `null`

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -40,6 +40,7 @@ export type { ShapeClickAction } from './fn.ts';
 export type { IssueSeverity, ValidationIssue } from './fn.ts';
 export type { AnimationEffect, AnimationOptions } from './fn.ts';
 export type { ImageCrop } from './fn.ts';
+export type { ImageFit } from './fn.ts';
 export type {
   ArrowOptions,
   GlowOptions,
@@ -394,6 +395,7 @@ export {
   getTableSize,
   getTableStyleFlags,
   getTableStyleId,
+  mergeTableCells,
   getThumbnail,
   getVisibleSlides,
   hasShapeText,

--- a/src/internal/chartml/chart-builder.ts
+++ b/src/internal/chartml/chart-builder.ts
@@ -624,6 +624,14 @@ const rPrAttrsFromStyle = (
       }),
     );
   }
+  // <a:latin> / <a:ea> follow the fill group in CT_TextCharacterProperties;
+  // ea carries the same face so CJK glyphs aren't dropped to the renderer's
+  // latin-only fallback (the latin slot is ignored for east-asian script).
+  if (style?.font !== undefined) {
+    const typeface = attr(qname('', 'typeface', ''), style.font);
+    children.push(elem(a('latin'), { attrs: [typeface] }));
+    children.push(elem(a('ea'), { attrs: [typeface] }));
+  }
   return { attrs, children };
 };
 

--- a/src/internal/chartml/chart-reader.ts
+++ b/src/internal/chartml/chart-reader.ts
@@ -432,12 +432,15 @@ const NAME_A_RPR = qname('a', 'rPr', NS_A);
 const NAME_A_DEF_RPR = qname('a', 'defRPr', NS_A);
 const NAME_A_PPR = qname('a', 'pPr', NS_A);
 const NAME_A_SRGB = qname('a', 'srgbClr', NS_A);
+const NAME_A_LATIN = qname('a', 'latin', NS_A);
+const ATTR_TYPEFACE = qname('', 'typeface', '');
 
 // Reads `<a:rPr>` / `<a:defRPr>` attributes (size in 100ths of a pt,
 // bold / italic) plus the first solidFill color inside it. Returns an
 // undefined-only style when nothing is authored — callers should drop
 // the style entirely in that case.
 const readRunStyle = (rPr: XmlElement): ChartTextStyle | undefined => {
+  let font: string | undefined;
   let sizePt: number | undefined;
   let bold: boolean | undefined;
   let italic: boolean | undefined;
@@ -459,10 +462,25 @@ const readRunStyle = (rPr: XmlElement): ChartTextStyle | undefined => {
       if (v !== null) color = `#${v.toUpperCase()}`;
     }
   }
-  if (sizePt === undefined && bold === undefined && italic === undefined && color === undefined) {
+  // The latin slot is the authoritative font face on the round-trip; the
+  // ea slot carries the same value (written by the builder) so reading
+  // latin alone recovers the authored `font`.
+  const latin = firstChildElement(rPr, NAME_A_LATIN);
+  if (latin) {
+    const tf = getAttrValue(latin, ATTR_TYPEFACE);
+    if (tf !== null && tf !== '') font = tf;
+  }
+  if (
+    font === undefined &&
+    sizePt === undefined &&
+    bold === undefined &&
+    italic === undefined &&
+    color === undefined
+  ) {
     return undefined;
   }
   return {
+    ...(font !== undefined ? { font } : {}),
     ...(sizePt !== undefined ? { sizePt } : {}),
     ...(bold !== undefined ? { bold } : {}),
     ...(italic !== undefined ? { italic } : {}),

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -301,6 +301,14 @@ export type ChartGrouping = 'clustered' | 'stacked' | 'percentStacked' | 'standa
  * renderer's default for this label position."
  */
 export interface ChartTextStyle {
+  /**
+   * Font face applied to both the latin and east-asian typeface slots —
+   * `<a:rPr><a:latin typeface="…"/><a:ea typeface="…"/>`. East-asian is
+   * set alongside latin so a Japanese / CJK family (e.g. `'Yu Gothic'`)
+   * renders the labels instead of the renderer's latin-only fallback.
+   * Mirrors the latin/ea pairing PowerPoint emits for CJK chart fonts.
+   */
+  readonly font?: string;
   /** Font size in points. From `<a:rPr sz="N"/>` where N is in 100ths of a pt. */
   readonly sizePt?: number;
   /** Bold flag from `<a:rPr b="1"/>`. */

--- a/src/internal/opc/image-format.ts
+++ b/src/internal/opc/image-format.ts
@@ -45,6 +45,77 @@ export const detectImageFormat = (bytes: Uint8Array): ImageFormat | null => {
   return null;
 };
 
+/** Natural pixel dimensions of an image. */
+export interface ImagePixelSize {
+  readonly width: number;
+  readonly height: number;
+}
+
+const readUint16Be = (bytes: Uint8Array, at: number): number => (bytes[at]! << 8) | bytes[at + 1]!;
+
+const readUint32Be = (bytes: Uint8Array, at: number): number =>
+  // `>>> 0` keeps the result an unsigned 32-bit int (a 4-byte PNG dimension
+  // with the high bit set would otherwise read as negative).
+  ((bytes[at]! << 24) | (bytes[at + 1]! << 16) | (bytes[at + 2]! << 8) | bytes[at + 3]!) >>> 0;
+
+// PNG: the IHDR chunk is the first chunk and always at a fixed offset —
+// 8-byte signature, 4-byte length, 4-byte "IHDR" tag, then width / height
+// as big-endian uint32 (PNG spec §11.2.2).
+const pngSize = (bytes: Uint8Array): ImagePixelSize | null => {
+  if (bytes.length < 24) return null;
+  const width = readUint32Be(bytes, 16);
+  const height = readUint32Be(bytes, 20);
+  if (width <= 0 || height <= 0) return null;
+  return { width, height };
+};
+
+// JPEG: walk the marker segments until a Start-Of-Frame marker, whose
+// payload carries the sample dimensions. SOF markers are 0xC0..0xCF except
+// the non-frame markers 0xC4 (DHT), 0xC8 (JPG), 0xCC (DAC).
+const JPEG_SOF_EXCLUDED = new Set([0xc4, 0xc8, 0xcc]);
+const jpegSize = (bytes: Uint8Array): ImagePixelSize | null => {
+  // Skip the SOI (0xFFD8); then each segment is 0xFF, marker, 2-byte length.
+  let offset = 2;
+  while (offset + 9 < bytes.length) {
+    if (bytes[offset] !== 0xff) {
+      offset++;
+      continue;
+    }
+    const marker = bytes[offset + 1]!;
+    // Padding / standalone markers (RSTn, SOI, EOI, TEM) carry no length.
+    if (marker === 0xff || (marker >= 0xd0 && marker <= 0xd9) || marker === 0x01) {
+      offset += 2;
+      continue;
+    }
+    const segmentLength = readUint16Be(bytes, offset + 2);
+    if (segmentLength < 2) return null;
+    if (marker >= 0xc0 && marker <= 0xcf && !JPEG_SOF_EXCLUDED.has(marker)) {
+      // SOF payload: 1-byte precision, 2-byte height, 2-byte width.
+      const height = readUint16Be(bytes, offset + 5);
+      const width = readUint16Be(bytes, offset + 7);
+      if (width <= 0 || height <= 0) return null;
+      return { width, height };
+    }
+    offset += 2 + segmentLength;
+  }
+  return null;
+};
+
+/**
+ * Reads an image's natural pixel dimensions from its header. Supports PNG
+ * and JPEG — the two formats whose headers carry dimensions cheaply and
+ * unambiguously. Returns `null` for every other format (and for truncated
+ * / malformed headers), letting callers fall back rather than fail: an
+ * aspect-ratio-preserving placement that can't measure the image just
+ * stretches it as before.
+ */
+export const readImagePixelSize = (bytes: Uint8Array): ImagePixelSize | null => {
+  const format = detectImageFormat(bytes);
+  if (format === 'png') return pngSize(bytes);
+  if (format === 'jpeg') return jpegSize(bytes);
+  return null;
+};
+
 /**
  * Returns the conventional file-extension token (no leading dot) for the
  * given format. `jpeg` maps to `jpg` because that's what PowerPoint emits.

--- a/src/internal/opc/index.ts
+++ b/src/internal/opc/index.ts
@@ -27,5 +27,10 @@ export {
 export type { Relationship, Relationships, TargetMode } from './rels.ts';
 export { emptyRels, nextRelId, parseRels, serializeRels } from './rels.ts';
 
-export type { ImageFormat } from './image-format.ts';
-export { contentTypeForFormat, detectImageFormat, extensionForFormat } from './image-format.ts';
+export type { ImageFormat, ImagePixelSize } from './image-format.ts';
+export {
+  contentTypeForFormat,
+  detectImageFormat,
+  extensionForFormat,
+  readImagePixelSize,
+} from './image-format.ts';

--- a/test/fn-chart-font.test.ts
+++ b/test/fn-chart-font.test.ts
@@ -1,0 +1,167 @@
+// ChartTextStyle.font — author a font face on chart labels and round-trip
+// it back. The builder writes both the latin and east-asian typeface
+// slots so CJK families (e.g. "Yu Gothic") aren't dropped to a latin-only
+// fallback; the reader recovers the face from the latin slot.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  _internalPackageOf,
+  addSlideChart,
+  getSlideCharts,
+  getSlides,
+  inches,
+  loadPresentation,
+  savePresentation,
+  setChartSpec,
+} from '../src/api/index.ts';
+import { expectSchemaValid, isSchemaValidationAvailable } from './lib/expect-schema-valid.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+const decode = (b: Uint8Array): string => new TextDecoder().decode(b);
+const skipIfNoXmllint = isSchemaValidationAvailable() ? it : it.skip;
+
+const YU_GOTHIC = 'Yu Gothic';
+
+describe('fn API: ChartTextStyle.font', () => {
+  it('round-trips font on title / axis / legend / data-label styles', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'column',
+        categories: ['一月', '二月'],
+        series: [{ name: '売上', values: [10, 20] }],
+        title: '四半期',
+        titleStyle: { font: YU_GOTHIC, sizePt: 18 },
+        categoryAxisLabelStyle: { font: YU_GOTHIC },
+        valueAxisLabelStyle: { font: YU_GOTHIC, color: '#333333' },
+        dataLabels: {
+          showValue: true,
+          showCategory: false,
+          showSeriesName: false,
+          showPercent: false,
+          textStyle: { font: YU_GOTHIC },
+        },
+        legend: { position: 'r', textStyle: { font: YU_GOTHIC } },
+      },
+    });
+    const reloaded = await loadPresentation(await savePresentation(pres));
+    const spec = getSlideCharts(getSlides(reloaded)[0]!)[0]!.spec!;
+    expect(spec.titleStyle?.font).toBe(YU_GOTHIC);
+    expect(spec.titleStyle?.sizePt).toBe(18);
+    expect(spec.categoryAxisLabelStyle?.font).toBe(YU_GOTHIC);
+    expect(spec.valueAxisLabelStyle?.font).toBe(YU_GOTHIC);
+    expect(spec.valueAxisLabelStyle?.color).toBe('#333333');
+    expect(spec.dataLabels?.textStyle?.font).toBe(YU_GOTHIC);
+    expect(spec.legend?.textStyle?.font).toBe(YU_GOTHIC);
+  });
+
+  it('emits both <a:latin> and <a:ea> typeface for the same face', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(4),
+      h: inches(3),
+      spec: {
+        kind: 'bar',
+        categories: ['A', 'B'],
+        series: [{ name: 'X', values: [1, 2] }],
+        title: 'T',
+        titleStyle: { font: YU_GOTHIC },
+      },
+    });
+    const reloaded = await loadPresentation(await savePresentation(pres));
+    const pkg = _internalPackageOf(reloaded);
+    const chartPart = pkg.parts.find((p) => p.name === '/ppt/charts/chart1.xml');
+    const xml = decode(chartPart!.data);
+    expect(xml).toContain(`<a:latin typeface="${YU_GOTHIC}"`);
+    expect(xml).toContain(`<a:ea typeface="${YU_GOTHIC}"`);
+  });
+
+  it('applies font on setChartSpec updates too', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(4),
+      h: inches(3),
+      spec: {
+        kind: 'column',
+        categories: ['A', 'B'],
+        series: [{ name: 'X', values: [1, 2] }],
+      },
+    });
+    const reloaded = await loadPresentation(await savePresentation(pres));
+    const chart = getSlideCharts(getSlides(reloaded)[0]!)[0]!;
+    setChartSpec(chart, {
+      kind: 'column',
+      categories: ['A', 'B'],
+      series: [{ name: 'X', values: [1, 2] }],
+      title: 'Styled',
+      titleStyle: { font: YU_GOTHIC },
+    });
+    const reread = await loadPresentation(await savePresentation(reloaded));
+    const spec = getSlideCharts(getSlides(reread)[0]!)[0]!.spec!;
+    expect(spec.titleStyle?.font).toBe(YU_GOTHIC);
+  });
+
+  it('omits the typeface children entirely when no font is authored', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(4),
+      h: inches(3),
+      spec: {
+        kind: 'bar',
+        categories: ['A'],
+        series: [{ name: 'X', values: [1] }],
+        title: 'NoFont',
+        titleStyle: { sizePt: 12 },
+      },
+    });
+    const reloaded = await loadPresentation(await savePresentation(pres));
+    const spec = getSlideCharts(getSlides(reloaded)[0]!)[0]!.spec!;
+    expect(spec.titleStyle?.font).toBeUndefined();
+    const pkg = _internalPackageOf(reloaded);
+    const xml = decode(pkg.parts.find((p) => p.name === '/ppt/charts/chart1.xml')!.data);
+    expect(xml).not.toContain('<a:latin');
+  });
+
+  skipIfNoXmllint('a chart with authored fonts stays schema-valid', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'column',
+        categories: ['一月', '二月'],
+        series: [{ name: '売上', values: [10, 20] }],
+        title: '四半期',
+        titleStyle: { font: YU_GOTHIC, sizePt: 18, color: '#FF0000' },
+        categoryAxisLabelStyle: { font: YU_GOTHIC },
+        valueAxisLabelStyle: { font: YU_GOTHIC },
+        legend: { position: 'b', textStyle: { font: YU_GOTHIC } },
+      },
+    });
+    const reloaded = await loadPresentation(await savePresentation(pres));
+    const pkg = _internalPackageOf(reloaded);
+    const chartPart = pkg.parts.find((p) => p.name === '/ppt/charts/chart1.xml');
+    expectSchemaValid(decode(chartPart!.data), 'chart');
+  });
+});

--- a/test/fn-image-fit.test.ts
+++ b/test/fn-image-fit.test.ts
@@ -1,0 +1,165 @@
+// addSlideImage / setShapeImage `fit` option — 'contain' scales the image
+// to fit inside the target box preserving aspect ratio (centered), 'fill'
+// (the default) stretches to the exact box as before. Natural size comes
+// from the PNG / JPEG header; unmeasurable formats fall back to 'fill'.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  addSlideImage,
+  getShapeBounds,
+  getSlides,
+  inches,
+  loadPresentation,
+  savePresentation,
+  setShapeImage,
+} from '../src/api/index.ts';
+import { readImagePixelSize } from '../src/internal/opc/index.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+// prettier-ignore
+const PNG_1X1 = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+  0x89, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00,
+  0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+  0x42, 0x60, 0x82,
+]);
+
+// The size reader only parses the IHDR header, so a dimension-patched copy
+// of the 1×1 PNG is enough to exercise the fit math (the pixel payload is
+// stored opaquely; nothing in the save path re-decodes it).
+const pngWithSize = (width: number, height: number): Uint8Array => {
+  const bytes = PNG_1X1.slice();
+  const view = new DataView(bytes.buffer);
+  view.setUint32(16, width);
+  view.setUint32(20, height);
+  return bytes;
+};
+
+// Minimal JPEG: SOI + one SOF0 segment carrying 64×32 + EOI.
+// prettier-ignore
+const JPEG_64X32 = new Uint8Array([
+  0xff, 0xd8,
+  0xff, 0xc0, 0x00, 0x11, 0x08, 0x00, 0x20, 0x00, 0x40, 0x03,
+  0x01, 0x22, 0x00, 0x02, 0x11, 0x01, 0x03, 0x11, 0x01,
+  0xff, 0xd9,
+]);
+
+// prettier-ignore
+const GIF_HEADER = new Uint8Array([
+  0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x02, 0x00, 0x01, 0x00, 0x80, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0x3b,
+]);
+
+describe('internal: readImagePixelSize', () => {
+  it('reads PNG dimensions from the IHDR header', () => {
+    expect(readImagePixelSize(pngWithSize(200, 100))).toEqual({ width: 200, height: 100 });
+    expect(readImagePixelSize(PNG_1X1)).toEqual({ width: 1, height: 1 });
+  });
+
+  it('reads JPEG dimensions from the SOF marker', () => {
+    expect(readImagePixelSize(JPEG_64X32)).toEqual({ width: 64, height: 32 });
+  });
+
+  it('returns null for formats without a cheap header (GIF) and truncated bytes', () => {
+    expect(readImagePixelSize(GIF_HEADER)).toBeNull();
+    expect(readImagePixelSize(PNG_1X1.subarray(0, 20))).toBeNull();
+    expect(readImagePixelSize(new Uint8Array([0xff, 0xd8, 0xff, 0xd9]))).toBeNull();
+  });
+});
+
+describe('fn API: addSlideImage fit option', () => {
+  const box = { x: inches(1), y: inches(1), w: inches(2), h: inches(2) };
+
+  it("defaults to 'fill' — the picture takes the exact box", async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const pic = addSlideImage(slide, pngWithSize(200, 100), box);
+    expect(getShapeBounds(pic)).toEqual({ x: box.x, y: box.y, w: box.w, h: box.h });
+  });
+
+  it("'contain' letterboxes a wide image (full width, centered vertically)", async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const pic = addSlideImage(slide, pngWithSize(200, 100), { ...box, fit: 'contain' });
+    const b = getShapeBounds(pic)!;
+    expect(b.w).toBe(inches(2));
+    expect(b.h).toBe(inches(1));
+    expect(b.x).toBe(inches(1));
+    // Centered: y + (boxH - h) / 2 = 1in + 0.5in.
+    expect(b.y).toBe(inches(1.5));
+  });
+
+  it("'contain' pillarboxes a tall image (full height, centered horizontally)", async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const pic = addSlideImage(slide, pngWithSize(100, 200), { ...box, fit: 'contain' });
+    const b = getShapeBounds(pic)!;
+    expect(b.w).toBe(inches(1));
+    expect(b.h).toBe(inches(2));
+    expect(b.x).toBe(inches(1.5));
+    expect(b.y).toBe(inches(1));
+  });
+
+  it("'contain' honors a JPEG's SOF dimensions", async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const pic = addSlideImage(slide, JPEG_64X32, { ...box, fit: 'contain' });
+    const b = getShapeBounds(pic)!;
+    expect(b.w).toBe(inches(2));
+    expect(b.h).toBe(inches(1));
+  });
+
+  it("'contain' falls back to 'fill' for unmeasurable formats (GIF) without erroring", async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const pic = addSlideImage(slide, GIF_HEADER, { ...box, fit: 'contain' });
+    expect(getShapeBounds(pic)).toEqual({ x: box.x, y: box.y, w: box.w, h: box.h });
+  });
+
+  it("'contain' geometry survives save → load", async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    addSlideImage(slide, pngWithSize(200, 100), { ...box, fit: 'contain' });
+    const reloaded = await loadPresentation(await savePresentation(pres));
+    const pics = getSlides(reloaded)[0]!;
+    const { getSlideShapes } = await import('../src/api/index.ts');
+    const pic = getSlideShapes(pics).find((s) => getShapeBounds(s)?.h === inches(1));
+    expect(pic).not.toBeUndefined();
+  });
+});
+
+describe('fn API: setShapeImage fit option', () => {
+  const box = { x: inches(1), y: inches(1), w: inches(2), h: inches(2) };
+
+  it('preserves geometry by default (back-compat)', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const pic = addSlideImage(slide, PNG_1X1, box);
+    setShapeImage(pic, pngWithSize(200, 100));
+    expect(getShapeBounds(pic)).toEqual({ x: box.x, y: box.y, w: box.w, h: box.h });
+  });
+
+  it("'contain' re-fits the extent to the replacement image inside the current box", async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const pic = addSlideImage(slide, PNG_1X1, box);
+    setShapeImage(pic, pngWithSize(200, 100), { fit: 'contain' });
+    const b = getShapeBounds(pic)!;
+    expect(b.w).toBe(inches(2));
+    expect(b.h).toBe(inches(1));
+    expect(b.y).toBe(inches(1.5));
+  });
+
+  it("'contain' with an unmeasurable replacement leaves the box unchanged", async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const pic = addSlideImage(slide, PNG_1X1, box);
+    setShapeImage(pic, GIF_HEADER, { fit: 'contain' });
+    expect(getShapeBounds(pic)).toEqual({ x: box.x, y: box.y, w: box.w, h: box.h });
+  });
+});

--- a/test/fn-table-merge.test.ts
+++ b/test/fn-table-merge.test.ts
@@ -1,0 +1,160 @@
+// mergeTableCells — the write counterpart to getTableCellSpan. Merges a
+// rectangular block into the top-left anchor (gridSpan / rowSpan) and
+// marks the covered cells hMerge / vMerge per ECMA-376 §21.1.3.18.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  _internalPackageOf,
+  addSlideTable,
+  getSlides,
+  getSlideTables,
+  getTableCell,
+  getTableCellSpan,
+  inches,
+  loadPresentation,
+  mergeTableCells,
+  savePresentation,
+} from '../src/api/index.ts';
+import { partName } from '../src/internal/opc/index.ts';
+import { expectSchemaValid, isSchemaValidationAvailable } from './lib/expect-schema-valid.ts';
+
+const fixture = (name: string): string =>
+  fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
+
+const decode = (b: Uint8Array): string => new TextDecoder().decode(b);
+const skipIfNoXmllint = isSchemaValidationAvailable() ? it : it.skip;
+
+const buildTable = (slide: ReturnType<typeof getSlides>[number]) =>
+  addSlideTable(slide, {
+    rows: [
+      ['a', 'b', 'c'],
+      ['d', 'e', 'f'],
+      ['g', 'h', 'i'],
+    ],
+    x: inches(0),
+    y: inches(0),
+    w: inches(6),
+    h: inches(3),
+  });
+
+describe('fn API: mergeTableCells', () => {
+  it('merges a horizontal 1×2 block (gridSpan on anchor, hMerge on cover)', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const tbl = buildTable(slide);
+    mergeTableCells(tbl, { row: 0, col: 0, rowSpan: 1, colSpan: 2 });
+
+    const anchor = getTableCellSpan(getTableCell(tbl, 0, 0));
+    expect(anchor.gridSpan).toBe(2);
+    expect(anchor.rowSpan).toBe(1);
+    expect(anchor.hMerge).toBe(false);
+
+    const covered = getTableCellSpan(getTableCell(tbl, 0, 1));
+    expect(covered.hMerge).toBe(true);
+    expect(covered.vMerge).toBe(false);
+  });
+
+  it('merges a vertical 2×1 block (rowSpan on anchor, vMerge on cover)', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const tbl = buildTable(slide);
+    mergeTableCells(tbl, { row: 0, col: 0, rowSpan: 2, colSpan: 1 });
+
+    const anchor = getTableCellSpan(getTableCell(tbl, 0, 0));
+    expect(anchor.rowSpan).toBe(2);
+    expect(anchor.gridSpan).toBe(1);
+
+    const covered = getTableCellSpan(getTableCell(tbl, 1, 0));
+    expect(covered.vMerge).toBe(true);
+    expect(covered.hMerge).toBe(false);
+  });
+
+  it('merges a 2×2 block with both markers on the bottom-right cover', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const tbl = buildTable(slide);
+    mergeTableCells(tbl, { row: 1, col: 1, rowSpan: 2, colSpan: 2 });
+
+    const anchor = getTableCellSpan(getTableCell(tbl, 1, 1));
+    expect(anchor.gridSpan).toBe(2);
+    expect(anchor.rowSpan).toBe(2);
+
+    // top-right cover of the anchor row → hMerge only.
+    const topRight = getTableCellSpan(getTableCell(tbl, 1, 2));
+    expect(topRight.hMerge).toBe(true);
+    expect(topRight.vMerge).toBe(false);
+
+    // bottom-left cover → vMerge only.
+    const bottomLeft = getTableCellSpan(getTableCell(tbl, 2, 1));
+    expect(bottomLeft.vMerge).toBe(true);
+    expect(bottomLeft.hMerge).toBe(false);
+
+    // bottom-right cover → both.
+    const bottomRight = getTableCellSpan(getTableCell(tbl, 2, 2));
+    expect(bottomRight.hMerge).toBe(true);
+    expect(bottomRight.vMerge).toBe(true);
+  });
+
+  it('round-trips a merge through save → load', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const tbl = buildTable(slide);
+    mergeTableCells(tbl, { row: 0, col: 0, rowSpan: 2, colSpan: 2 });
+
+    const reloaded = await loadPresentation(await savePresentation(pres));
+    const reloadedTable = getSlideTables(getSlides(reloaded)[0]!)[0]!;
+    const anchor = getTableCellSpan(getTableCell(reloadedTable, 0, 0));
+    expect(anchor.gridSpan).toBe(2);
+    expect(anchor.rowSpan).toBe(2);
+    expect(getTableCellSpan(getTableCell(reloadedTable, 1, 1)).vMerge).toBe(true);
+  });
+
+  it('rejects out-of-range blocks', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const tbl = buildTable(slide);
+    expect(() => mergeTableCells(tbl, { row: 2, col: 2, rowSpan: 2, colSpan: 1 })).toThrow(
+      /exceed/,
+    );
+    expect(() => mergeTableCells(tbl, { row: 0, col: 2, rowSpan: 1, colSpan: 2 })).toThrow(
+      /exceed/,
+    );
+  });
+
+  it('rejects a 1×1 "merge" and non-positive spans', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const tbl = buildTable(slide);
+    expect(() => mergeTableCells(tbl, { row: 0, col: 0, rowSpan: 1, colSpan: 1 })).toThrow(
+      /1×1 block is not a merge/,
+    );
+    expect(() => mergeTableCells(tbl, { row: 0, col: 0, rowSpan: 0, colSpan: 2 })).toThrow(/≥ 1/);
+  });
+
+  it('rejects overlapping merges and leaves the table untouched', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const tbl = buildTable(slide);
+    mergeTableCells(tbl, { row: 0, col: 0, rowSpan: 1, colSpan: 2 });
+    // (0,1) is now hMerge — a second merge touching it must be rejected.
+    expect(() => mergeTableCells(tbl, { row: 0, col: 1, rowSpan: 2, colSpan: 1 })).toThrow(
+      /already part of a merge/,
+    );
+    // The rejected call must not have set rowSpan on (0,1).
+    expect(getTableCellSpan(getTableCell(tbl, 0, 1)).rowSpan).toBe(1);
+  });
+
+  skipIfNoXmllint('a slide with a merged table validates against pml.xsd', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const tbl = buildTable(slide);
+    mergeTableCells(tbl, { row: 1, col: 1, rowSpan: 2, colSpan: 2 });
+    const reloaded = await loadPresentation(await savePresentation(pres));
+    const pkg = _internalPackageOf(reloaded);
+    const slidePart = pkg.getPart(partName('/ppt/slides/slide1.xml'));
+    expect(slidePart).not.toBeNull();
+    expectSchemaValid(decode(slidePart!.data), 'pml');
+  });
+});


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Three feature gaps reported by a downstream integration (flyle-nexus): charts could not specify a font face for their labels (blocking Japanese-font decks), table cell merges were readable (`getTableCellSpan`) but not writable, and images were always stretched to the target box with no aspect-ratio-preserving option.

## Motivation

A consumer authoring Japanese business decks needs (1) Yu Gothic on chart titles / axis labels / legends / data labels, (2) merged header cells in tables, and (3) logo / screenshot placement that doesn't distort. All three were unreachable through the public API. Opened without an issue because the requirements came from direct integration feedback with concrete repro cases, all covered by the new tests.

## Changes

- `ChartTextStyle.font?: string` — writes `<a:latin typeface>` **and** `<a:ea typeface>` (CJK families need the east-asian slot); read back via `getSlideCharts` / `getShapeChartSpec`. Effective for every `ChartTextStyle` site: title, axis titles, axis tick labels, legend, data labels, through both `addSlideChart` and `setChartSpec`. The SVG preview keeps its fixed substitution font set (deterministic headless rasterization), so authored faces affect the emitted PPTX, not the preview raster — scoped out deliberately.
- `mergeTableCells(table, { row, col, rowSpan, colSpan })` — new export. Anchor gets `gridSpan` / `rowSpan`; covered cells get `hMerge` / `vMerge` per ECMA-376 §21.1.3.18 (bottom-right region of a 2D merge carries both). Rejects out-of-range blocks, 1×1 blocks, and overlaps with existing merges **before** mutating, so a failed call leaves the table untouched. No split/unmerge API in this PR.
- `fit?: 'fill' | 'contain'` on `addSlideImage` opts and `setShapeImage` options — `'contain'` inscribes + centers preserving aspect ratio; default `'fill'` keeps the existing stretch behavior (back-compat). Natural size read from PNG IHDR / JPEG SOF headers (new internal `readImagePixelSize`); other formats fall back to `'fill'` without erroring. On `setShapeImage`, `'contain'` re-fits the replacement inside the picture's current box.
- changeset: minor.

## Testing

- New: `test/fn-chart-font.test.ts` (5), `test/fn-table-merge.test.ts` (8), `test/fn-image-fit.test.ts` (12) — round-trips through save → load, failure cases, and xmllint XSD validation (`dml-chart.xsd` for the chart part, `pml.xsd` for the merged-table slide).
- Full suite: `pnpm test` → 296 files passed / 2 skipped, 1142 tests passed / 24 skipped.
- `pnpm format:check && pnpm lint && pnpm typecheck && pnpm build` all green.
- Size gate (`test/tree-shake.test.ts`): minimal load+save bundle 57,331 bytes (< 75,000), full fn-API bundle 122,341 bytes (< 250,000).

## Breaking changes

None — all three additions are opt-in; defaults preserve existing behavior.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, the PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)