### PR TITLE
fix: emit PowerPoint default cell insets; expand parity corpus to 32 cases

### DIFF
--- a/.changeset/table-cell-default-insets.md
+++ b/.changeset/table-cell-default-insets.md
@@ -1,0 +1,16 @@
+---
+'pptx-kit': patch
+---
+
+Emit PowerPoint's default cell insets on table cells
+
+`addSlideTable` cells now carry the explicit default insets PowerPoint and
+PptxGenJS both write — `<a:tcPr marL="91440" marR="91440" marT="45720"
+marB="45720">` — plus a `<a:pPr marL="0" indent="0"><a:buNone/></a:pPr>` that
+suppresses any inherited list bullet on the cell paragraph. The table renders
+identically (these match the values PowerPoint applies when they're absent),
+but the cell is now self-describing, so the output matches a PowerPoint- or
+PptxGenJS-authored table byte-for-byte at the cell level.
+
+Note: `getTableCellMargins` now returns the explicit `91440 / 45720` defaults
+for a freshly-authored cell instead of `null`.

--- a/src/internal/presentationml/table-builder.ts
+++ b/src/internal/presentationml/table-builder.ts
@@ -50,7 +50,14 @@ const NAME_RPR = qname('a', 'rPr', NS.dml);
 const NAME_SOLID_FILL = qname('a', 'solidFill', NS.dml);
 const NAME_SRGB_CLR = qname('a', 'srgbClr', NS.dml);
 const NAME_T = qname('a', 't', NS.dml);
+const NAME_PPR = qname('a', 'pPr', NS.dml);
+const NAME_BU_NONE = qname('a', 'buNone', NS.dml);
 const ATTR_VAL = qname('', 'val', '');
+const ATTR_MAR_L = qname('', 'marL', '');
+const ATTR_MAR_R = qname('', 'marR', '');
+const ATTR_MAR_T = qname('', 'marT', '');
+const ATTR_MAR_B = qname('', 'marB', '');
+const ATTR_INDENT = qname('', 'indent', '');
 const ATTR_ID = qname('', 'id', '');
 const ATTR_NAME = qname('', 'name', '');
 const ATTR_NO_GRP = qname('', 'noGrp', '');
@@ -120,13 +127,34 @@ const buildTextCellBody = (value: string, textColorHex: string | undefined): Xml
   const r = elem(NAME_R, {
     children: [buildCellRunProps(textColorHex), t],
   });
-  const p = elem(NAME_P, { children: [r] });
+  // `<a:pPr marL="0" indent="0"><a:buNone/></a:pPr>` suppresses any inherited
+  // list bullet on the cell paragraph — what PowerPoint and PptxGenJS both
+  // emit. Renders the same as omitting it (table cells inherit no bullet), but
+  // makes the cell self-describing.
+  const pPr = elem(NAME_PPR, {
+    attrs: [attr(ATTR_MAR_L, '0'), attr(ATTR_INDENT, '0')],
+    children: [elem(NAME_BU_NONE)],
+  });
+  const p = elem(NAME_P, { children: [pPr, r] });
   return elem(NAME_TX_BODY, { children: [elem(NAME_BODY_PR), elem(NAME_LST_STYLE), p] });
 };
 
+// PowerPoint's default cell insets (0.1in horizontal, 0.05in vertical).
+// Emitting them explicitly — as PowerPoint and PptxGenJS do — renders
+// identically to omitting them, but keeps the cell self-describing.
+const buildCellProps = (): XmlElement =>
+  elem(NAME_TC_PR, {
+    attrs: [
+      attr(ATTR_MAR_L, '91440'),
+      attr(ATTR_MAR_R, '91440'),
+      attr(ATTR_MAR_T, '45720'),
+      attr(ATTR_MAR_B, '45720'),
+    ],
+  });
+
 /** @internal — used by row-mutation paths in the public API. */
 export const buildTableCell = (value: string, textColorHex?: string): XmlElement => {
-  return elem(NAME_TC, { children: [buildTextCellBody(value, textColorHex), elem(NAME_TC_PR)] });
+  return elem(NAME_TC, { children: [buildTextCellBody(value, textColorHex), buildCellProps()] });
 };
 
 /** @internal — used by row-mutation paths in the public API. */

--- a/test/corpus/canonical.ts
+++ b/test/corpus/canonical.ts
@@ -61,16 +61,6 @@ const isWhitespaceText = (n: XmlNode): boolean => n.kind === 'text' && n.data.tr
 // carry no rendering meaning. Dropped on every element.
 const VOLATILE_ATTR_LOCALS = new Set(['dirty', 'smtClean', 'noProof']);
 
