### PR TITLE
feat: resolve scheme colors through the slide color map

### DIFF
--- a/.changeset/clrmap-aware-color-resolution.md
+++ b/.changeset/clrmap-aware-color-resolution.md
@@ -1,0 +1,13 @@
+---
+'pptx-kit': minor
+'pptx-kit-preview': minor
+---
+
+Resolve scheme colors through the slide's color map so inverted-map templates render correctly
+
+Templates whose slide master inverts the color map (`<p:clrMap bg1="dk1" tx1="lt1">`, common in Google Slides / Canva exports) previously rendered with swapped light/dark colors: slide backgrounds came out black in the preview while PowerPoint paints them white, and generated tables and charts came out with invisible text (the default `tx1` token resolved to the same color as the background).
+
+- **`getEffectiveColorMap(slide)`** — new export returning the slide's effective color map (the master's `<p:clrMap>` overlaid by a per-slide `<p:clrMapOvr>`). Color resolution and renderers apply it to `schemeClr` tokens before indexing the theme.
+- **`resolveDrawingColor(colorEl, theme, clrMap?)`** — accepts an optional color map; scheme tokens are remapped through it before the theme lookup. Omitting it preserves the previous behavior (correct for the standard map).
+- **`addSlideTable` / `addSlideChart`** now bake the deck's resolved body-text color onto table cells and chart text (axis labels, legend, data labels) so generated tables and charts stay readable regardless of the template's color map. Authored colors still win; override table cells afterwards with `setTableCellTextFormat`.
+- **`pptx-kit-preview`** resolves `schemeClr` tokens through the effective color map, so previews of inverted-map decks match what PowerPoint paints.