-// `<a:tcPr>` insets that equal PowerPoint's built-in defaults: a cell that
-// omits them renders identically, so emitting them (PptxGenJS) vs inheriting
-// them (pptx-kit) is the same picture.
-const DEFAULT_TC_MARGINS: Record<string, string> = {
-  marL: '91440',
-  marR: '91440',
-  marT: '45720',
-  marB: '45720',
-};
-
 // `<a:hlinkClick>` attributes PptxGenJS writes out at their default value (or
 // empty); PowerPoint omits them. Folded when empty or equal to the default.
 const HLINK_DEFAULTS: Record<string, string> = {
@@ -134,8 +124,6 @@ const canonicalAttrs = (el: XmlElement): string[] => {
       continue;
     // No-op bullet reset (`marL="0" indent="0"` alongside `<a:buNone/>`).
     if (local === 'pPr' && (an === 'marL' || an === 'indent') && a.value === '0') continue;
-    // Default cell insets — see DEFAULT_TC_MARGINS.
-    if (local === 'tcPr' && DEFAULT_TC_MARGINS[an] === a.value) continue;
     // Row height is an advisory minimum PowerPoint recomputes from content.
     if (local === 'tr' && an === 'h') continue;
     // Hyperlink no-op defaults PptxGenJS spells out and PowerPoint omits.

--- a/test/corpus/cases.ts
+++ b/test/corpus/cases.ts
@@ -444,6 +444,83 @@ export const CASES: CorpusCase[] = [
     },
   },
   {
+    id: 'chart-bar-horizontal',
+    pgjs: (s) => {
+      s.addChart('bar', [{ name: 'S', labels: ['A', 'B', 'C'], values: [3, 7, 5] }], {
+        x: 1,
+        y: 1,
+        w: 6,
+        h: 4,
+        barDir: 'bar',
+      });
+    },
+    kit: (_p, slide) => {
+      addSlideChart(slide, {
+        x: inches(1),
+        y: inches(1),
+        w: inches(6),
+        h: inches(4),
+        spec: {
+          kind: 'bar',
+          categories: ['A', 'B', 'C'],
+          series: [{ name: 'S', values: [3, 7, 5] }],
+        },
+      });
+    },
+  },
+  {
+    id: 'chart-area',
+    pgjs: (s) => {
+      s.addChart('area', [{ name: 'S', labels: ['A', 'B', 'C'], values: [3, 7, 5] }], {
+        x: 1,
+        y: 1,
+        w: 6,
+        h: 4,
+      });
+    },
+    kit: (_p, slide) => {
+      addSlideChart(slide, {
+        x: inches(1),
+        y: inches(1),
+        w: inches(6),
+        h: inches(4),
+        spec: {
+          kind: 'area',
+          categories: ['A', 'B', 'C'],
+          series: [{ name: 'S', values: [3, 7, 5] }],
+        },
+      });
+    },
+  },
+  {
+    id: 'chart-doughnut',
+    pgjs: (s) => {
+      s.addChart(
+        'doughnut',
+        [{ name: 'Share', labels: ['Web', 'Mobile', 'Desktop'], values: [55, 30, 15] }],
+        {
+          x: 1,
+          y: 1,
+          w: 6,
+          h: 4,
+        },
+      );
+    },
+    kit: (_p, slide) => {
+      addSlideChart(slide, {
+        x: inches(1),
+        y: inches(1),
+        w: inches(6),
+        h: inches(4),
+        spec: {
+          kind: 'doughnut',
+          categories: ['Web', 'Mobile', 'Desktop'],
+          series: [{ name: 'Share', values: [55, 30, 15] }],
+        },
+      });
+    },
+  },
+  {
     id: 'text-hyperlink',
     pgjs: (s) => {
       s.addText('Open', {

--- a/test/corpus/parity-baseline.json
+++ b/test/corpus/parity-baseline.json
@@ -1,5 +1,8 @@
 {
+  "chart-area": 0,
+  "chart-bar-horizontal": 0,
   "chart-column": 0,
+  "chart-doughnut": 0,
   "chart-line": 0,
   "chart-multiseries": 0,
   "chart-pie": 0,


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Per the decision to make pptx-kit's output structurally match PptxGenJS **where
doing so does not degrade quality**, this makes table cells emit PowerPoint's
default insets (so they match a PowerPoint/PptxGenJS table at the cell level
without the corpus folding the difference away), and expands the parity corpus
to 32 cases covering every chart kind pptx-kit can author.

## Motivation

The PptxGenJS-parity corpus previously *folded* the cell-inset difference
(pptx-kit relied on PowerPoint supplying the defaults; PptxGenJS wrote them
explicitly). The goal is for pptx-kit to genuinely produce the same structure,
not to normalize the difference away — so the emitter now writes the defaults
and the fold is removed.

The degrading direction is deliberately **not** taken: PptxGenJS also writes
`w="0"` noFill cell borders, which override the table-grid style and render
borderless. pptx-kit keeps its gridline-resolving style (the 0.6.1 fix), so the
corpus still folds that one difference, documented as "pptx-kit is intentionally
better here." (The text-box `buNone` match was tried and reverted: its `marL="0"`
blocked the bullet hanging indent from 0.6.2 — i.e. it was degrading.)

## Changes

- **Table cells emit `<a:tcPr marL=91440 marR=91440 marT=45720 marB=45720>`**
  and a `<a:pPr marL="0" indent="0"><a:buNone/></a:pPr>` — the structure
  PowerPoint and PptxGenJS write. Renders identically.
  - `getTableCellMargins` now returns the explicit defaults for a fresh cell
    instead of `null`.
- **Corpus → 32 cases**: adds bar (horizontal), area, doughnut charts.
- **Comparator**: cell-margin fold removed (genuine match now).

## Testing

- `pnpm test` — full suite green (1220 passed / 24 skipped).
- `pnpm test test/corpus` — 32 cases, table cells now match **without** the
  margin fold.

## Breaking changes

None functional. `getTableCellMargins` returns `91440 / 45720` instead of `null`
for a freshly-authored cell (the value PowerPoint already applied); flagged in
the changeset.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and
      flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale
      comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this
      PR represents real work that warrants a maintainer's review, and I am
      willing to defend each line in review.

<!-- pr-template:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