--- a/packages/preview/src/render-slide.ts
+++ b/packages/preview/src/render-slide.ts
@@ -30,6 +30,7 @@ import {
   getParagraphIndent,
   getParagraphLevel,
   getParagraphPropertiesEffective,
+  getEffectiveColorMap,
   getParagraphSpacing,
   getPresentationFonts,
   getPresentationTheme,
@@ -484,7 +485,10 @@ const resolveColor = (
   else if (SCHEME_TO_THEME[c]) token = c;
   if (token !== null) {
     if (theme) {
-      const key = SCHEME_TO_THEME[token];
+      // Remap the slide token through the effective color map first, then index
+      // the theme — so an inverted map (tx1→lt1) paints what PowerPoint paints.
+      const mapped = activeColorMap?.[token] ?? token;
+      const key = SCHEME_TO_THEME[mapped] ?? SCHEME_TO_THEME[token];
       if (key) return normalizeHex(theme[key]);
     }
     if (token === 'tx1' || token === 'dk1') return '#000000';
@@ -505,6 +509,15 @@ const resolveColor = (
 // document. Plain monotonic counter is fine.
 let nextDefId = 0;
 const mintId = (): string => `pkdef-${(nextDefId++).toString(36)}`;
+
+// Effective color map (`<p:clrMap>` overlaid by `<p:clrMapOvr>`) for the slide
+// currently rendering. PowerPoint remaps the slide tokens (`tx1`, `bg1`, …) to
+// theme slots through this map before the theme lookup; an inverted map
+// (`bg1="dk1" tx1="lt1"`) is common in Google-Slides / Canva exports and makes
+// `tx1` resolve to the light slot. `renderSlideSvg` sets this at the start of
+// each (synchronous, single-slide) render and `resolveColor` reads it. Like
+// `nextDefId` above, every entry overwrites it, so it needs no reset.
+let activeColorMap: Readonly<Record<string, string>> | null = null;
 
 // `<linearGradient>` definition + `fill="url(#…)"` reference, projected
 // from pptx-kit's `{ stops, angleDeg }` shape onto SVG's
@@ -5798,6 +5811,7 @@ export const renderSlideSvg = (
   const W = size.width as number;
   const H = size.height as number;
   const theme = getPresentationTheme(pres);
+  activeColorMap = getEffectiveColorMap(slide);
   const ctx: LayoutCtx = {
     mode: opts.textLayout ?? 'foreignObject',
     measure: opts.measureText ?? defaultMeasurer,

--- a/src/api/fn.ts
+++ b/src/api/fn.ts
@@ -40,6 +40,7 @@ export * from './fn/shape-animation.ts';
 
 // Slide features
 export * from './fn/slide-background.ts';
+export * from './fn/color-map.ts';
 export * from './fn/slide-transition.ts';
 export * from './fn/slide-notes.ts';
 export * from './fn/slide-size.ts';

--- a/src/api/fn/charts.ts
+++ b/src/api/fn/charts.ts
@@ -15,6 +15,7 @@ import {
   type ChartKind,
   type ChartSeries,
   type ChartSpec,
+  type ChartTextStyle,
   buildChartSpaceDoc,
   buildEmbeddedXlsx,
   readChartSpec,
@@ -43,6 +44,7 @@ import {
   type SlideShapeData,
 } from '../_internal-symbols.ts';
 import { appendAndReturnNewShape, decode, encode, nextShapeId, setOpcDefault } from './_helpers.ts';
+import { resolveDeckBodyTextColor } from './color-map.ts';
 import { getSlides } from './slide-query.ts';
 // ---------------------------------------------------------------------------
 // Charts.
@@ -185,6 +187,29 @@ const validateChartSpecColors = (spec: ChartSpec): void => {
  *   - All series should have at most `categories.length` values; missing
  *     values are treated as blanks (gaps in the visualization).
  */
+// A chart inherits no master text style, so any label without an authored
+// color falls back to the `tx1` token — which a deck with an inverted color
+// map paints the same as the surface, hiding axis labels, the legend, and data
+// labels. Bake the deck's resolved body-text color onto every text style the
+// caller left unset (authored colors always win).
+const withChartDefaultTextColor = (spec: ChartSpec, color: string | null): ChartSpec => {
+  if (color === null) return spec;
+  const withColor = (style: ChartTextStyle | undefined): ChartTextStyle =>
+    style === undefined ? { color } : style.color === undefined ? { ...style, color } : style;
+  return {
+    ...spec,
+    categoryAxisLabelStyle: withColor(spec.categoryAxisLabelStyle),
+    valueAxisLabelStyle: withColor(spec.valueAxisLabelStyle),
+    ...(spec.title !== undefined ? { titleStyle: withColor(spec.titleStyle) } : {}),
+    ...(spec.legend !== undefined
+      ? { legend: { ...spec.legend, textStyle: withColor(spec.legend.textStyle) } }
+      : {}),
+    ...(spec.dataLabels !== undefined
+      ? { dataLabels: { ...spec.dataLabels, textStyle: withColor(spec.dataLabels.textStyle) } }
+      : {}),
+  };
+};
+
 export const addSlideChart = (
   slide: SlideData,
   opts: {
@@ -197,6 +222,7 @@ export const addSlideChart = (
   },
 ): SlideShapeData => {
   validateChartSpecColors(opts.spec);
+  const spec = withChartDefaultTextColor(opts.spec, resolveDeckBodyTextColor(slide));
   const pkg = slide[INTERNAL_PACKAGE];
   const chartN = allocateChartIndex(pkg);
   const chartPartName = partName(`/ppt/charts/chart${chartN}.xml`);
@@ -204,17 +230,17 @@ export const addSlideChart = (
 
   // Build the embedded xlsx bytes. Each row in the sheet corresponds to
   // one category; header row carries the series names.
-  const xlsxRows = opts.spec.categories.map((label, i) => ({
+  const xlsxRows = spec.categories.map((label, i) => ({
     label,
-    values: opts.spec.series.map((s) => s.values[i] ?? null),
+    values: spec.series.map((s) => s.values[i] ?? null),
   }));
   const xlsxBytes = buildEmbeddedXlsx(
-    opts.spec.series.map((s) => s.name),
+    spec.series.map((s) => s.name),
     xlsxRows,
   );
 
   // Build the chart XML and serialize.
-  const chartDoc = buildChartSpaceDoc(opts.spec);
+  const chartDoc = buildChartSpaceDoc(spec);
   const chartBytes = encode(serializeXml(chartDoc));
 
   // Add the chart part + its rel → embedded xlsx.

--- a/src/api/fn/color-map.ts
+++ b/src/api/fn/color-map.ts
@@ -1,0 +1,143 @@
+// Effective color-map resolution.
+//
+// PowerPoint resolves every `schemeClr` token (`tx1`, `bg1`, `accent1`, …)
+// through the slide's effective color map before indexing the theme. The map
+// comes from the slide master's `<p:clrMap>`, optionally overridden per-slide
+// by `<p:clrMapOvr><a:overrideClrMapping>`. Most decks use the standard map
+// (`bg1="lt1" tx1="dk1"`), but exports from Google Slides / Canva frequently
+// INVERT it (`bg1="dk1" tx1="lt1"`). Resolving colors without the map then
+// paints text and backgrounds with swapped light/dark colors — the bug this
+// module exists to prevent.
+
+import { partName, resolveTarget } from '../../internal/opc/index.ts';
+import { REL_TYPES } from '../../internal/presentationml/index.ts';
+import {
+  NS,
+  type XmlElement,
+  firstChildElement,
+  parseXml,
+  qname,
+} from '../../internal/xml/index.ts';
+import { INTERNAL_PACKAGE, SLIDE_PART_NAME, type SlideData } from '../_internal-symbols.ts';
+import { decode } from './_helpers.ts';
+import { resolveDrawingColor, resolveSchemeToken } from './shape-color.ts';
+import { getSlideColorMapOverride } from './slide-background.ts';
+import { themeFromPackage } from './theme.ts';
+
+// The standard `<p:clrMap>` — the fallback for the rare deck that omits the
+// element entirely. `bg1`/`tx1`/`bg2`/`tx2` point at the matching theme slots;
+// accents and hyperlinks are identity.
+const STANDARD_COLOR_MAP: Readonly<Record<string, string>> = {
+  bg1: 'lt1',
+  tx1: 'dk1',
+  bg2: 'lt2',
+  tx2: 'dk2',
+  accent1: 'accent1',
+  accent2: 'accent2',
+  accent3: 'accent3',
+  accent4: 'accent4',
+  accent5: 'accent5',
+  accent6: 'accent6',
+  hlink: 'hlink',
+  folHlink: 'folHlink',
+};
+
+const NAME_CLR_MAP = qname('p', 'clrMap', NS.pml);
+const NAME_TX_STYLES = qname('p', 'txStyles', NS.pml);
+const NAME_BODY_STYLE = qname('p', 'bodyStyle', NS.pml);
+const NAME_LVL1_PPR = qname('a', 'lvl1pPr', NS.dml);
+const NAME_DEF_RPR = qname('a', 'defRPr', NS.dml);
+const NAME_SOLID_FILL = qname('a', 'solidFill', NS.dml);
+
+// Walk slide → layout → master, returning the master part's root element.
+// Mirrors the rel-walking pattern in `getSlideLayout` / `getSlideMasterBackground`;
+// kept self-contained here so this module doesn't depend on those readers.
+const getSlideMasterRoot = (slide: SlideData): XmlElement | null => {
+  const pkg = slide[INTERNAL_PACKAGE];
+  const slideRels = pkg.getRels(slide[SLIDE_PART_NAME]);
+  if (slideRels === null) return null;
+  const layoutRel = slideRels.items.find((r) => r.type === REL_TYPES.slideLayout);
+  if (!layoutRel) return null;
+  const layoutPartName = layoutRel.target.startsWith('/')
+    ? partName(layoutRel.target)
+    : resolveTarget(slide[SLIDE_PART_NAME], layoutRel.target);
+  const layoutRels = pkg.getRels(layoutPartName);
+  if (layoutRels === null) return null;
+  const masterRel = layoutRels.items.find((r) => r.type === REL_TYPES.slideMaster);
+  if (!masterRel) return null;
+  const masterPartName = masterRel.target.startsWith('/')
+    ? partName(masterRel.target)
+    : resolveTarget(layoutPartName, masterRel.target);
+  const masterPart = pkg.getPart(masterPartName);
+  if (masterPart === null) return null;
+  return parseXml(decode(masterPart.data)).root;
+};
+
+const readClrMapElement = (root: XmlElement): Record<string, string> | null => {
+  const clrMap = firstChildElement(root, NAME_CLR_MAP);
+  if (!clrMap) return null;
+  const out: Record<string, string> = {};
+  for (const a of clrMap.attrs) {
+    if (a.name.namespaceURI !== '') continue;
+    out[a.name.localName] = a.value;
+  }
+  return Object.keys(out).length > 0 ? out : null;
+};
+
+/**
+ * The slide's effective color map: the master's `<p:clrMap>`, overlaid by a
+ * per-slide `<p:clrMapOvr><a:overrideClrMapping>` when present. Falls back to
+ * the standard map for decks that omit it.
+ *
+ * Pass the result to color resolution / renderers so `schemeClr` tokens map to
+ * the theme slot PowerPoint actually paints — critical for decks with an
+ * inverted map (`bg1="dk1" tx1="lt1"`).
+ */
+export const getEffectiveColorMap = (slide: SlideData): Record<string, string> => {
+  const override = getSlideColorMapOverride(slide);
+  if (override) return { ...STANDARD_COLOR_MAP, ...override };
+  const masterRoot = getSlideMasterRoot(slide);
+  const masterMap = masterRoot ? readClrMapElement(masterRoot) : null;
+  return masterMap ? { ...STANDARD_COLOR_MAP, ...masterMap } : { ...STANDARD_COLOR_MAP };
+};
+
+// First DrawingML color child of a `<a:solidFill>` element.
+const firstColorChild = (solidFill: XmlElement): XmlElement | null => {
+  for (const c of solidFill.children) {
+    if (c.kind === 'element' && c.name.namespaceURI === NS.dml) return c;
+  }
+  return null;
+};
+
+/**
+ * The concrete `#RRGGBB` color the deck paints body text in, resolved through
+ * the effective color map + theme. Read from the master's `bodyStyle` level-1
+ * default run properties; falls back to the `tx1` token resolved through the
+ * map. Returns `null` only when the deck carries no theme.
+ *
+ * Tables and charts authored by this library inherit no master text style, so
+ * their text otherwise falls back to `tx1` — which an inverted color map paints
+ * the SAME as the background, making the text invisible. Baking the body color
+ * in keeps generated tables / charts readable on whatever surface the deck uses.
+ */
+export const resolveDeckBodyTextColor = (slide: SlideData): string | null => {
+  const theme = themeFromPackage(slide[INTERNAL_PACKAGE]);
+  if (!theme) return null;
+  const clrMap = getEffectiveColorMap(slide);
+  const masterRoot = getSlideMasterRoot(slide);
+  if (masterRoot) {
+    const txStyles = firstChildElement(masterRoot, NAME_TX_STYLES);
+    const bodyStyle = txStyles ? firstChildElement(txStyles, NAME_BODY_STYLE) : null;
+    const lvl1 = bodyStyle ? firstChildElement(bodyStyle, NAME_LVL1_PPR) : null;
+    const defRPr = lvl1 ? firstChildElement(lvl1, NAME_DEF_RPR) : null;
+    const solidFill = defRPr ? firstChildElement(defRPr, NAME_SOLID_FILL) : null;
+    const colorEl = solidFill ? firstColorChild(solidFill) : null;
+    if (colorEl) {
+      const hex = resolveDrawingColor(colorEl, theme, clrMap);
+      if (hex) return hex;
+    }
+  }
+  // No explicit body color in the master: resolve the conventional text token
+  // through the (possibly inverted) map.
+  return resolveSchemeToken('tx1', theme, clrMap);
+};

--- a/src/api/fn/shape-authoring.ts
+++ b/src/api/fn/shape-authoring.ts
@@ -28,6 +28,7 @@ import {
   type SlideShapeData,
 } from '../_internal-symbols.ts';
 import { appendAndReturnNewShape, nextShapeId } from './_helpers.ts';
+import { resolveDeckBodyTextColor } from './color-map.ts';
 // ---------------------------------------------------------------------------
 // Slide-level shape authoring.
 //
@@ -112,9 +113,15 @@ export const addSlideLine = (
 };
 
 /**
- * Adds a table to the slide. Cells render as plain text with default
- * theme-aware styling; `firstRow` / `bandRow` flags drive PowerPoint's
- * banded-header look unless options say otherwise.
+ * Adds a table to the slide. Cells render as plain text; `firstRow` /
+ * `bandRow` flags drive PowerPoint's banded-header look unless options say
+ * otherwise.
+ *
+ * Cell text color is baked from the deck's resolved body-text color so the
+ * table stays readable even on templates with an inverted color map
+ * (`bg1="dk1" tx1="lt1"`), where the default `tx1` text token would otherwise
+ * paint the text the same as the background. Override per cell afterwards with
+ * `setTableCellTextFormat`.
  */
 export const addSlideTable = (
   slide: SlideData,
@@ -131,6 +138,7 @@ export const addSlideTable = (
     name?: string;
   },
 ): SlideShapeData => {
+  const textColorHex = resolveDeckBodyTextColor(slide);
   const frame = buildTable({
     id: nextShapeId(slide),
     ...(opts.name !== undefined ? { name: opts.name } : {}),
@@ -143,6 +151,7 @@ export const addSlideTable = (
     ...(opts.rowHeights !== undefined ? { rowHeights: opts.rowHeights } : {}),
     ...(opts.firstRow !== undefined ? { firstRow: opts.firstRow } : {}),
     ...(opts.bandRow !== undefined ? { bandRow: opts.bandRow } : {}),
+    ...(textColorHex !== null ? { textColorHex } : {}),
   });
   return appendAndReturnNewShape(slide, frame);
 };

--- a/src/api/fn/shape-color.ts
+++ b/src/api/fn/shape-color.ts
@@ -205,9 +205,25 @@ const SCHEME_TOKEN_TO_THEME_KEY: Record<string, keyof Omit<PresentationTheme, 'n
   folHlink: 'followedHyperlink',
 };
 
-const resolveSchemeToken = (token: string, theme: PresentationTheme | null): string | null => {
+/**
+ * Resolves a scheme token (`tx1`, `bg1`, `accent1`, …) to its `#RRGGBB`.
+ *
+ * When `clrMap` is supplied, the slide token is first remapped through it
+ * (`<p:clrMap>` / `<a:overrideClrMapping>`) — `tx1` may point at `dk1` or
+ * `lt1` depending on the deck — and only then indexed into the theme. Without
+ * a map the token is indexed directly, preserving the historical behavior
+ * (correct for the standard map, the overwhelming common case).
+ *
+ * @internal
+ */
+export const resolveSchemeToken = (
+  token: string,
+  theme: PresentationTheme | null,
+  clrMap?: Readonly<Record<string, string>> | null,
+): string | null => {
   if (!theme) return null;
-  const key = SCHEME_TOKEN_TO_THEME_KEY[token];
+  const mapped = clrMap?.[token] ?? token;
+  const key = SCHEME_TOKEN_TO_THEME_KEY[mapped] ?? SCHEME_TOKEN_TO_THEME_KEY[token];
   if (!key) return null;
   const hex = theme[key];
   if (typeof hex !== 'string') return null;
@@ -229,6 +245,7 @@ const resolveSchemeToken = (token: string, theme: PresentationTheme | null): str
 export const resolveDrawingColor = (
   colorEl: XmlElement,
   theme: PresentationTheme | null,
+  clrMap?: Readonly<Record<string, string>> | null,
 ): string | null => {
   if (colorEl.name.namespaceURI !== NS.dml) return null;
   const local = colorEl.name.localName;
@@ -238,7 +255,7 @@ export const resolveDrawingColor = (
     if (v) baseHex = `#${v.toUpperCase()}`;
   } else if (local === 'schemeClr') {
     const v = getAttrValue(colorEl, qname('', 'val', ''));
-    if (v) baseHex = resolveSchemeToken(v, theme);
+    if (v) baseHex = resolveSchemeToken(v, theme, clrMap);
   } else if (local === 'sysClr') {
     const last = getAttrValue(colorEl, qname('', 'lastClr', ''));
     if (last) baseHex = `#${last.toUpperCase()}`;

--- a/src/api/fn/theme.ts
+++ b/src/api/fn/theme.ts
@@ -8,6 +8,7 @@ import {
   parseXml,
   qname,
 } from '../../internal/xml/index.ts';
+import type { OpcPackage } from '../../internal/parts/index.ts';
 import { INTERNAL_PACKAGE, type PresentationData } from '../_internal-symbols.ts';
 import { decode } from './_helpers.ts';
 
@@ -67,8 +68,17 @@ const readSchemeSlot = (parent: XmlElement, local: string): string => {
  * first one found (alphabetical by part name). Per-master theme
  * lookup will land if a concrete user need shows up.
  */
-export const getPresentationTheme = (pres: PresentationData): PresentationTheme | null => {
-  const pkg = pres[INTERNAL_PACKAGE];
+export const getPresentationTheme = (pres: PresentationData): PresentationTheme | null =>
+  themeFromPackage(pres[INTERNAL_PACKAGE]);
+
+/**
+ * Package-level theme reader behind {@link getPresentationTheme}. Exposed so
+ * helpers holding only a package handle (e.g. color baking off a `SlideData`)
+ * can read the theme without a `PresentationData`.
+ *
+ * @internal
+ */
+export const themeFromPackage = (pkg: OpcPackage): PresentationTheme | null => {
   const themePart = pkg.parts
     .filter((p) => p.contentType === THEME_CONTENT_TYPE)
     .sort((a, b) => a.name.localeCompare(b.name))[0];

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -191,6 +191,7 @@ export {
   getCommentsSortedByDate,
   getCoreProperties,
   getDistinctHyperlinkUrls,
+  getEffectiveColorMap,
   getEmptySlides,
   getGroupChildren,
   getGroupTransform,

--- a/src/internal/presentationml/table-builder.ts
+++ b/src/internal/presentationml/table-builder.ts
@@ -37,7 +37,10 @@ const NAME_LST_STYLE = qname('a', 'lstStyle', NS.dml);
 const NAME_P = qname('a', 'p', NS.dml);
 const NAME_R = qname('a', 'r', NS.dml);
 const NAME_RPR = qname('a', 'rPr', NS.dml);
+const NAME_SOLID_FILL = qname('a', 'solidFill', NS.dml);
+const NAME_SRGB_CLR = qname('a', 'srgbClr', NS.dml);
 const NAME_T = qname('a', 't', NS.dml);
+const ATTR_VAL = qname('', 'val', '');
 const ATTR_ID = qname('', 'id', '');
 const ATTR_NAME = qname('', 'name', '');
 const ATTR_NO_GRP = qname('', 'noGrp', '');
@@ -70,9 +73,28 @@ export interface TableOptions {
   firstRow?: boolean;
   /** Emit `bandRow="1"` so alternating rows get banded shading. Default true. */
   bandRow?: boolean;
+  /**
+   * `#RRGGBB` baked onto every cell's run as an explicit `<a:solidFill>`.
+   * Without it, cells fall back to the `tx1` token, which a deck with an
+   * inverted color map paints the same as the background (invisible text).
+   * The caller resolves the deck's body-text color and passes it here.
+   */
+  textColorHex?: string;
 }
 
-const buildTextCellBody = (value: string): XmlElement => {
+// `<a:rPr>` with the run's language and, when a color is baked in, an explicit
+// solid fill so the cell text doesn't fall through to the theme's `tx1` token.
+const buildCellRunProps = (textColorHex: string | undefined): XmlElement => {
+  const langAttr = attr(ATTR_LANG, 'en-US');
+  if (textColorHex === undefined) return elem(NAME_RPR, { attrs: [langAttr] });
+  const hex = textColorHex.startsWith('#') ? textColorHex.slice(1) : textColorHex;
+  const solidFill = elem(NAME_SOLID_FILL, {
+    children: [elem(NAME_SRGB_CLR, { attrs: [attr(ATTR_VAL, hex.toUpperCase())] })],
+  });
+  return elem(NAME_RPR, { attrs: [langAttr], children: [solidFill] });
+};
+
+const buildTextCellBody = (value: string, textColorHex: string | undefined): XmlElement => {
   const needsPreserve =
     value.length > 0 && (value.startsWith(' ') || value.endsWith(' ') || /[\t\n]/.test(value));
   const t = elem(NAME_T, {
@@ -80,22 +102,26 @@ const buildTextCellBody = (value: string): XmlElement => {
     children: value.length > 0 ? [textNode(value)] : [],
   });
   const r = elem(NAME_R, {
-    children: [elem(NAME_RPR, { attrs: [attr(ATTR_LANG, 'en-US')] }), t],
+    children: [buildCellRunProps(textColorHex), t],
   });
   const p = elem(NAME_P, { children: [r] });
   return elem(NAME_TX_BODY, { children: [elem(NAME_BODY_PR), elem(NAME_LST_STYLE), p] });
 };
 
 /** @internal — used by row-mutation paths in the public API. */
-export const buildTableCell = (value: string): XmlElement => {
-  return elem(NAME_TC, { children: [buildTextCellBody(value), elem(NAME_TC_PR)] });
+export const buildTableCell = (value: string, textColorHex?: string): XmlElement => {
+  return elem(NAME_TC, { children: [buildTextCellBody(value, textColorHex), elem(NAME_TC_PR)] });
 };
 
 /** @internal — used by row-mutation paths in the public API. */
-export const buildTableRow = (cells: ReadonlyArray<string>, h: number): XmlElement =>
+export const buildTableRow = (
+  cells: ReadonlyArray<string>,
+  h: number,
+  textColorHex?: string,
+): XmlElement =>
   elem(NAME_TR, {
     attrs: [attr(ATTR_H, String(Math.round(h)))],
-    children: cells.map(buildTableCell),
+    children: cells.map((value) => buildTableCell(value, textColorHex)),
   });
 
 const equalShares = (total: number, n: number): number[] => {
@@ -175,7 +201,7 @@ export const buildTable = (opts: TableOptions): XmlElement => {
       elem(NAME_GRID_COL, { attrs: [attr(ATTR_W, String(Math.round(w)))] }),
     ),
   });
-  const tableRows = rows.map((row, i) => buildTableRow(row, rowHeights[i] ?? 0));
+  const tableRows = rows.map((row, i) => buildTableRow(row, rowHeights[i] ?? 0, opts.textColorHex));
   const tbl = elem(NAME_TBL, { children: [tblPr, tblGrid, ...tableRows] });
 
   const graphicData = elem(NAME_GRAPHIC_DATA, {

--- a/test/fn-clrmap-color-resolution.test.ts
+++ b/test/fn-clrmap-color-resolution.test.ts
@@ -1,0 +1,400 @@
+// Tests for clrMap-aware color resolution and the baking of body-text color
+// onto authored tables and charts.
+//
+// Covered behaviors (added in fix/clrmap-aware-color-resolution):
+//
+//   a. resolveDrawingColor + clrMap parameter — schemeClr tokens are remapped
+//      through the clrMap before the theme lookup.
+//   b. getEffectiveColorMap — returns the standard map for a createPresentation
+//      deck (master clrMap bg1="lt1" tx1="dk1").
+//   c. addSlideTable bakes color — cell runs carry the resolved body-text color
+//      as an explicit <a:solidFill> when the deck has a theme.
+//   d. addSlideChart bakes color — catAx / valAx (and legend / dLbls when
+//      present) carry the resolved body-text color when no authored color is set.
+//   e. Inverted clrMap end-to-end — rewriting the master's <p:clrMap> to an
+//      inverted form makes getEffectiveColorMap report the swap, and the baked
+//      table / chart colors follow (tx1 → lt1 → FFFFFF on the standard theme).
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  _internalPackageOf,
+  addSlide,
+  addSlideChart,
+  addSlideTable,
+  createPresentation,
+  findSlideLayout,
+  getEffectiveColorMap,
+  getSlides,
+  getSlideXmlString,
+  getTableCell,
+  inches,
+  loadPresentation,
+  resolveDrawingColor,
+  savePresentation,
+  setTableCellTextFormat,
+} from '../src/api/index.ts';
+import { parseXml } from '../src/internal/xml/index.ts';
+import { renderSlideToSvg } from '../packages/preview/src/index.ts';
+
+const blankFixture = (): string =>
+  fileURLToPath(new URL('./fixtures/minimal/blank.pptx', import.meta.url));
+
+const decode = (b: Uint8Array): string => new TextDecoder().decode(b);
+const encode = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+// ---------------------------------------------------------------------------
+// a. resolveDrawingColor + clrMap
+// ---------------------------------------------------------------------------
+
+describe('fn API: resolveDrawingColor with clrMap param', () => {
+  const theme = {
+    name: 'Test',
+    dark1: '#000000',
+    light1: '#FFFFFF',
+    dark2: '#222222',
+    light2: '#EEEEEE',
+    accent1: '#4472C4',
+    accent2: '#ED7D31',
+    accent3: '#A9D18E',
+    accent4: '#8064A2',
+    accent5: '#4BACC6',
+    accent6: '#F79646',
+    hyperlink: '#0000FF',
+    followedHyperlink: '#800080',
+  };
+
+  it('WITHOUT clrMap, schemeClr tx1 resolves to dark1', () => {
+    const el = parseXml(
+      `<a:schemeClr xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" val="tx1"/>`,
+    ).root;
+    // tx1 directly maps to dark1 in SCHEME_TOKEN_TO_THEME_KEY
+    expect(resolveDrawingColor(el, theme)).toBe('#000000');
+  });
+
+  it('WITH clrMap {tx1:"lt1"}, schemeClr tx1 resolves to light1', () => {
+    const el = parseXml(
+      `<a:schemeClr xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" val="tx1"/>`,
+    ).root;
+    // clrMap remaps tx1 → lt1 before the theme lookup
+    expect(resolveDrawingColor(el, theme, { tx1: 'lt1' })).toBe('#FFFFFF');
+  });
+
+  it('WITH clrMap {tx1:"dk1"}, schemeClr tx1 still resolves to dark1', () => {
+    const el = parseXml(
+      `<a:schemeClr xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" val="tx1"/>`,
+    ).root;
+    // Standard map: tx1 → dk1 → dark1
+    expect(resolveDrawingColor(el, theme, { tx1: 'dk1' })).toBe('#000000');
+  });
+
+  it('clrMap null behaves like no clrMap', () => {
+    const el = parseXml(
+      `<a:schemeClr xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" val="tx1"/>`,
+    ).root;
+    expect(resolveDrawingColor(el, theme, null)).toBe('#000000');
+  });
+
+  it('non-scheme token (srgbClr) is unaffected by clrMap', () => {
+    const el = parseXml(
+      `<a:srgbClr xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" val="FF0000"/>`,
+    ).root;
+    expect(resolveDrawingColor(el, theme, { tx1: 'lt1' })).toBe('#FF0000');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// b. getEffectiveColorMap on a createPresentation deck
+// ---------------------------------------------------------------------------
+
+describe('fn API: getEffectiveColorMap', () => {
+  it('returns the standard map for a createPresentation deck', async () => {
+    const pres = createPresentation();
+    // createPresentation() creates the blank scaffold with layouts but no slides.
+    // We must add a slide to get a SlideData with a valid master chain.
+    const layout = findSlideLayout(pres, 'Blank');
+    if (!layout) throw new Error('expected Blank layout');
+    const slide = addSlide(pres, { layout });
+    const clrMap = getEffectiveColorMap(slide);
+    // Standard map: bg1→lt1, tx1→dk1
+    expect(clrMap['tx1']).toBe('dk1');
+    expect(clrMap['bg1']).toBe('lt1');
+    expect(clrMap['tx2']).toBe('dk2');
+    expect(clrMap['bg2']).toBe('lt2');
+    // Accents are identity in the standard map
+    expect(clrMap['accent1']).toBe('accent1');
+    expect(clrMap['accent2']).toBe('accent2');
+  });
+
+  it('returns standard map for a slide added to blank.pptx', async () => {
+    const pres = await loadPresentation(await readFile(blankFixture()));
+    const layout = findSlideLayout(pres, 'Blank');
+    if (!layout) throw new Error('expected Blank layout');
+    const slide = addSlide(pres, { layout });
+    const clrMap = getEffectiveColorMap(slide);
+    expect(clrMap['tx1']).toBe('dk1');
+    expect(clrMap['bg1']).toBe('lt1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// c. addSlideTable bakes body-text color onto cell runs
+// ---------------------------------------------------------------------------
+
+describe('fn API: addSlideTable — baked color', () => {
+  it('bakes 000000 onto each cell run in a createPresentation deck', async () => {
+    const pres = createPresentation();
+    const layout = findSlideLayout(pres, 'Blank');
+    if (!layout) throw new Error('expected Blank layout');
+    const slide = addSlide(pres, { layout });
+    addSlideTable(slide, {
+      x: inches(1),
+      y: inches(1),
+      w: inches(6),
+      h: inches(2),
+      rows: [
+        ['Header A', 'Header B'],
+        ['Value 1', 'Value 2'],
+      ],
+    });
+    const xml = getSlideXmlString(getSlides(pres).at(-1)!);
+    // Every run should have the baked solidFill with srgbClr val="000000"
+    expect(xml).toContain('<a:solidFill><a:srgbClr val="000000"/></a:solidFill>');
+    // The rPr elements must contain the fill (not just the bare <a:rPr lang="en-US"/>)
+    expect(xml).toContain('lang="en-US"');
+    // There should be no cell run without the color baked in
+    // (rPr immediately followed by a closing tag would be the bare form)
+    expect(xml).not.toMatch(/<a:rPr lang="en-US"\/>/);
+  });
+
+  it('setTableCellTextFormat can override the baked color', async () => {
+    const pres = createPresentation();
+    const layout = findSlideLayout(pres, 'Blank');
+    if (!layout) throw new Error('expected Blank layout');
+    const slide = addSlide(pres, { layout });
+    const tbl = addSlideTable(slide, {
+      x: inches(1),
+      y: inches(1),
+      w: inches(4),
+      h: inches(2),
+      rows: [['Cell A', 'Cell B']],
+    });
+    // Override the first cell's color to red
+    const cell = getTableCell(tbl, 0, 0);
+    setTableCellTextFormat(cell, { color: '#FF0000' });
+    const reloaded = await loadPresentation(await savePresentation(pres));
+    const xml = getSlideXmlString(getSlides(reloaded).at(-1)!);
+    // The override should be present
+    expect(xml).toContain('FF0000');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// d. addSlideChart bakes body-text color onto axis labels / legend / dLbls
+// ---------------------------------------------------------------------------
+
+describe('fn API: addSlideChart — baked color', () => {
+  it('bakes 000000 on catAx and valAx txPr in a createPresentation deck', async () => {
+    const pres = createPresentation();
+    const layout = findSlideLayout(pres, 'Blank');
+    if (!layout) throw new Error('expected Blank layout');
+    const slide = addSlide(pres, { layout });
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'column',
+        categories: ['Q1', 'Q2', 'Q3'],
+        series: [{ name: 'Revenue', values: [10, 20, 30] }],
+      },
+    });
+    const bytes = await savePresentation(pres);
+    const pkg = _internalPackageOf(await loadPresentation(bytes));
+    const chartPart = pkg.parts.find((p) => p.name === '/ppt/charts/chart1.xml');
+    expect(chartPart).toBeDefined();
+    const chartXml = decode(chartPart!.data);
+    // Both catAx and valAx must have a txPr with the baked color
+    expect(chartXml).toContain('<c:catAx>');
+    expect(chartXml).toContain('<c:valAx>');
+    // The baked color should appear in the chart XML
+    expect(chartXml).toContain('val="000000"');
+    // Specifically in a defRPr inside a txPr
+    expect(chartXml).toContain('<a:defRPr>');
+    expect(chartXml).toContain('<a:solidFill>');
+    expect(chartXml).toContain('<a:srgbClr val="000000"/>');
+  });
+
+  it('bakes 000000 on legend and dLbls when present', async () => {
+    const pres = createPresentation();
+    const layout = findSlideLayout(pres, 'Blank');
+    if (!layout) throw new Error('expected Blank layout');
+    const slide = addSlide(pres, { layout });
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'column',
+        categories: ['A', 'B'],
+        series: [{ name: 'X', values: [1, 2] }],
+        legend: { position: 'b' },
+        dataLabels: {
+          showValue: true,
+          showCategory: false,
+          showSeriesName: false,
+          showPercent: false,
+        },
+      },
+    });
+    const bytes = await savePresentation(pres);
+    const pkg = _internalPackageOf(await loadPresentation(bytes));
+    const chartXml = decode(pkg.parts.find((p) => p.name === '/ppt/charts/chart1.xml')!.data);
+    // Legend txPr and dLbls txPr should both contain the baked color
+    expect(chartXml).toContain('<c:legend>');
+    expect(chartXml).toContain('<c:dLbls>');
+    // The baked color should appear multiple times (once per axis, once for legend, once for dLbls)
+    const occurrences = (chartXml.match(/srgbClr val="000000"/g) ?? []).length;
+    expect(occurrences).toBeGreaterThanOrEqual(3);
+  });
+
+  it('authored axis color is preserved over the baked default', async () => {
+    const pres = createPresentation();
+    const layout = findSlideLayout(pres, 'Blank');
+    if (!layout) throw new Error('expected Blank layout');
+    const slide = addSlide(pres, { layout });
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'column',
+        categories: ['A', 'B'],
+        series: [{ name: 'X', values: [1, 2] }],
+        categoryAxisLabelStyle: { color: '#FF0000' },
+      },
+    });
+    const bytes = await savePresentation(pres);
+    const pkg = _internalPackageOf(await loadPresentation(bytes));
+    const chartXml = decode(pkg.parts.find((p) => p.name === '/ppt/charts/chart1.xml')!.data);
+    // The authored color should be present
+    expect(chartXml).toContain('FF0000');
+    // The baked default (000000) should still appear for valAx
+    expect(chartXml).toContain('000000');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// e. Inverted clrMap end-to-end
+// ---------------------------------------------------------------------------
+
+describe('fn API: inverted clrMap end-to-end', () => {
+  // Helper: build a createPresentation() deck and rewrite the slide master's
+  // <p:clrMap> to the inverted form (bg1="dk1" tx1="lt1" ...).
+  // Returns the modified presentation with a Blank slide already added.
+  const buildInvertedDeck = async (): Promise<ReturnType<typeof createPresentation>> => {
+    const pres = createPresentation();
+    const pkg = _internalPackageOf(pres);
+
+    // Find the slide master part
+    const masterPart = pkg.parts.find((p) => p.name.startsWith('/ppt/slideMasters/slideMaster'));
+    if (!masterPart) throw new Error('slide master not found');
+
+    // Rewrite the <p:clrMap> attributes to the inverted form
+    const xml = decode(masterPart.data);
+    const invertedXml = xml.replace(
+      /(<p:clrMap\s+)bg1="lt1"\s+tx1="dk1"\s+bg2="lt2"\s+tx2="dk2"/,
+      '$1bg1="dk1" tx1="lt1" bg2="dk2" tx2="lt2"',
+    );
+    masterPart.data = encode(invertedXml);
+
+    // Add a slide so the deck has a SlideData we can call getEffectiveColorMap on
+    const layout = findSlideLayout(pres, 'Blank');
+    if (!layout) throw new Error('expected Blank layout');
+    addSlide(pres, { layout });
+
+    return pres;
+  };
+
+  it('getEffectiveColorMap reports tx1:"lt1" after inverting the master clrMap', async () => {
+    const pres = await buildInvertedDeck();
+    // Save and reload so the package is fresh, then check the effective map
+    const reloaded = await loadPresentation(await savePresentation(pres));
+    // The reloaded deck has the slide we added in buildInvertedDeck
+    const slides = getSlides(reloaded);
+    expect(slides.length).toBeGreaterThan(0);
+    const slide = slides[0]!;
+    const clrMap = getEffectiveColorMap(slide);
+    expect(clrMap['tx1']).toBe('lt1');
+    expect(clrMap['bg1']).toBe('dk1');
+  });
+
+  it('addSlideTable bakes FFFFFF (light1) when tx1 maps to lt1', async () => {
+    const pres = await buildInvertedDeck();
+    const layout = findSlideLayout(pres, 'Blank');
+    if (!layout) throw new Error('expected Blank layout');
+    const slide = addSlide(pres, { layout });
+    addSlideTable(slide, {
+      x: inches(1),
+      y: inches(1),
+      w: inches(6),
+      h: inches(2),
+      rows: [
+        ['Cell 1', 'Cell 2'],
+        ['Cell 3', 'Cell 4'],
+      ],
+    });
+    const xml = getSlideXmlString(getSlides(pres).at(-1)!);
+    // With inverted map: tx1 → lt1 → light1 = #FFFFFF
+    expect(xml).toContain('<a:solidFill><a:srgbClr val="FFFFFF"/></a:solidFill>');
+    // Must NOT bake the standard 000000 (that would be the wrong color)
+    expect(xml).not.toContain('val="000000"');
+  });
+
+  it('addSlideChart bakes FFFFFF on catAx when tx1 maps to lt1', async () => {
+    const pres = await buildInvertedDeck();
+    const layout = findSlideLayout(pres, 'Blank');
+    if (!layout) throw new Error('expected Blank layout');
+    const slide = addSlide(pres, { layout });
+    addSlideChart(slide, {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'column',
+        categories: ['Jan', 'Feb'],
+        series: [{ name: 'Sales', values: [100, 200] }],
+      },
+    });
+    const bytes = await savePresentation(pres);
+    const pkg = _internalPackageOf(await loadPresentation(bytes));
+    const chartXml = decode(pkg.parts.find((p) => p.name === '/ppt/charts/chart1.xml')!.data);
+    // The baked color should be FFFFFF, not 000000
+    expect(chartXml).toContain('FFFFFF');
+    expect(chartXml).not.toContain('val="000000"');
+  });
+
+  it('renderSlideToSvg flips the scheme-colored master background per the clrMap', async () => {
+    // The blank-deck master paints its background with schemeClr bg1. The first
+    // full-canvas <rect> in the SVG is that background. Standard map: bg1 → lt1 →
+    // light1 = white. Inverted map: bg1 → dk1 → dark1 = black. The preview must
+    // resolve through the effective map, so the fill flips between the two decks.
+    const firstRectFill = (svg: string): string | undefined =>
+      svg.match(/<rect width="[0-9.]+" height="[0-9.]+" fill="(#[0-9A-Fa-f]{6})"\/>/)?.[1];
+
+    const std = createPresentation();
+    const stdLayout = findSlideLayout(std, 'Blank');
+    if (!stdLayout) throw new Error('expected Blank layout');
+    const stdSlide = addSlide(std, { layout: stdLayout });
+    expect(firstRectFill(renderSlideToSvg(std, stdSlide))).toBe('#FFFFFF');
+
+    const inv = await buildInvertedDeck();
+    const invSlide = getSlides(inv)[0]!;
+    expect(firstRectFill(renderSlideToSvg(inv, invSlide))).toBe('#000000');
+  });
+});


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

PowerPoint resolves every `schemeClr` token through the slide's color map (`<p:clrMap>` on the master, optionally overridden per-slide by `<p:clrMapOvr>`) before indexing the theme. pptx-kit and pptx-kit-preview skipped that step and indexed the theme directly, which is only correct for the standard map. Templates that **invert** the map (`bg1="dk1" tx1="lt1"` — common in Google Slides / Canva exports) therefore rendered with swapped light/dark colors. This PR resolves colors through the effective map and bakes a readable text color onto generated tables/charts.

## Motivation

A real deck built from an inverted-map template exhibited three bugs at once:

1. The **preview painted slide backgrounds black** while PowerPoint paints them white (the master background uses `schemeClr tx1`, which the inverted map sends to `lt1`/white — but the preview hard-mapped `tx1` → `dark1`/black).
2. **Tables had invisible text** — cells inherit the template's default table style, whose text token is `tx1`; the inverted map paints that the same as the (white) cell background.
3. **Chart axis labels / legend / data labels were invisible** for the same reason (a chart with no authored `txPr` falls back to `tx1`).

All three are the same root cause: scheme tokens resolved without the color map.

Closes #<!-- no issue; reported directly by a maintainer with a sample deck -->

## Changes

- **New export `getEffectiveColorMap(slide)`** — the master's `<p:clrMap>` overlaid by a per-slide `<p:clrMapOvr>`, falling back to the standard map.
- **`resolveDrawingColor(colorEl, theme, clrMap?)`** — optional third argument; a `schemeClr` token is remapped through it before the theme lookup. Omitting it preserves the previous behavior (correct for the standard map), so existing callers are unaffected.
- **`addSlideTable` / `addSlideChart`** bake the deck's resolved body-text color (read from the master `bodyStyle`, resolved through the effective map) onto table cells and chart text (axis labels, legend, data labels). Authored colors still win; override cells afterwards with `setTableCellTextFormat`.
- **`pptx-kit-preview`** resolves `schemeClr` tokens through `getEffectiveColorMap`, so previews of inverted-map decks match what PowerPoint paints.

## Testing

- New `test/fn-clrmap-color-resolution.test.ts`: `resolveDrawingColor` with/without a map, `getEffectiveColorMap` on a standard deck, table/chart color baking (standard → `000000`), authored-color precedence, and an **inverted-map end-to-end** group (rewrites a `createPresentation()` master's `<p:clrMap>` and asserts the effective map, the baked table/chart color, and the preview background fill all flip to the swapped slot).
- Verified against the original failing real-world template (table text and chart labels now render dark on the white background; preview background now matches PowerPoint).
- Full suite green: `pnpm test` (1158 passed), `pnpm typecheck` (+ preview), `pnpm lint`, `pnpm format:check`.

## Breaking changes

None for the standard color map (the common case): resolution and rendering are byte-identical. Decks with a non-standard map now resolve colors the way PowerPoint does, and generated tables/charts now carry an explicit body-text color instead of inheriting `tx1`. Shipped as a `minor` changeset.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
