### PR TITLE
feat: validate authoring inputs at the API boundary; fix schema-invalid output + add AI-agent skill

### DIFF
--- a/.changeset/boundary-validation.md
+++ b/.changeset/boundary-validation.md
@@ -1,0 +1,36 @@
+---
+'pptx-kit': minor
+---
+
+Validate authoring inputs at the API boundary so out-of-range values throw a
+clear `RangeError` instead of silently emitting a schema-invalid `.pptx` that
+PowerPoint marks corrupt and "repairs".
+
+A generative schema-validation sweep surfaced a whole class of defects where a
+caller-supplied number/string was serialized straight into a constrained
+ECMA-376 attribute. These now reject (or, for GUIDs, normalize) at the boundary:
+
+- Run formatting: `setShapeRunFormat` font `size` (ST_TextFontSize, 1..4000 pt)
+  and `spc` (ST_TextPoint). It also now accepts the 3-digit hex shorthand for
+  run `color` / `highlight`, matching `setShapeFill` / `setShapeStroke`.
+- Tables: `setTableStyleId` / `addSlideTable` `styleId` (ST_Guid — a lowercase
+  GUID from `crypto.randomUUID()` is now accepted and normalized to uppercase;
+  a non-GUID string throws); `setTableCellBorders` `widthEmu` (ST_LineWidth);
+  `setTableColumnWidth` / `setTableRowHeight` / `addSlideTable` `w`/`h`
+  (ST_PositiveCoordinate); `setTableCellMargins` (ST_Coordinate32).
+- Charts: bar/column `overlapPct` (ST_Overlap), `gapWidthPct` (ST_GapAmount),
+  and series `lineWidthEmu` (ST_LineWidth).
+- Animations / transitions: `setShapeAnimation` `durationMs` and
+  `setSlideTransition` `advanceAfterMs` (xsd:unsignedInt); the transition
+  `effect` token is validated against the spec's effect set (an empty or unknown
+  string previously produced non-well-formed or schema-invalid XML).
+- Connectors / strokes: `addSlideLine` and `setShapeStroke` `widthEmu`
+  (ST_LineWidth) and `addSlideLine` endpoint coordinates.
+- Text boxes: `setShapeTextColumns` `count` (ST_TextColumnCount, 2..16) and
+  `gapEmu` (ST_PositiveCoordinate32); `setShapeTextMargins` insets
+  (ST_Coordinate32); `setShapeTextBodyRotationDeg` (guards the ST_Angle overflow).
+- Fills: `setShapePatternFill` `preset` is validated against ST_PresetPatternVal
+  (and the `PatternPreset` type is now the exact token union, not `string`).
+- Shape / image / chart geometry: `addSlideShape` / `addSlideTextBox` /
+  `addSlideImage` / `addSlideChart` and `setShapePosition` / `setShapeSize`
+  `x`/`y` (ST_Coordinate) and `w`/`h` (ST_PositiveCoordinate).

--- a/.changeset/llm-authoring-correctness.md
+++ b/.changeset/llm-authoring-correctness.md
@@ -1,0 +1,65 @@
+---
+'pptx-kit': minor
+---
+
+Fix a batch of "generates but is schema-invalid / wrong" authoring bugs, add an
+AI-agent authoring skill, and smooth several LLM-facing rough edges.
+
+Correctness fixes (output is now schema-valid in these cases):
+
+- Notes slides emitted a `<p:notesSlide>` root instead of the spec's `<p:notes>`,
+  failing schema validation.
+- Combining a run's text `color` with `highlight` emitted them out of order.
+- Combining stroke dash / arrowheads / join, or a paragraph's bullet with
+  `setParagraphSpacing`, or a table cell's fill with `setTableCellBorders`,
+  emitted child elements out of their schema-mandated order.
+- Table cells containing leading/trailing spaces, tabs, or newlines emitted an
+  illegal `xml:space` attribute (and a newline now correctly splits a cell into
+  multiple lines).
+- `setSlideTransition({ effect: 'none' })` emitted an invalid `<p:none/>`; per-effect
+  attributes (`direction`/`orientation`/`thruBlack`) are now only emitted on
+  effects that allow them, and `direction` is validated against the effect's own
+  value domain (e.g. `blinds` takes `horz`/`vert`, `push` takes `l`/`r`/`u`/`d`) —
+  a mismatched pair like `{ effect: 'blinds', direction: 'l' }` now throws instead
+  of emitting schema-invalid XML.
+- Charts emitted `<c:marker>`, `<c:smooth>`, `<c:invertIfNegative>`, and
+  `<c:trendline>` on series kinds that don't permit them (e.g. a trendline on a
+  `pie`/`doughnut`/`radar` series, which `CT_PieSer`/`CT_RadarSer` reject), and
+  `valueAxis` `min`/`max` in the wrong order.
+- `setShapeImageBrightness` / `setShapeImageContrast` emitted `<a:lumOff>` /
+  `<a:lumMod>`, which aren't valid `<a:blip>` children; both now write a single
+  schema-valid `<a:lum bright/contrast>`.
+- `setShapeGradientFill` ignored its documented `path` / `focus` options, silently
+  downgrading radial/shape gradients to linear.
+- `importSlide` could emit a duplicate `rId` when the source slide's layout
+  relationship wasn't `rId1`.
+- `setShapeAnimation` wiped any pre-existing `<p:timing>` on the slide (losing a
+  template's authored animations); it now merges, so multiple shapes can animate.
+- `compactPackage` / `readPackagePart` / `setMediaPartBytes` matched part names
+  case-sensitively, unlike the rest of the package layer — a referenced image
+  whose rel-target case differed could be wrongly deleted or missed.
+
+Behavior change:
+
+- `setShapeImageContrast` now takes a `[-1, 1]` offset (`0` = no change) instead
+  of the previous `[0, 2]` multiplier, matching the underlying `<a:lum contrast>`.
+- Unstyled connectors (`addSlideLine` without an explicit stroke) previously
+  emitted no line style and rendered invisibly; they now carry a default
+  `<p:style>` (`lnRef`/`fillRef`/`effectRef`/`fontRef`) so the line is visible.
+
+Ergonomics:
+
+- Colors accept the CSS-style 3-digit hex shorthand (`#f0a` → `FF00AA`).
+- New `setParagraphLineSpacing(shape, p, { kind, value })` (the writer counterpart
+  to the existing getter).
+- `setTableCellBorders` accepts a partial border per side, so `{ color, widthEmu }`
+  type-checks without spelling out `dash` (the read type `getTableCellBorders`
+  returns stays strict — all fields populated).
+- `addSlideShape` `textAnchor` is narrowed to the valid vertical anchors
+  (`'t' | 'ctr' | 'b'`).
+
+Docs:
+
+- New `skill/SKILL.md` — a guide for driving pptx-kit from an AI agent (canonical
+  calls, design rules, footguns, and a QA protocol), with a verified worked
+  example.

--- a/.changeset/sweep-criticals.md
+++ b/.changeset/sweep-criticals.md
@@ -1,0 +1,34 @@
+---
+'pptx-kit': minor
+---
+
+Close a final batch of correctness defects a generative schema sweep surfaced,
+where the writer emitted a `.pptx` PowerPoint marks corrupt:
+
+- **XML-illegal control characters** in any text field (shape text, table cells,
+  notes, chart titles/categories/series, hyperlink tooltip/URL, section names,
+  comments) used to serialize raw, producing a non-well-formed part that
+  corrupts the whole package. They are now rejected at serialization with a
+  clear error; the XML-legal whitespace controls (tab / LF / CR) still pass
+  through. (XML 1.0 forbids the other C0 controls outright — they cannot even be
+  escaped as numeric references.)
+- **Chart percentages** are now range-checked at the boundary: `gapWidthPct`
+  (ST_GapAmount, 0..500 — the previous limit of 65535 let 501..65535 through),
+  doughnut `holeSizePct` (ST_HoleSize, 1..90), and pie/doughnut
+  `firstSliceAngleDeg` (ST_FirstSliceAng, 0..360).
+- **Shape effects**: `setShapeShadow` `blurEmu`/`offsetEmu` and `setShapeGlow`
+  `radiusEmu` are validated as ST_PositiveCoordinate (fractional rounds;
+  negative / non-finite / over-max throws) instead of emitting an invalid value.
+- **Scheme-color round-trip**: the read-back getters return `scheme:<token>`, but
+  the setters rejected that string. `setShapeFill` / `setShapeStroke` /
+  `setSlideBackground` now accept the `scheme:` prefix, so `setX(getX(...))`
+  round-trips. (An unknown `scheme:` token still throws.)
+- **`importSlide` / `mergePresentations`**: importing a slide that contains a
+  chart left a dangling `r:id` (the chart frame referenced a relationship the
+  imported slide no longer carried), producing a corrupt package. The orphaned
+  graphic frame is now dropped, matching the documented "charts are not imported
+  in v1" behavior.
+- **`addSlideShape` presets**: the math-operator tokens were misspelled
+  (`minus`/`mult`/`div`/`equal`/`notEqual`) and not in `ST_ShapeType`, so the
+  shape silently vanished on open. They are now the spec names `mathMinus`,
+  `mathMultiply`, `mathDivide`, `mathEqual`, `mathNotEqual` (plus `mathPlus`).

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ site/fidelity/baseline.candidate.json
 
 # corpus harness output
 test/corpus/out/
+
+# Local scratch probes (not part of the package)
+.probe/

--- a/README.md
+++ b/README.md
@@ -100,6 +100,16 @@ if (title) setShapeText(title, 'Hello');
 const out = await savePresentation(pres);
 ```
 
+## Driving pptx-kit from an AI agent
+
+[`skill/SKILL.md`](skill/SKILL.md) is a self-contained guide for an LLM agent
+authoring presentations with this library: the canonical call for each
+capability, the design rules that keep output from looking template-generated,
+the handful of API footguns worth memorizing, and a QA loop to run before
+declaring a deck done. Its [worked example](skill/examples/business-deck.md) is
+exercised by the test suite, so the code there is known to produce a
+schema-valid deck.
+
 CI enforces the tree-shake bound in `test/tree-shake.test.ts`.
 
 ## Usage
@@ -349,7 +359,7 @@ shown together.
 | Shape authoring      | `addSlideTextBox`, `addSlideShape`, `addSlideLine`, `addSlideTable`, `addSlideImage`, `addSlideChart`                                                                                                                                                                                   |
 | Shape lookup         | `findShapeByName`, `findShapesByName`, `findShapesByKind`, `findShapeInPresentation`, `getAllShapes`, `getSlideShapes`                                                                                                                                                                  |
 | Shape text           | `setShapeText`, `setShapeBullets`, `setShapeAlignment`, `setShapeTextFormat`, `setShapeHyperlink` / `getShapeHyperlink`                                                                                                                                                                 |
-| Per-paragraph        | `setParagraphAlignment` / `getParagraphAlignment`, `setParagraphLevel` / `getParagraphLevel`, `setParagraphBullet` / `getParagraphBullet`                                                                                                                                               |
+| Per-paragraph        | `setParagraphAlignment` / `getParagraphAlignment`, `setParagraphLevel` / `getParagraphLevel`, `setParagraphBullet` / `getParagraphBullet`, `setParagraphSpacing` / `getParagraphSpacing`, `setParagraphLineSpacing` / `getParagraphLineSpacing`                                         |
 | Per-run text         | `setShapeRunText` / `getShapeRunText`, `setShapeRunFormat` / `getShapeRunFormat`, `getShapeParagraphCount`, `getShapeRunCount`                                                                                                                                                          |
 | Text frame           | `setShapeTextAnchor` / `getShapeTextAnchor`, `setShapeTextMargins` / `getShapeTextMargins`                                                                                                                                                                                              |
 | Fill                 | `setShapeFill` / `getShapeFill`, `setShapeGradientFill`, `setShapePatternFill`, `setShapeImageFill`, `setShapeNoFill`, `clearShapeFill`                                                                                                                                                 |

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,0 +1,338 @@
+---
+name: pptx-kit
+description: Author and edit PowerPoint (.pptx) files from TypeScript/JavaScript with pptx-kit — in Node or the browser. Use when an agent must generate a presentation from scratch, fill a template, or programmatically edit slides, shapes, text, tables, charts, and images, and needs the output to open cleanly in PowerPoint, Keynote, Google Slides, and LibreOffice.
+---
+
+# Authoring PPTX with pptx-kit
+
+`pptx-kit` generates **schema-valid** Office Open XML PresentationML. Every
+authoring call maps to a specific ECMA-376 element, so a deck you build here
+opens and is **fully editable** in PowerPoint — not a flattened image, and not
+"valid enough to usually open." That is the bar: _if a file can't be opened and
+edited in PowerPoint, it isn't done._
+
+This guide is the fast path for an LLM agent. It covers the canonical call for
+each capability, the design rules that separate a real deck from an
+AI-template-looking one, the handful of footguns worth memorizing, and a QA
+loop you must run before declaring success.
+
+## When to use this
+
+- **Create from scratch** — build a deck programmatically and emit `.pptx`.
+- **Fill a template** — load an existing `.pptx`, replace text/images, add
+  slides from its layouts, emit the result.
+- **Edit** — mutate shapes, text, tables, charts on existing slides.
+
+If you need a _pixel-perfect render_ (print/archival) or format conversion
+(Keynote/ODP), this is the wrong tool — use PowerPoint/LibreOffice headless.
+
+## Setup
+
+```sh
+npm install pptx-kit
+```
+
+```ts
+import {
+  createPresentation,
+  addTitleSlide,
+  addContentSlide,
+  addBlankSlide,
+  addSlideTextBox,
+  addSlideShape,
+  addSlideTable,
+  addSlideChart,
+  addSlideImage,
+  findSlidePlaceholder,
+  setShapeText,
+  setShapeRunFormat,
+  setShapeFill,
+  savePresentation,
+} from 'pptx-kit';
+// Node-only convenience (reads/writes files):
+import { loadPresentationFile, savePresentationToFile } from 'pptx-kit/node';
+```
+
+`savePresentation(pres)` returns a `Uint8Array`. In Node, write it with
+`fs.writeFile`; in the browser, wrap it in a `Blob`.
+
+## Mental model (read this once)
+
+1. **One free-function API.** Every capability is a named export that takes the
+   thing it operates on (`PresentationData`, `SlideData`, a shape handle) as its
+   first argument. There are no classes to instantiate and no fluent chains.
+   Import only what you use.
+2. **Units are EMU.** Positions/sizes are English Metric Units (914400 per inch).
+   Always go through the unit helpers — `inches(1)`, `cm(2)`, `mm(5)`, `pt(18)`,
+   `emu(n)` — never raw numbers.
+3. **Build, then format.** Add a shape/slide; it returns a handle. Pass that
+   handle to formatting functions (`setShape*`). Order of formatting calls does
+   not matter — the library inserts each XML child at its schema-mandated slot.
+4. **Colors** are `#RRGGBB`, the 3-digit shorthand `#RGB`, bare `RRGGBB`, or a
+   theme token (`accent1`…`accent6`, `tx1`, `bg1`, `dk1`, `lt1`, `hlink`). An
+   unrecognized color **throws** — it is never silently emitted. One exception:
+   chart series colors accept the hex forms but **not** theme tokens (a series
+   must resolve to a concrete sRGB value).
+
+## Core workflow — build a deck from scratch
+
+`createPresentation()` returns an immediately-authorable deck (slide master,
+Office theme, and `Blank` / `Title Slide` / `Title and Content` layouts) with
+no slides. Defaults to 16:9; pass `{ size: '4:3' }` for the classic ratio.
+
+```ts
+const pres = createPresentation();
+
+// Title slide — sugar picks the right layout by its locale-stable type token.
+const cover = addTitleSlide(pres, 'FY26 Business Review');
+const subtitle = findSlidePlaceholder(cover, 'subTitle');
+if (subtitle) setShapeText(subtitle, 'Strategy, results, and the road ahead');
+
+// Title + body content slide.
+const agenda = addContentSlide(pres, { title: 'Agenda' });
+const body = findSlidePlaceholder(agenda, 'body');
+// IMPORTANT: bullet *content* is multi-line text + a bullet style, NOT a list arg.
+if (body) setShapeText(body, 'Highlights\nFinancials\nRoadmap\nRisks', { bullets: 'bullet' });
+
+const out = await savePresentation(pres);
+```
+
+Slide constructors:
+
+| Goal                              | Call                                                              |
+| --------------------------------- | ----------------------------------------------------------------- |
+| Title slide                       | `addTitleSlide(pres, title)`                                      |
+| Title + body (bulleted)           | `addContentSlide(pres, { title, body })`                          |
+| Section divider                   | `addSectionHeaderSlide(pres, title)`                              |
+| Empty canvas for free-form layout | `addBlankSlide(pres)`                                             |
+| Bind a layout explicitly          | `addSlide(pres, { layout: findSlideLayoutByType(pres, 'obj')! })` |
+
+Prefer `findSlideLayoutByType(pres, 'title' | 'obj' | 'secHead' | 'blank')` —
+the `type` token is stable across PowerPoint UI languages. `findSlideLayout`
+matches the localized, case-sensitive display name.
+
+## Capability cheat-sheet (the canonical call)
+
+Content on a blank slide (all positions via `inches`/`cm`/`pt`):
+
+```ts
+const slide = addBlankSlide(pres);
+
+// Text box.
+const tb = addSlideTextBox(slide, {
+  x: inches(0.6),
+  y: inches(0.4),
+  w: inches(8),
+  h: inches(1),
+  text: 'A strong year',
+});
+setShapeRunFormat(tb, 0, 0, { bold: true, size: 32, color: '#1F2937', font: 'Arial' });
+
+// Preset shape with centered text + gradient + shadow.
+const card = addSlideShape(slide, {
+  preset: 'roundRect',
+  x: inches(0.6),
+  y: inches(1.6),
+  w: inches(3.6),
+  h: inches(2.2),
+  text: 'Revenue +38%',
+  textAnchor: 'ctr',
+});
+setShapeGradientFill(card, {
+  stops: [
+    { offset: 0, color: '#2563EB' },
+    { offset: 1, color: '#1E3A8A' },
+  ],
+  angleDeg: 90,
+});
+setShapeShadow(card, {
+  color: '#000000',
+  blurEmu: pt(8),
+  offsetEmu: pt(3),
+  angleDeg: 90,
+  opacity: 0.35,
+});
+
+// Table (firstRow + bandRow give the banded header look).
+addSlideTable(slide, {
+  x: inches(0.6),
+  y: inches(1.6),
+  w: inches(8.2),
+  h: inches(2.5),
+  rows: [
+    ['Metric', 'FY25', 'FY26'],
+    ['Revenue', '$120M', '$166M'],
+    ['Margin', '64%', '67%'],
+  ],
+  firstRow: true,
+  bandRow: true,
+});
+
+// Chart (embedded workbook + caches are generated automatically).
+addSlideChart(slide, {
+  x: inches(0.6),
+  y: inches(1.1),
+  w: inches(8.2),
+  h: inches(4.2),
+  spec: {
+    kind: 'column', // bar | column | line | pie | doughnut | area
+    categories: ['Q1', 'Q2', 'Q3', 'Q4'],
+    series: [
+      { name: 'Revenue', values: [120, 138, 152, 166] },
+      { name: 'Plan', values: [115, 130, 148, 160] },
+    ],
+    title: 'Revenue vs plan ($M)',
+    dataLabels: { showValue: true, showCategory: false, showSeriesName: false, showPercent: false },
+  },
+});
+
+// Image (format auto-detected from the bytes; `fit` controls letterbox/crop).
+addSlideImage(slide, pngBytes, {
+  x: inches(0.6),
+  y: inches(1.1),
+  w: inches(8.2),
+  h: inches(4.2),
+  fit: 'contain',
+});
+```
+
+Formatting and slide features (one canonical call each):
+
+| Capability                      | Call                                                                                                                       |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| Whole-shape text                | `setShapeText(shape, text, { bullets? })` (split lines with `\n`)                                                          |
+| One run's format                | `setShapeRunFormat(shape, p, r, { bold, italic, underline, size, color, font, highlight, ... })`                           |
+| Paragraph align / level         | `setParagraphAlignment(shape, p, 'ctr')`, `setParagraphLevel(shape, p, 1)`                                                 |
+| Paragraph spacing / leading     | `setParagraphSpacing(shape, p, { beforePts, afterPts })`, `setParagraphLineSpacing(shape, p, { kind: 'pct', value: 1.5 })` |
+| Solid / gradient / pattern fill | `setShapeFill(shape, '#2563EB')`, `setShapeGradientFill(...)`, `setShapePatternFill(...)`                                  |
+| Outline                         | `setShapeStroke(shape, { color, widthEmu })` + `setShapeStrokeDash/Arrow/Cap/Join`                                         |
+| Effects                         | `setShapeShadow(shape, {...})`, `setShapeGlow(shape, {...})`                                                               |
+| Geometry                        | `setShapePosition/Size/Rotation/Flip/Bounds`, `bringShapeToFront`, `sendShapeToBack`                                       |
+| Picture corrections             | `setShapeImageCrop/Opacity/Brightness/Contrast` (brightness/contrast in `[-1, 1]`)                                         |
+| Hyperlink / click action        | `setShapeHyperlink(shape, url)`, `setShapeClickAction(shape, { kind: 'nextSlide' })`                                       |
+| Slide background                | `setSlideBackground(slide, '#102030')`, `setSlideBackgroundImage(slide, bytes)`                                            |
+| Transition                      | `setSlideTransition(slide, { effect: 'fade' })` — key is **`effect`**, not `type`                                          |
+| Animation                       | `setShapeAnimation(shape, { effect: 'fadeIn' })` (`fadeIn`/`fadeOut`/`appear`/`disappear`)                                 |
+| Speaker notes                   | `setSlideNotes(slide, '...')`                                                                                              |
+| Comments                        | `addSlideComment(slide, { author: { name }, text })`                                                                       |
+| Sections                        | `setSlideSections(pres, [{ name, slides: [...] }])`                                                                        |
+
+## Fill a template instead
+
+```ts
+import {
+  loadPresentation,
+  getSlides,
+  findSlidePlaceholder,
+  setShapeText,
+  replaceTokensInPresentation,
+  setShapeImage,
+  getSlideShapes,
+  getShapeKind,
+  getShapeName,
+  savePresentation,
+} from 'pptx-kit';
+
+const pres = await loadPresentation(templateBytes);
+
+// Placeholder text:
+const title = findSlidePlaceholder(getSlides(pres)[0]!, 'title');
+if (title) setShapeText(title, 'Q3 Review');
+
+// Token fill across every slide ({{name}}, {{date}}, ...):
+replaceTokensInPresentation(pres, { name: 'Alice', date: '2026-12-01' });
+
+// Swap an image in place (geometry preserved):
+for (const s of getSlides(pres))
+  for (const sh of getSlideShapes(s))
+    if (getShapeKind(sh) === 'picture' && getShapeName(sh) === 'Logo')
+      setShapeImage(sh, newLogoBytes);
+
+const out = await savePresentation(pres);
+```
+
+Out-of-scope parts are preserved on round-trip — the library never silently
+strips content it doesn't model.
+
+## Design rules (so it doesn't look AI-generated)
+
+A schema-valid deck can still look like a template. Before building, commit to a
+look and apply it consistently:
+
+- **Pick a bold, content-informed palette** and let _one_ color dominate
+  (~60–70% of visual weight), with one accent. Don't scatter six accent colors
+  per slide. Define the palette once as hex constants and reuse it.
+- **Every slide needs a visual element** — a chart, table, image, colored
+  shape, or a strong type hierarchy. Avoid bullet-only text slides; convert
+  lists into two-column layouts, icon/number rows, or small-multiple cards.
+- **Don't repeat the same layout** slide after slide. Alternate: full-bleed
+  title, two-column, chart-led, table-led, quote/stat callout.
+- **Typography**: titles 32–44pt bold, body 14–18pt, one or two font families.
+  Keep a ≥0.5in (`inches(0.5)`) margin from the slide edge; don't crowd edges.
+- **Numbers deserve charts**, not sentences. A trend → line; parts of a whole →
+  pie/doughnut; comparison across categories → column/bar.
+- **Avoid the tells**: a thin accent line under every title, dense walls of
+  bullets, clip-art, and four different accent colors all read as "generated."
+
+Sizing reference (16:9 deck): the canvas is `inches(13.333) × inches(7.5)`.
+Keep content within `x ∈ [0.5, 12.83]`, `y ∈ [0.5, 7.0]` inches.
+
+## Footguns (memorize these — each is a real, easy mistake)
+
+- **Bullets are content + style, not a list argument.** To make a bulleted
+  list: `setShapeText(shape, 'A\nB\nC', { bullets: 'bullet' })`.
+  `setShapeBullets(shape, style)` sets the _bullet glyph style_ (`'bullet'` |
+  `'number'` | `'none'` | `{ char }` | `{ autoNum }`) on existing paragraphs —
+  it is NOT how you set the text.
+- **`setShapeFill(shape, color)` takes a color string**, e.g.
+  `setShapeFill(card, '#059669')` — not an object.
+- **Transitions key on `effect`**: `setSlideTransition(slide, { effect: 'fade' })`.
+  `{ type: 'fade' }` is wrong. `effect: 'none'` emits no transition (use
+  `clearSlideTransition` to remove one).
+- **Multi-line text** in a text box, shape, or table cell uses `\n` between
+  lines — each becomes its own paragraph. A literal newline inside one run is
+  not a line break.
+- **Authorable chart kinds** are `bar`, `column`, `line`, `pie`, `doughnut`,
+  `area`. `scatter`/`radar`/`bubble` are read-only today (authoring them
+  throws). `pie`/`doughnut` take exactly one series.
+- **Find placeholders by type token**, not display name:
+  `findSlidePlaceholder(slide, 'title' | 'body' | 'ctrTitle' | 'subTitle')`.
+
+## QA protocol — run this before saying "done"
+
+1. **Structural validation.** `const issues = validatePresentation(pres);` —
+   treat any `severity === 'error'` as a blocker (missing rels, dangling slide
+   ids, layouts without masters, etc.). Fix and re-run until clean.
+2. **Round-trip.** `loadPresentation(await savePresentation(pres))` must not
+   throw and must report the same slide count.
+3. **Schema validity.** If you have `xmllint` + the ECMA-376 XSDs, validate each
+   emitted part. The library's own test suite gates this; if you author novel
+   combinations, validate them too.
+4. **Visual check.** Render to an image and _look at it_ — overflowing text,
+   collisions, off-canvas shapes, and unreadable color contrast do not show up
+   in schema validation. Use `pptx-kit-preview` (SVG in the browser, PNG on the
+   server) or open the file in PowerPoint/LibreOffice. `findShapesOutsideCanvas`
+   and `findOverlappingShapePairs` catch layout problems programmatically.
+5. **Content check.** Grep the saved deck's text (`getPresentationText(pres)`)
+   for leftover placeholder tokens (`{{`, "Lorem", "TODO") before shipping.
+
+## Known limitations (don't fight these — design around them)
+
+Read-pass-through or post-1.0, _not_ authorable today:
+
+- `scatter` / `radar` / `bubble` charts, combo charts, and secondary value axes.
+- Multiple independently-formatted runs **within one paragraph** (inline rich
+  text like "make _this word_ bold"); each paragraph is authored as one run.
+  Use per-shape or per-paragraph formatting, or split across shapes.
+- Constructing new themes / masters / layouts from scratch (author _on top of_
+  the ones `createPresentation` or a template provides).
+- SmartArt authoring, complex multi-step animation timing trees, OLE/ActiveX,
+  and document encryption.
+- Modern threaded comments (legacy `<p:cm>` comments are read + written).
+
+## Worked example
+
+A complete, validated multi-slide business deck is in
+[`examples/business-deck.md`](examples/business-deck.md). It is exercised by the
+library's test suite (`test/skill-example.test.ts`), so the code there is known
+to produce a schema-valid deck.

--- a/skill/examples/business-deck.md
+++ b/skill/examples/business-deck.md
@@ -1,0 +1,173 @@
+# Worked example — a 7-slide business deck from scratch
+
+This is the canonical end-to-end example referenced by [`../SKILL.md`](../SKILL.md).
+The same code is exercised by `test/skill-example.test.ts`, which asserts the
+result is structurally valid, schema-valid, and round-trips — so this is known
+to produce a clean `.pptx`, not just plausible-looking code.
+
+It demonstrates the rules from the skill: a single two-color palette reused
+across slides, varied layouts (title → bulleted agenda → section divider → stat
+cards → table → chart → image), numbers shown as a chart, and speaker notes.
+
+```ts
+import {
+  createPresentation,
+  addTitleSlide,
+  addContentSlide,
+  addSectionHeaderSlide,
+  addBlankSlide,
+  addSlideShape,
+  addSlideTextBox,
+  addSlideTable,
+  addSlideChart,
+  addSlideImage,
+  findSlidePlaceholder,
+  setShapeText,
+  setShapeRunFormat,
+  setShapeFill,
+  setShapeGradientFill,
+  setShapeShadow,
+  setShapeStroke,
+  setSlideNotes,
+  setSlideTransition,
+  validatePresentation,
+  savePresentation,
+  inches,
+  pt,
+} from 'pptx-kit';
+
+// Define the palette once and reuse it everywhere.
+const BRAND = '#2563EB';
+const BRAND_DARK = '#1E3A8A';
+const INK = '#1F2937';
+
+const pres = createPresentation(); // 16:9 by default
+
+// 1. Title slide.
+const cover = addTitleSlide(pres, 'FY26 Business Review');
+const subtitle = findSlidePlaceholder(cover, 'subTitle');
+if (subtitle) setShapeText(subtitle, 'Strategy, results, and the road ahead');
+
+// 2. Agenda — bulleted body (multi-line text + a bullet style).
+const agenda = addContentSlide(pres, { title: 'Agenda' });
+const body = findSlidePlaceholder(agenda, 'body');
+if (body) setShapeText(body, 'Highlights\nFinancials\nRoadmap\nRisks', { bullets: 'bullet' });
+
+// 3. Section divider.
+addSectionHeaderSlide(pres, 'Highlights');
+
+// 4. Stat cards on a free-form blank slide.
+const cards = addBlankSlide(pres);
+const heading = addSlideTextBox(cards, {
+  x: inches(0.6),
+  y: inches(0.4),
+  w: inches(8),
+  h: inches(0.9),
+  text: 'A strong year',
+});
+setShapeRunFormat(heading, 0, 0, { bold: true, size: 32, color: INK });
+
+const statCard = (x: ReturnType<typeof inches>, text: string) =>
+  addSlideShape(cards, {
+    preset: 'roundRect',
+    x,
+    y: inches(1.6),
+    w: inches(3.6),
+    h: inches(2.2),
+    text,
+    textAnchor: 'ctr',
+  });
+
+const cardA = statCard(inches(0.6), 'Revenue +38%');
+setShapeGradientFill(cardA, {
+  stops: [
+    { offset: 0, color: BRAND },
+    { offset: 1, color: BRAND_DARK },
+  ],
+  angleDeg: 90,
+});
+setShapeShadow(cardA, {
+  color: '#000000',
+  blurEmu: pt(8),
+  offsetEmu: pt(3),
+  angleDeg: 90,
+  opacity: 0.35,
+});
+
+const cardB = statCard(inches(4.6), 'NPS 62');
+setShapeFill(cardB, '#059669');
+setShapeStroke(cardB, { color: '#065F46', widthEmu: pt(1.5) });
+
+// 5. Financials table (banded header).
+const fin = addContentSlide(pres, { title: 'Financials' });
+addSlideTable(fin, {
+  x: inches(0.6),
+  y: inches(1.6),
+  w: inches(8.2),
+  h: inches(2.5),
+  rows: [
+    ['Metric', 'FY25', 'FY26', 'Δ'],
+    ['Revenue', '$120M', '$166M', '+38%'],
+    ['Gross margin', '64%', '67%', '+3pt'],
+  ],
+  firstRow: true,
+  bandRow: true,
+});
+
+// 6. Chart-led slide — numbers as a chart, not sentences.
+const chartSlide = addBlankSlide(pres);
+addSlideTextBox(chartSlide, {
+  x: inches(0.6),
+  y: inches(0.3),
+  w: inches(8),
+  h: inches(0.7),
+  text: 'Quarterly revenue',
+});
+addSlideChart(chartSlide, {
+  x: inches(0.6),
+  y: inches(1.1),
+  w: inches(8.2),
+  h: inches(4.2),
+  spec: {
+    kind: 'column',
+    categories: ['Q1', 'Q2', 'Q3', 'Q4'],
+    series: [
+      { name: 'Revenue', values: [120, 138, 152, 166], color: BRAND },
+      { name: 'Plan', values: [115, 130, 148, 160] },
+    ],
+    title: 'Revenue vs plan ($M)',
+    valueAxisTitle: 'USD (millions)',
+    dataLabels: {
+      showValue: true,
+      showCategory: false,
+      showSeriesName: false,
+      showPercent: false,
+    },
+  },
+});
+
+// 7. Image slide with a closing transition + speaker notes.
+const imgSlide = addBlankSlide(pres);
+addSlideImage(imgSlide, pngBytes, {
+  x: inches(0.6),
+  y: inches(1.1),
+  w: inches(8.2),
+  h: inches(4.2),
+  fit: 'contain',
+});
+setSlideTransition(imgSlide, { effect: 'fade' });
+setSlideNotes(imgSlide, 'Wrap in under two minutes, then open Q&A.');
+
+// QA before shipping.
+const errors = validatePresentation(pres).filter((i) => i.severity === 'error');
+if (errors.length) throw new Error(`invalid deck: ${errors.map((e) => e.message).join('; ')}`);
+
+const bytes = await savePresentation(pres);
+// Node:    await fs.writeFile('review.pptx', bytes)
+// Browser: new Blob([bytes], { type: 'application/vnd.openxmlformats-officedocument.presentationml.presentation' })
+```
+
+`pngBytes` is any `Uint8Array` of PNG/JPEG/GIF image data — the format is
+detected from the bytes. Chart series `color` accepts the same hex forms as
+shape colors (`#RGB` / `#RRGGBB` / bare `RRGGBB`) but, unlike shape colors, not
+theme/scheme tokens — a chart series must resolve to a concrete sRGB value.

--- a/src/api/fn/charts.ts
+++ b/src/api/fn/charts.ts
@@ -9,6 +9,7 @@ import {
   resolveTarget,
 } from '../../internal/opc/index.ts';
 import type { OpcPackage } from '../../internal/parts/index.ts';
+import { emuCoordinate, emuExtent } from '../../internal/bounds.ts';
 import { parseSrgbHex } from '../../internal/drawingml/index.ts';
 import { REL_TYPES } from '../../internal/presentationml/index.ts';
 import {
@@ -105,14 +106,14 @@ const buildChartGraphicFrame = (opts: {
   // Round to whole EMU; fractional ST_Coordinate values corrupt the file.
   const off = elem(NAME_OFF, {
     attrs: [
-      attr(qname('', 'x', ''), String(Math.round(opts.x))),
-      attr(qname('', 'y', ''), String(Math.round(opts.y))),
+      attr(qname('', 'x', ''), String(emuCoordinate(opts.x, 'addSlideChart: x'))),
+      attr(qname('', 'y', ''), String(emuCoordinate(opts.y, 'addSlideChart: y'))),
     ],
   });
   const ext = elem(NAME_EXT, {
     attrs: [
-      attr(qname('', 'cx', ''), String(Math.round(opts.w))),
-      attr(qname('', 'cy', ''), String(Math.round(opts.h))),
+      attr(qname('', 'cx', ''), String(emuExtent(opts.w, 'addSlideChart: w'))),
+      attr(qname('', 'cy', ''), String(emuExtent(opts.h, 'addSlideChart: h'))),
     ],
   });
   const xfrm = elem(NAME_XFRM, { children: [off, ext] });
@@ -523,7 +524,8 @@ export const findChartsWithTrendlines = (slide: SlideData): ReadonlyArray<SlideC
 export const findChartsWithDataLabels = (slide: SlideData): ReadonlyArray<SlideChartData> => {
   const out: SlideChartData[] = [];
   const hasLabel = (dl: ChartSpec['dataLabels'] | undefined): boolean =>
-    dl !== undefined && (dl.showValue || dl.showCategory || dl.showSeriesName || dl.showPercent);
+    dl !== undefined &&
+    Boolean(dl.showValue || dl.showCategory || dl.showSeriesName || dl.showPercent);
   for (const chart of getSlideCharts(slide)) {
     if (chart.spec === null) continue;
     if (hasLabel(chart.spec.dataLabels)) {

--- a/src/api/fn/package-introspection.ts
+++ b/src/api/fn/package-introspection.ts
@@ -63,7 +63,11 @@ export const listPackageParts = (pres: PresentationData): ReadonlyArray<PackageP
  * (e.g. parsing custom extension parts).
  */
 export const readPackagePart = (pres: PresentationData, name: string): Uint8Array | null => {
-  const part = pres[INTERNAL_PACKAGE].parts.find((p) => p.name === name);
+  // OPC part names compare case-insensitively (ECMA-376 Part 2 §9.1.1), and
+  // OpcPackage.getPart already honors that — match it so a caller passing
+  // `/ppt/Media/Image1.PNG` resolves the same part the package stores.
+  const target = name.toLowerCase();
+  const part = pres[INTERNAL_PACKAGE].parts.find((p) => p.name.toLowerCase() === target);
   return part?.data ?? null;
 };
 
@@ -138,13 +142,17 @@ export const getOrphanMediaPartNames = (pres: PresentationData): ReadonlyArray<s
     if (!sourceRels) continue;
     for (const rel of sourceRels.items) {
       if (rel.targetMode === 'External') continue;
-      referenced.add(resolve(sourceName, rel.target));
+      // Lowercase keys: OPC part names compare case-insensitively, so a rel
+      // target whose case differs from the media part name still counts as a
+      // reference (otherwise a referenced image is wrongly reported as orphan /
+      // deleted by compactPackage).
+      referenced.add(resolve(sourceName, rel.target).toLowerCase());
     }
   }
   const out: string[] = [];
   for (const part of pkg.parts) {
     if (!part.name.startsWith('/ppt/media/')) continue;
-    if (!referenced.has(part.name)) out.push(part.name);
+    if (!referenced.has(part.name.toLowerCase())) out.push(part.name);
   }
   return out;
 };
@@ -261,7 +269,11 @@ export const compactPackage = (
     if (!rels) continue;
     for (const rel of rels.items) {
       if (rel.targetMode === 'External') continue;
-      referenced.add(resolve(sourceName, rel.target));
+      // Lowercase keys: OPC part names compare case-insensitively, so a rel
+      // target whose case differs from the media part name still counts as a
+      // reference (otherwise a referenced image is wrongly reported as orphan /
+      // deleted by compactPackage).
+      referenced.add(resolve(sourceName, rel.target).toLowerCase());
     }
   }
 
@@ -269,7 +281,7 @@ export const compactPackage = (
   const orphans: string[] = [];
   for (const part of pkg.parts) {
     if (!part.name.startsWith('/ppt/media/')) continue;
-    if (!referenced.has(part.name)) orphans.push(part.name);
+    if (!referenced.has(part.name.toLowerCase())) orphans.push(part.name);
   }
   for (const name of orphans) {
     pkg.removePart(partName(name));
@@ -293,7 +305,10 @@ export const setMediaPartBytes = (
   partName: string,
   bytes: Uint8Array,
 ): boolean => {
-  const part = pres[INTERNAL_PACKAGE].parts.find((p) => p.name === partName);
+  // Case-insensitive match, consistent with OPC part-name semantics and
+  // OpcPackage.getPart (see readPackagePart).
+  const target = partName.toLowerCase();
+  const part = pres[INTERNAL_PACKAGE].parts.find((p) => p.name.toLowerCase() === target);
   if (!part) return false;
   part.data = bytes;
   return true;

--- a/src/api/fn/shape-animation.ts
+++ b/src/api/fn/shape-animation.ts
@@ -9,6 +9,7 @@ import {
   NS,
   type XmlElement,
   allChildElements,
+  elem,
   firstChildElement,
   getAttrValue,
   qname,
@@ -32,6 +33,7 @@ import { commitSlideData, refreshSlideData } from './_helpers.ts';
 export type { AnimationEffect, AnimationOptions };
 
 const NAME_TIMING_FN = qname('p', 'timing', NS.pml);
+const ATTR_ID_FN = qname('', 'id', '');
 
 const removeExistingTiming = (slide: SlideData): void => {
   slide[SLIDE_DOCUMENT].root.children = slide[SLIDE_DOCUMENT].root.children.filter(
@@ -40,6 +42,12 @@ const removeExistingTiming = (slide: SlideData): void => {
   );
 };
 
+const findTiming = (slide: SlideData): XmlElement | null =>
+  slide[SLIDE_DOCUMENT].root.children.find(
+    (c): c is XmlElement =>
+      c.kind === 'element' && c.name.namespaceURI === NS.pml && c.name.localName === 'timing',
+  ) ?? null;
+
 const insertTimingAtEnd = (slide: SlideData, timing: XmlElement): void => {
   // Schema ordering: `<p:timing>` is one of the last children of `<p:sld>`
   // (after cSld, clrMapOvr, transition). Appending to the end of
@@ -47,11 +55,137 @@ const insertTimingAtEnd = (slide: SlideData, timing: XmlElement): void => {
   slide[SLIDE_DOCUMENT].root.children.push(timing);
 };
 
+// Depth-first search for the first descendant (or self) matching `pred`.
+const findDescendant = (el: XmlElement, pred: (e: XmlElement) => boolean): XmlElement | null => {
+  if (pred(el)) return el;
+  for (const c of el.children) {
+    if (c.kind === 'element') {
+      const found = findDescendant(c, pred);
+      if (found) return found;
+    }
+  }
+  return null;
+};
+
+const isPml = (el: XmlElement, local: string): boolean =>
+  el.name.namespaceURI === NS.pml && el.name.localName === local;
+
+// Largest numeric `<p:cTn id="N">` anywhere in the tree (0 when none).
+const maxCTnId = (el: XmlElement): number => {
+  let max = 0;
+  const walk = (e: XmlElement): void => {
+    if (isPml(e, 'cTn')) {
+      const n = Number.parseInt(getAttrValue(e, ATTR_ID_FN) ?? '', 10);
+      if (Number.isFinite(n) && n > max) max = n;
+    }
+    for (const c of e.children) if (c.kind === 'element') walk(c);
+  };
+  walk(el);
+  return max;
+};
+
+const shiftCTnIds = (el: XmlElement, offset: number): void => {
+  const walk = (e: XmlElement): void => {
+    if (isPml(e, 'cTn')) {
+      const raw = getAttrValue(e, ATTR_ID_FN);
+      const n = raw === null ? Number.NaN : Number.parseInt(raw, 10);
+      if (Number.isFinite(n)) {
+        e.attrs = e.attrs.map((a) =>
+          a.name.namespaceURI === '' && a.name.localName === 'id'
+            ? { ...a, value: String(n + offset) }
+            : a,
+        );
+      }
+    }
+    for (const c of e.children) if (c.kind === 'element') walk(c);
+  };
+  walk(el);
+};
+
+// Largest numeric `grpId` attribute anywhere in the tree (-1 when none), so a
+// freshly-merged build group can take max+1 and never collide with an existing
+// one even when the authored grpIds have gaps.
+const maxGrpId = (el: XmlElement): number => {
+  let max = -1;
+  const walk = (e: XmlElement): void => {
+    const raw = getAttrValue(e, qname('', 'grpId', ''));
+    if (raw !== null) {
+      const n = Number.parseInt(raw, 10);
+      if (Number.isFinite(n) && n > max) max = n;
+    }
+    for (const c of e.children) if (c.kind === 'element') walk(c);
+  };
+  walk(el);
+  return max;
+};
+
+const setGrpId = (el: XmlElement, grpId: string): void => {
+  el.attrs = el.attrs.map((a) =>
+    a.name.namespaceURI === '' && a.name.localName === 'grpId' ? { ...a, value: grpId } : a,
+  );
+};
+
+// Merges a freshly-built single-effect timing into an existing `<p:timing>`,
+// renumbering the new effect's cTn ids so they stay unique. Returns false when
+// the existing tree lacks the mainSeq structure we know how to extend (so the
+// caller can avoid destroying it). This is what lets a second shape animate
+// without wiping a template's pre-existing animations.
+const mergeEffectInto = (existing: XmlElement, fresh: XmlElement): boolean => {
+  const existingMainSeqChildTnLst = (() => {
+    const mainSeq = findDescendant(
+      existing,
+      (e) => isPml(e, 'cTn') && getAttrValue(e, qname('', 'nodeType', '')) === 'mainSeq',
+    );
+    return mainSeq ? firstChildElement(mainSeq, qname('p', 'childTnLst', NS.pml)) : null;
+  })();
+  if (!existingMainSeqChildTnLst) return false;
+
+  // The fresh tree's click-effect wrapper is the <p:par> under its own mainSeq
+  // childTnLst. Lift it out and renumber its cTn ids past the existing max.
+  const freshMainSeq = findDescendant(
+    fresh,
+    (e) => isPml(e, 'cTn') && getAttrValue(e, qname('', 'nodeType', '')) === 'mainSeq',
+  );
+  const freshChildTnLst = freshMainSeq
+    ? firstChildElement(freshMainSeq, qname('p', 'childTnLst', NS.pml))
+    : null;
+  const newPar = freshChildTnLst
+    ? freshChildTnLst.children.find((c): c is XmlElement => c.kind === 'element' && isPml(c, 'par'))
+    : null;
+  const freshBldP = findDescendant(fresh, (e) => isPml(e, 'bldP'));
+  if (!newPar || !freshBldP) return false;
+
+  const offset = maxCTnId(existing) - 2; // fresh effect ids start at 3
+  if (offset > 0) shiftCTnIds(newPar, offset);
+
+  // Group the build with its effect under a fresh grpId so PowerPoint renders
+  // each shape's effect independently. Use max-existing-grpId + 1 (not a count)
+  // because a template's authored build grpIds need not be the contiguous
+  // 0..n-1 sequence — PowerPoint can leave gaps after a delete/reorder, and a
+  // count would then collide with an existing group.
+  const newGrpId = String(maxGrpId(existing) + 1);
+  const effectCTn = findDescendant(
+    newPar,
+    (e) => getAttrValue(e, qname('', 'presetID', '')) !== null,
+  );
+  if (effectCTn) setGrpId(effectCTn, newGrpId);
+  setGrpId(freshBldP, newGrpId);
+
+  existingMainSeqChildTnLst.children.push(newPar);
+  const existingBldLst = findDescendant(existing, (e) => isPml(e, 'bldLst'));
+  if (existingBldLst) existingBldLst.children.push(freshBldP);
+  else existing.children.push(elem(qname('p', 'bldLst', NS.pml), { children: [freshBldP] }));
+  return true;
+};
+
 /**
  * Sets a single click-triggered animation effect on the given shape.
- * Replaces any existing `<p:timing>` block on the slide — v1 supports
- * exactly one effect per slide. Calling this on a second shape replaces
- * the first.
+ *
+ * The effect is *merged* into any existing `<p:timing>` on the slide rather
+ * than replacing it: animating a second shape (or re-running on a template that
+ * already has authored animations) preserves the existing effects and appends
+ * this one as the next click stop, with cTn ids renumbered to stay unique. To
+ * clear every animation first, call `clearSlideAnimations`.
  *
  * Supported `effect` tokens:
  *
@@ -65,10 +199,19 @@ const insertTimingAtEnd = (slide: SlideData, timing: XmlElement): void => {
  */
 export const setShapeAnimation = (shape: SlideShapeData, opts: AnimationOptions): void => {
   const slide = shape[SHAPE_SLIDE];
-  removeExistingTiming(slide);
   const spid = shape[SHAPE_SNAPSHOT].id;
-  const timing = buildSingleEffectTiming(spid, opts);
-  insertTimingAtEnd(slide, timing);
+  const fresh = buildSingleEffectTiming(spid, opts);
+  const existing = findTiming(slide);
+  if (existing === null) {
+    insertTimingAtEnd(slide, fresh);
+  } else if (!mergeEffectInto(existing, fresh)) {
+    // A timing tree we don't know how to extend (no mainSeq). Leave it intact
+    // rather than silently destroying authored animations.
+    throw new Error(
+      'setShapeAnimation: the slide already has an animation timing tree this single-effect ' +
+        'API cannot safely extend. Call clearSlideAnimations(slide) first to reset it.',
+    );
+  }
   commitSlideData(slide);
   refreshSlideData(slide);
 };

--- a/src/api/fn/shape-authoring.ts
+++ b/src/api/fn/shape-authoring.ts
@@ -72,7 +72,9 @@ export const addSlideShape = (
     w: Emu;
     h: Emu;
     text?: string;
-    textAnchor?: 'l' | 'ctr' | 'r' | 't' | 'b';
+    /** Vertical text anchor (`t` / `ctr` / `b`). Horizontal alignment is set
+     * separately via `setShapeAlignment` / `setParagraphAlignment`. */
+    textAnchor?: 'ctr' | 't' | 'b';
     name?: string;
   },
 ): SlideShapeData => {

--- a/src/api/fn/shape-image-effects.ts
+++ b/src/api/fn/shape-image-effects.ts
@@ -501,122 +501,115 @@ export const getShapeImageCrop = (shape: SlideShapeData): ImageCrop | null => {
   };
 };
 
+// Brightness and contrast are two attributes of a SINGLE `<a:lum>` effect
+// (CT_LuminanceEffect: `bright` / `contrast`, both ST_FixedPercentage ×100000).
+// `<a:lumOff>` / `<a:lumMod>` are color-transform children — they are NOT in
+// the CT_Blip effect choice, so emitting them under `<a:blip>` is schema-invalid.
+// Both setters share the one element: writing one attribute preserves the
+// other, and removing the last attribute drops the `<a:lum>` element entirely.
+const NAME_LUM = qname('a', 'lum', NS.dml);
+
+const requirePictureBlip = (shape: SlideShapeData, fnName: string): XmlElement => {
+  if (shape[SHAPE_SNAPSHOT].kind !== 'picture') {
+    throw new Error(
+      `${fnName} only works on picture shapes; ${shape[SHAPE_SNAPSHOT].kind} is not one`,
+    );
+  }
+  const blipFill = firstChildElement(shape[SHAPE_ELEMENT], qname('p', 'blipFill', NS.pml));
+  if (!blipFill) throw new Error('picture has no <p:blipFill>');
+  const blip = firstChildElement(blipFill, qname('a', 'blip', NS.dml));
+  if (!blip) throw new Error('picture <p:blipFill> has no <a:blip>');
+  return blip;
+};
+
+const setLumAttr = (blip: XmlElement, local: 'bright' | 'contrast', value: number | null): void => {
+  let lum = firstChildElement(blip, NAME_LUM);
+  if (lum) {
+    lum.attrs = lum.attrs.filter(
+      (a) => !(a.name.namespaceURI === '' && a.name.localName === local),
+    );
+  }
+  if (value !== null && value !== 0) {
+    // `<a:lum>` is part of CT_Blip's unbounded effect choice, so its position
+    // among sibling effects (e.g. alphaModFix) is unconstrained — append.
+    if (!lum) {
+      lum = elem(NAME_LUM);
+      blip.children.push(lum);
+    }
+    lum.attrs.push(attr(qname('', local, ''), String(Math.round(value * 100000))));
+  }
+  if (lum && lum.attrs.length === 0) {
+    blip.children = blip.children.filter((c) => c !== lum);
+  }
+};
+
+const getLumAttr = (shape: SlideShapeData, local: 'bright' | 'contrast'): number | null => {
+  if (shape[SHAPE_SNAPSHOT].kind !== 'picture') return null;
+  const blipFill = firstChildElement(shape[SHAPE_ELEMENT], qname('p', 'blipFill', NS.pml));
+  if (!blipFill) return null;
+  const blip = firstChildElement(blipFill, qname('a', 'blip', NS.dml));
+  if (!blip) return null;
+  const lum = firstChildElement(blip, NAME_LUM);
+  if (!lum) return null;
+  const v = getAttrValue(lum, qname('', local, ''));
+  if (v === null) return null;
+  const n = Number.parseInt(v, 10);
+  return Number.isFinite(n) ? n / 100000 : null;
+};
+
 /**
- * Adjusts the picture's brightness by writing `<a:lumOff val="…"/>`
- * inside `<a:blip>`. The value is a -1..1 fraction:
+ * Adjusts the picture's brightness via `<a:blip><a:lum bright="…"/>`. The value
+ * is a -1..1 fraction:
  *
  *   - `1`     → +100% brightness
- *   - `0` or `null` → no offset (any prior `<a:lumOff>` is removed)
+ *   - `0` or `null` → no brightness change (the `bright` attribute is removed)
  *   - `-1`    → -100% brightness
  *
- * Throws for non-picture shapes and on values outside [-1, 1].
- *
- * Note: PowerPoint's "Picture Format › Corrections" UI couples this
- * with `<a:lumMod>` for some presets; this primitive sets only
- * `lumOff` to keep the surface honest. Read it back via
- * `getShapeImageBrightness`.
+ * Brightness and contrast share the one `<a:lum>` element, so setting one keeps
+ * the other. Throws for non-picture shapes and on values outside [-1, 1].
  */
 export const setShapeImageBrightness = (shape: SlideShapeData, value: number | null): void => {
-  if (shape[SHAPE_SNAPSHOT].kind !== 'picture') {
-    throw new Error(
-      `setShapeImageBrightness only works on picture shapes; ${shape[SHAPE_SNAPSHOT].kind} is not one`,
-    );
+  const blip = requirePictureBlip(shape, 'setShapeImageBrightness');
+  if (value !== null && value !== 0 && (!Number.isFinite(value) || value < -1 || value > 1)) {
+    throw new RangeError(`brightness must be in [-1, 1], got ${value}`);
   }
-  const blipFill = firstChildElement(shape[SHAPE_ELEMENT], qname('p', 'blipFill', NS.pml));
-  if (!blipFill) throw new Error('picture has no <p:blipFill>');
-  const blip = firstChildElement(blipFill, qname('a', 'blip', NS.dml));
-  if (!blip) throw new Error('picture <p:blipFill> has no <a:blip>');
-  blip.children = blip.children.filter(
-    (c) =>
-      !(c.kind === 'element' && c.name.namespaceURI === NS.dml && c.name.localName === 'lumOff'),
-  );
-  if (value !== null && value !== 0) {
-    if (!Number.isFinite(value) || value < -1 || value > 1) {
-      throw new RangeError(`brightness must be in [-1, 1], got ${value}`);
-    }
-    blip.children.push(
-      elem(qname('a', 'lumOff', NS.dml), {
-        attrs: [attr(qname('', 'val', ''), String(Math.round(value * 100000)))],
-      }),
-    );
-  }
+  setLumAttr(blip, 'bright', value);
   commitAndRefresh(shape);
 };
 
 /**
- * Adjusts the picture's contrast by writing `<a:lumMod val="…"/>` on
- * `<a:blip>`. The value is a 0..2 fraction:
+ * Adjusts the picture's contrast via `<a:blip><a:lum contrast="…"/>`. The value
+ * is a -1..1 fraction (ECMA-376 `ST_FixedPercentage`):
  *
- *   - `1` or `null` → no modulation (any prior `<a:lumMod>` is removed)
- *   - `0.5`         → 50% of original luminance variance (washed out)
- *   - `1.5`         → 150% (boosted contrast; PowerPoint clamps to
- *                       what the renderer supports)
+ *   - `0` or `null` → no contrast change (the `contrast` attribute is removed)
+ *   - `0.5`         → +50% contrast (boosted)
+ *   - `-0.5`        → -50% contrast (washed out)
  *
- * Throws on non-picture shapes and on values outside `[0, 2]`. The
- * primitive maps directly to `ST_PositiveFixedPercentage` × 100000.
+ * Brightness and contrast share the one `<a:lum>` element, so setting one keeps
+ * the other. Throws on non-picture shapes and on values outside [-1, 1].
  */
 export const setShapeImageContrast = (shape: SlideShapeData, value: number | null): void => {
-  if (shape[SHAPE_SNAPSHOT].kind !== 'picture') {
-    throw new Error(
-      `setShapeImageContrast only works on picture shapes; ${shape[SHAPE_SNAPSHOT].kind} is not one`,
-    );
+  const blip = requirePictureBlip(shape, 'setShapeImageContrast');
+  if (value !== null && value !== 0 && (!Number.isFinite(value) || value < -1 || value > 1)) {
+    throw new RangeError(`contrast must be in [-1, 1], got ${value}`);
   }
-  const blipFill = firstChildElement(shape[SHAPE_ELEMENT], qname('p', 'blipFill', NS.pml));
-  if (!blipFill) throw new Error('picture has no <p:blipFill>');
-  const blip = firstChildElement(blipFill, qname('a', 'blip', NS.dml));
-  if (!blip) throw new Error('picture <p:blipFill> has no <a:blip>');
-  blip.children = blip.children.filter(
-    (c) =>
-      !(c.kind === 'element' && c.name.namespaceURI === NS.dml && c.name.localName === 'lumMod'),
-  );
-  if (value !== null && value !== 1) {
-    if (!Number.isFinite(value) || value < 0 || value > 2) {
-      throw new RangeError(`contrast must be in [0, 2], got ${value}`);
-    }
-    blip.children.push(
-      elem(qname('a', 'lumMod', NS.dml), {
-        attrs: [attr(qname('', 'val', ''), String(Math.round(value * 100000)))],
-      }),
-    );
-  }
+  setLumAttr(blip, 'contrast', value);
   commitAndRefresh(shape);
 };
 
 /**
- * Reads the picture's contrast modulation (the `<a:lumMod>` fraction
- * in [0, 2]). Returns `null` when no `<a:lumMod>` is present.
+ * Reads the picture's contrast (the `<a:lum contrast>` fraction in [-1, 1]).
+ * Returns `null` when no contrast adjustment is present.
  */
-export const getShapeImageContrast = (shape: SlideShapeData): number | null => {
-  if (shape[SHAPE_SNAPSHOT].kind !== 'picture') return null;
-  const blipFill = firstChildElement(shape[SHAPE_ELEMENT], qname('p', 'blipFill', NS.pml));
-  if (!blipFill) return null;
-  const blip = firstChildElement(blipFill, qname('a', 'blip', NS.dml));
-  if (!blip) return null;
-  const lumMod = firstChildElement(blip, qname('a', 'lumMod', NS.dml));
-  if (!lumMod) return null;
-  const v = getAttrValue(lumMod, qname('', 'val', ''));
-  if (v === null) return null;
-  const n = Number.parseInt(v, 10);
-  return Number.isFinite(n) ? n / 100000 : null;
-};
+export const getShapeImageContrast = (shape: SlideShapeData): number | null =>
+  getLumAttr(shape, 'contrast');
 
 /**
- * Reads the picture's brightness offset (the `<a:lumOff>` fraction
- * in [-1, 1]). Returns `null` when no `<a:lumOff>` is present.
+ * Reads the picture's brightness (the `<a:lum bright>` fraction in [-1, 1]).
+ * Returns `null` when no brightness adjustment is present.
  */
-export const getShapeImageBrightness = (shape: SlideShapeData): number | null => {
-  if (shape[SHAPE_SNAPSHOT].kind !== 'picture') return null;
-  const blipFill = firstChildElement(shape[SHAPE_ELEMENT], qname('p', 'blipFill', NS.pml));
-  if (!blipFill) return null;
-  const blip = firstChildElement(blipFill, qname('a', 'blip', NS.dml));
-  if (!blip) return null;
-  const lumOff = firstChildElement(blip, qname('a', 'lumOff', NS.dml));
-  if (!lumOff) return null;
-  const v = getAttrValue(lumOff, qname('', 'val', ''));
-  if (v === null) return null;
-  const n = Number.parseInt(v, 10);
-  return Number.isFinite(n) ? n / 100000 : null;
-};
+export const getShapeImageBrightness = (shape: SlideShapeData): number | null =>
+  getLumAttr(shape, 'bright');
 
 export const setShapeImageOpacity = (shape: SlideShapeData, opacity: number | null): void => {
   if (shape[SHAPE_SNAPSHOT].kind !== 'picture') {

--- a/src/api/fn/shape-runs.ts
+++ b/src/api/fn/shape-runs.ts
@@ -16,6 +16,7 @@ import {
   elem,
   firstChildElement,
   getAttrValue,
+  insertChildByRank,
   qname,
 } from '../../internal/xml/index.ts';
 import {
@@ -518,6 +519,30 @@ export const getParagraphLevel = (shape: SlideShapeData, paragraphIndex: number)
   return Number.isFinite(n) ? n : 0;
 };
 
+// CT_TextParagraphProperties (a:pPr) is an xsd:sequence: line spacing, then
+// before/after spacing, then the bullet-related groups, then tabLst/defRPr.
+// Setters strip their element then re-insert at the mandated slot.
+const PPR_CHILD_RANK: Record<string, number> = {
+  lnSpc: 0,
+  spcBef: 1,
+  spcAft: 2,
+  buClrTx: 3,
+  buClr: 3,
+  buSzTx: 4,
+  buSzPct: 4,
+  buSzPts: 4,
+  buFontTx: 5,
+  buFont: 5,
+  buNone: 6,
+  buAutoNum: 6,
+  buChar: 6,
+  tabLst: 7,
+  defRPr: 8,
+  extLst: 9,
+};
+const pPrChildRank = (el: XmlElement): number =>
+  el.name.namespaceURI === NS.dml ? (PPR_CHILD_RANK[el.name.localName] ?? 99) : 99;
+
 /**
  * Sets the spacing before and/or after a paragraph, in points (where
  * a "point" is 1/72 inch). PowerPoint stores these as hundredths of a
@@ -554,7 +579,10 @@ export const setParagraphSpacing = (
         }),
       ],
     });
-    pPr.children.push(spcEl);
+    // spcBef/spcAft must precede any bullet (buChar/buAutoNum/buFont/...) and
+    // tabLst/defRPr in CT_TextParagraphProperties; insert at the schema slot
+    // rather than pushing to the end of a paragraph that already has bullets.
+    insertChildByRank(pPr, spcEl, pPrChildRank);
   };
 
   writeSide('spcBef', opts.beforePts);
@@ -662,6 +690,51 @@ export const getParagraphLineSpacing = (
     }
   }
   return null;
+};
+
+/**
+ * Sets a paragraph's line spacing — the writer counterpart to
+ * `getParagraphLineSpacing`. Two modes (mirroring `<a:lnSpc>`):
+ *
+ *   - `{ kind: 'pct', value }` — a multiple of single spacing
+ *     (`1` = single, `1.5` = 150%, `2` = double) → `<a:spcPct>`.
+ *   - `{ kind: 'pts', value }` — a fixed leading in points → `<a:spcPts>`.
+ *
+ * Pass `null` to clear the override (the paragraph then inherits line
+ * spacing from the layout / master).
+ */
+export const setParagraphLineSpacing = (
+  shape: SlideShapeData,
+  paragraphIndex: number,
+  spacing:
+    | { readonly kind: 'pct'; readonly value: number }
+    | { readonly kind: 'pts'; readonly value: number }
+    | null,
+): void => {
+  const paragraph = requireParagraph(shape, paragraphIndex);
+  const pPr = ensurePPr(paragraph);
+  pPr.children = pPr.children.filter(
+    (c) =>
+      !(c.kind === 'element' && c.name.namespaceURI === NS.dml && c.name.localName === 'lnSpc'),
+  );
+  if (spacing !== null) {
+    if (!Number.isFinite(spacing.value) || spacing.value < 0) {
+      throw new RangeError(
+        `line spacing value must be a non-negative number, got ${spacing.value}`,
+      );
+    }
+    const inner =
+      spacing.kind === 'pct'
+        ? elem(qname('a', 'spcPct', NS.dml), {
+            attrs: [attr(qname('', 'val', ''), String(Math.round(spacing.value * 100000)))],
+          })
+        : elem(qname('a', 'spcPts', NS.dml), {
+            attrs: [attr(qname('', 'val', ''), String(Math.round(spacing.value * 100)))],
+          });
+    // <a:lnSpc> is the first child of CT_TextParagraphProperties.
+    insertChildByRank(pPr, elem(qname('a', 'lnSpc', NS.dml), { children: [inner] }), pPrChildRank);
+  }
+  commitAndRefresh(shape);
 };
 
 /**

--- a/src/api/fn/shape-text.ts
+++ b/src/api/fn/shape-text.ts
@@ -15,6 +15,12 @@ import {
   applyFormatToAllRuns,
   setTextBody,
 } from '../../internal/drawingml/index.ts';
+import {
+  angle60000,
+  emuCoordinate32,
+  emuPositiveCoordinate32,
+  textColumnCount,
+} from '../../internal/bounds.ts';
 import { partName, resolveTarget } from '../../internal/opc/index.ts';
 import { REL_TYPES, readShapeTreeFromCsldRoot } from '../../internal/presentationml/index.ts';
 import {
@@ -299,8 +305,8 @@ export const getShapeTextColumns = (
  * Sets the multi-column layout on the shape's text body — writes
  * `<a:bodyPr numCol="N" [spcCol="EMU"]/>`. Pass `null` to clear both
  * attributes so the text body falls back to PowerPoint's default
- * single column. `count` must be `>= 2` (PowerPoint clamps higher
- * values silently; OOXML allows up to 16). `gapEmu`, when omitted,
+ * single column. `count` must be in `2..16` (ST_TextColumnCount caps at
+ * 16, and single column is the `null` default). `gapEmu`, when omitted,
  * removes any prior `spcCol`. Throws for non-text-bearing shape kinds.
  */
 export const setShapeTextColumns = (
@@ -321,9 +327,12 @@ export const setShapeTextColumns = (
         `setShapeTextColumns: count must be >= 2 (single column is the default — pass null instead). Got ${columns.count}.`,
       );
     }
-    bodyPr.attrs.push(attr(qname('', 'numCol', ''), String(columns.count)));
+    // ST_TextColumnCount caps at 16; spcCol is ST_PositiveCoordinate32.
+    const numCol = textColumnCount(columns.count, 'setShapeTextColumns: count');
+    bodyPr.attrs.push(attr(qname('', 'numCol', ''), String(numCol)));
     if (columns.gapEmu !== undefined) {
-      bodyPr.attrs.push(attr(qname('', 'spcCol', ''), String(Math.round(columns.gapEmu))));
+      const spcCol = emuPositiveCoordinate32(columns.gapEmu, 'setShapeTextColumns: gapEmu');
+      bodyPr.attrs.push(attr(qname('', 'spcCol', ''), String(spcCol)));
     }
   }
   commitAndRefresh(shape);
@@ -370,7 +379,9 @@ export const setShapeTextBodyRotationDeg = (
     (a) => !(a.name.namespaceURI === '' && a.name.localName === 'rot'),
   );
   if (rotationDeg !== null && rotationDeg !== 0) {
-    bodyPr.attrs.push(attr(qname('', 'rot', ''), String(Math.round(rotationDeg * 60000))));
+    // `rot` is ST_Angle in 1/60000 degree (xsd:int); guard the *60000 overflow.
+    const rot = angle60000(rotationDeg * 60000, 'setShapeTextBodyRotationDeg: rotationDeg');
+    bodyPr.attrs.push(attr(qname('', 'rot', ''), String(rot)));
   }
   commitAndRefresh(shape);
 };
@@ -630,7 +641,9 @@ export const setShapeTextMargins = (
     (a) => !(a.name.namespaceURI === '' && localsToClear.has(a.name.localName)),
   );
   for (const w of writes) {
-    bodyPr.attrs.push(attr(qname('', w.name, ''), String(Math.round(w.value))));
+    // Insets are ST_Coordinate32 (xsd:int EMU).
+    const emu = emuCoordinate32(w.value, `setShapeTextMargins: ${w.name}`);
+    bodyPr.attrs.push(attr(qname('', w.name, ''), String(emu)));
   }
   commitAndRefresh(shape);
 };

--- a/src/api/fn/slide-deck.ts
+++ b/src/api/fn/slide-deck.ts
@@ -541,6 +541,40 @@ export const duplicateSlideAt = (
   return slides[clamped]!;
 };
 
+// Collects every relationship id referenced (r:id / r:embed / r:link) anywhere
+// in `el`'s subtree. Relationship-typed attributes live in the officeDocRels
+// namespace regardless of local name.
+const collectRelRefs = (el: XmlElement, into: Set<string>): void => {
+  for (const a of el.attrs) {
+    if (a.name.namespaceURI === NS.officeDocRels) into.add(a.value);
+  }
+  for (const c of el.children) {
+    if (c.kind === 'element') collectRelRefs(c, into);
+  }
+};
+
+// importSlide copies the body verbatim but only carries image + hyperlink rels
+// across (charts / diagrams / OLE are dropped in v1). A `<p:graphicFrame>` that
+// still points at a dropped rel would be a dangling r:id — PowerPoint reports
+// the whole package corrupt. Drop those frames so the imported slide stays valid
+// (a chart-less slide is the documented v1 behavior). Recurses through groups.
+const pruneDanglingGraphicFrames = (el: XmlElement, keptRelIds: Set<string>): void => {
+  el.children = el.children.filter((c) => {
+    if (c.kind !== 'element') return true;
+    if (c.name.namespaceURI === NS.pml && c.name.localName === 'graphicFrame') {
+      const refs = new Set<string>();
+      collectRelRefs(c, refs);
+      for (const id of refs) {
+        if (!keptRelIds.has(id)) return false;
+      }
+    }
+    return true;
+  });
+  for (const c of el.children) {
+    if (c.kind === 'element') pruneDanglingGraphicFrames(c, keptRelIds);
+  }
+};
+
 /**
  * Imports a slide from another presentation into `targetPres`. The
  * slide's part bytes are copied verbatim; image rels are followed and
@@ -591,15 +625,19 @@ export const importSlide = (
   if (targetPkg.getPart(layoutPartName) === null) {
     throw new Error(`importSlide: layout ${layoutPartName} not in target package`);
   }
+  // The copied slide body keeps its original `r:embed` / `r:link` ids, so image
+  // and hyperlink rels are preserved verbatim below. The layout rel is NOT
+  // referenced from the body (PowerPoint resolves it by relationship type), so
+  // we can give it any id — but it must not collide with a preserved source id.
+  // Allocating past the source max keeps every rId on the new slide unique.
+  const layoutRelId = nextRelId(sourceRels?.items.map((r) => r.id) ?? []);
   newRels.items.push({
-    id: 'rId1',
+    id: layoutRelId,
     type: REL_TYPES.slideLayout,
     target: `../slideLayouts/${basename(layoutPartName)}`,
     targetMode: 'Internal',
   });
 
-  // Map from source rId → new rId so we can rewrite blip references later
-  // (skipped in v1; we just preserve original rId values when possible).
   if (sourceRels !== null) {
     for (const rel of sourceRels.items) {
       if (rel.type === REL_TYPES.slideLayout) continue; // handled above
@@ -641,6 +679,30 @@ export const importSlide = (
     }
   }
   targetPkg.setRels(newSlidePartName, newRels);
+
+  // The verbatim body may still reference a dropped rel (e.g. a chart frame's
+  // `<c:chart r:id="rId2"/>`). Strip any graphicFrame whose r:id is no longer in
+  // the slide's rels so we never emit a dangling relationship. Only re-serialize
+  // when there is actually a dangling reference, to keep the common (frame-less)
+  // import byte-for-byte identical.
+  const newPart = targetPkg.getPart(newSlidePartName);
+  if (newPart) {
+    const keptRelIds = new Set(newRels.items.map((r) => r.id));
+    const bodyDoc = parseXml(decode(newPart.data));
+    const bodyRefs = new Set<string>();
+    collectRelRefs(bodyDoc.root, bodyRefs);
+    let hasDangling = false;
+    for (const id of bodyRefs) {
+      if (!keptRelIds.has(id)) {
+        hasDangling = true;
+        break;
+      }
+    }
+    if (hasDangling) {
+      pruneDanglingGraphicFrames(bodyDoc.root, keptRelIds);
+      newPart.data = encode(serializeXml(bodyDoc));
+    }
+  }
 
   // presentation → slide rel + sldIdLst entry.
   const presRels = targetPkg.getRels(PRES_PART_NAME) ?? emptyRels();

--- a/src/api/fn/tables.ts
+++ b/src/api/fn/tables.ts
@@ -21,6 +21,7 @@ import {
   elem,
   firstChildElement,
   getAttrValue,
+  insertChildByRank,
   qname,
   text,
 } from '../../internal/xml/index.ts';
@@ -38,6 +39,7 @@ import {
   type SlideShapeData,
   type TableCellData,
 } from '../_internal-symbols.ts';
+import { emuCoordinate32, emuExtent, lineWidthEmu, normalizeGuid } from '../../internal/bounds.ts';
 import { commitSlideData, refreshSlideData } from './_helpers.ts';
 import { type ShapeParagraphElement, readParagraphElements } from './shape-runs.ts';
 import { ALIGN_TOKEN_MAP } from './shape-paragraph.ts';
@@ -193,7 +195,10 @@ export const setTableStyleId = (table: SlideShapeData, styleId: string | null): 
       ),
   );
   if (styleId !== null) {
-    tblPr.children.push(elem(qname('a', 'tableStyleId', NS.dml), { children: [text(styleId)] }));
+    // ST_Guid requires uppercase hex in braces; normalize so a lowercase GUID
+    // (e.g. from crypto.randomUUID) is accepted, and reject non-GUID strings.
+    const guid = normalizeGuid(styleId, 'setTableStyleId: styleId');
+    tblPr.children.push(elem(qname('a', 'tableStyleId', NS.dml), { children: [text(guid)] }));
   }
   commitSlideData(table[SHAPE_SLIDE]);
   refreshSlideData(table[SHAPE_SLIDE]);
@@ -391,7 +396,7 @@ export const setTableColumnWidth = (table: SlideShapeData, col: number, width: E
   target.attrs = target.attrs.filter(
     (a) => !(a.name.namespaceURI === '' && a.name.localName === 'w'),
   );
-  target.attrs.push(attr(ATTR_W_TBL, String(Math.round(width))));
+  target.attrs.push(attr(ATTR_W_TBL, String(emuExtent(width, 'setTableColumnWidth: width'))));
   commitSlideData(table[SHAPE_SLIDE]);
   refreshSlideData(table[SHAPE_SLIDE]);
 };
@@ -409,7 +414,7 @@ export const setTableRowHeight = (table: SlideShapeData, row: number, height: Em
   target.attrs = target.attrs.filter(
     (a) => !(a.name.namespaceURI === '' && a.name.localName === 'h'),
   );
-  target.attrs.push(attr(ATTR_H_TBL, String(Math.round(height))));
+  target.attrs.push(attr(ATTR_H_TBL, String(emuExtent(height, 'setTableRowHeight: height'))));
   commitSlideData(table[SHAPE_SLIDE]);
   refreshSlideData(table[SHAPE_SLIDE]);
 };
@@ -631,6 +636,10 @@ export const mergeTableCells = (
  * when the border is inherited / un-styled.
  */
 export interface TableCellBorder {
+  // Read contract: `getTableCellBorders` always populates all three (each is the
+  // concrete value or `null` when un-styled). The setter takes a `Partial` of
+  // this (see `setTableCellBorders`), so authoring `{ color, widthEmu }` without
+  // `dash` is allowed without widening what reads return.
   readonly color: string | null;
   readonly widthEmu: number | null;
   readonly dash: string | null;
@@ -703,10 +712,34 @@ const BORDER_SIDE_LOCALS = {
   blToTr: 'lnBlToTr',
 } as const;
 
+// CT_TableCellProperties (a:tcPr) is an xsd:sequence: the six border lines
+// (lnL/lnR/lnT/lnB/lnTlToBr/lnBlToTr), then cell3D, then the fill choice, then
+// headers, then extLst. Border setters must drop their element at the mandated
+// slot, or styling a cell's fill before its borders emits invalid order.
+const TCPR_CHILD_RANK: Record<string, number> = {
+  lnL: 0,
+  lnR: 1,
+  lnT: 2,
+  lnB: 3,
+  lnTlToBr: 4,
+  lnBlToTr: 5,
+  cell3D: 6,
+  noFill: 7,
+  solidFill: 7,
+  gradFill: 7,
+  blipFill: 7,
+  pattFill: 7,
+  grpFill: 7,
+  headers: 8,
+  extLst: 9,
+};
+const tcPrChildRank = (el: XmlElement): number =>
+  el.name.namespaceURI === NS.dml ? (TCPR_CHILD_RANK[el.name.localName] ?? 99) : 99;
+
 const writeBorderLn = (
   tcPr: XmlElement,
   local: 'lnL' | 'lnR' | 'lnT' | 'lnB' | 'lnTlToBr' | 'lnBlToTr',
-  border: TableCellBorder | null,
+  border: Partial<TableCellBorder> | null,
 ): void => {
   // Strip any prior side first.
   tcPr.children = tcPr.children.filter(
@@ -715,7 +748,8 @@ const writeBorderLn = (
   if (border === null) return;
   const lnAttrs = [];
   if (border.widthEmu !== null && border.widthEmu !== undefined) {
-    lnAttrs.push(attr(qname('', 'w', ''), String(Math.round(border.widthEmu))));
+    const w = lineWidthEmu(border.widthEmu, 'setTableCellBorders: widthEmu');
+    lnAttrs.push(attr(qname('', 'w', ''), String(w)));
   }
   const children: XmlElement[] = [];
   if (border.color !== null && border.color !== undefined) {
@@ -728,7 +762,11 @@ const writeBorderLn = (
       elem(qname('a', 'prstDash', NS.dml), { attrs: [attr(qname('', 'val', ''), border.dash)] }),
     );
   }
-  tcPr.children.push(elem(qname('a', local, NS.dml), { attrs: lnAttrs, children }));
+  insertChildByRank(
+    tcPr,
+    elem(qname('a', local, NS.dml), { attrs: lnAttrs, children }),
+    tcPrChildRank,
+  );
 };
 
 /**
@@ -743,12 +781,12 @@ const writeBorderLn = (
 export const setTableCellBorders = (
   cell: TableCellData,
   sides: {
-    left?: TableCellBorder | null;
-    right?: TableCellBorder | null;
-    top?: TableCellBorder | null;
-    bottom?: TableCellBorder | null;
-    tlToBr?: TableCellBorder | null;
-    blToTr?: TableCellBorder | null;
+    left?: Partial<TableCellBorder> | null;
+    right?: Partial<TableCellBorder> | null;
+    top?: Partial<TableCellBorder> | null;
+    bottom?: Partial<TableCellBorder> | null;
+    tlToBr?: Partial<TableCellBorder> | null;
+    blToTr?: Partial<TableCellBorder> | null;
   } | null,
 ): void => {
   const tcPr = ensureCellTcPr(cell);
@@ -916,7 +954,8 @@ export const setTableCellMargins = (
     ];
     for (const [name, val] of pairs) {
       if (val !== null && val !== undefined) {
-        tcPr.attrs.push(attr(qname('', name, ''), String(Math.round(val))));
+        const emu = emuCoordinate32(val, `setTableCellMargins: ${name}`);
+        tcPr.attrs.push(attr(qname('', name, ''), String(emu)));
       }
     }
   }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -470,6 +470,7 @@ export {
   setParagraphAlignment,
   setParagraphBullet,
   setParagraphLevel,
+  setParagraphLineSpacing,
   setParagraphSpacing,
   setShapePosition,
   setShapeRotation,

--- a/src/internal/bounds.ts
+++ b/src/internal/bounds.ts
@@ -1,0 +1,120 @@
+// ECMA-376 simple-type numeric/string bounds, enforced at the authoring boundary.
+//
+// A recurring defect class in a typed OOXML writer: a caller-supplied number is
+// rounded and serialized straight into a constrained attribute (a coordinate, a
+// line width, a font size, a duration, a percentage, an angle), and a value
+// outside the schema's range produces a `.pptx` that PowerPoint marks corrupt
+// and "repairs". Authoring input is an external boundary (per the project's
+// defensive-programming rule: validate at boundaries, trust internally), so the
+// value is checked HERE, once, before it reaches the wire. An out-of-range value
+// is a caller error and throws `RangeError` naming the field and the allowed
+// range — it is never silently clamped (that would hide the mistake) nor emitted.
+//
+// Leaf module: no imports, so any layer (drawingml / presentationml / chartml)
+// may use it. The ranges below are transcribed from the ECMA-376 XSDs; the
+// comment on each names the simple type so the next reader can verify it.
+
+const RANGES = {
+  coordinate: [-27273042329600, 27273042316900], // ST_Coordinate (EMU, xsd:long)
+  positiveCoordinate: [0, 27273042316900], // ST_PositiveCoordinate
+  coordinate32: [-2147483648, 2147483647], // ST_Coordinate32 (xsd:int)
+  positiveCoordinate32: [0, 2147483647], // ST_PositiveCoordinate32
+  lineWidth: [0, 20116800], // ST_LineWidth
+  angle: [-2147483648, 2147483647], // ST_Angle (1/60000 degree, xsd:int)
+  fontSize: [100, 400000], // ST_TextFontSize (1/100 pt → 1..4000 pt)
+  textPoint: [-400000, 400000], // ST_TextPoint (1/100 pt)
+  textSpacingPoint: [0, 158400], // ST_TextSpacingPoint (1/100 pt)
+  unsignedInt: [0, 4294967295], // xsd:unsignedInt (advTm; ST_TLTime numeric form)
+  columnCount: [1, 16], // ST_TextColumnCount
+  overlap: [-100, 100], // ST_OverlapByte (bar/column overlap %)
+  // ST_GapAmount unions ST_GapAmountPercent and ST_GapAmountUShort; both cap at
+  // 500 (we emit the numeric/UShort form). The earlier 65535 was the raw
+  // xsd:unsignedShort domain, not the schema's maxInclusive — values 501..65535
+  // serialized to a `<c:gapWidth>` PowerPoint rejects.
+  gapAmount: [0, 500], // ST_GapAmountUShort (bar/column gap width %)
+  holeSize: [1, 90], // ST_HoleSizeUByte (doughnut hole %)
+  firstSliceAng: [0, 360], // ST_FirstSliceAng (pie/doughnut start angle, degrees)
+} as const;
+
+type RangeKey = keyof typeof RANGES;
+
+// Validates `value` as an integer in the named ECMA-376 range, returning the
+// rounded integer. Non-finite or out-of-range input throws.
+export const boundedInt = (value: number, key: RangeKey, field: string): number => {
+  if (!Number.isFinite(value)) {
+    throw new RangeError(`${field}: expected a finite number, got ${value}`);
+  }
+  const n = Math.round(value);
+  const [min, max] = RANGES[key];
+  if (n < min || n > max) {
+    throw new RangeError(`${field}: ${value} is out of range for ${key} (${min}..${max})`);
+  }
+  return n;
+};
+
+/** EMU position coordinate (`<a:off>` x/y) — ST_Coordinate. */
+export const emuCoordinate = (v: number, field: string): number =>
+  boundedInt(v, 'coordinate', field);
+/** EMU extent (`<a:ext>` cx/cy, column/table widths, row heights) — ST_PositiveCoordinate. */
+export const emuExtent = (v: number, field: string): number =>
+  boundedInt(v, 'positiveCoordinate', field);
+/** 32-bit EMU (text-body insets, cell margins) — ST_Coordinate32. */
+export const emuCoordinate32 = (v: number, field: string): number =>
+  boundedInt(v, 'coordinate32', field);
+/** Non-negative 32-bit EMU (column gap) — ST_PositiveCoordinate32. */
+export const emuPositiveCoordinate32 = (v: number, field: string): number =>
+  boundedInt(v, 'positiveCoordinate32', field);
+/** Line width in EMU — ST_LineWidth. */
+export const lineWidthEmu = (v: number, field: string): number => boundedInt(v, 'lineWidth', field);
+/** Angle in 1/60000 degree — ST_Angle. */
+export const angle60000 = (v: number, field: string): number => boundedInt(v, 'angle', field);
+/** Font size in 1/100 pt — ST_TextFontSize. */
+export const fontSizeHundredthPt = (v: number, field: string): number =>
+  boundedInt(v, 'fontSize', field);
+/** Character spacing in 1/100 pt — ST_TextPoint. */
+export const textPointSpacing = (v: number, field: string): number =>
+  boundedInt(v, 'textPoint', field);
+/** Paragraph spacing in 1/100 pt — ST_TextSpacingPoint. */
+export const textSpacingPoint = (v: number, field: string): number =>
+  boundedInt(v, 'textSpacingPoint', field);
+/** Auto-advance / timing duration in ms — xsd:unsignedInt. */
+export const unsignedIntMs = (v: number, field: string): number =>
+  boundedInt(v, 'unsignedInt', field);
+/** Text column count — ST_TextColumnCount (1..16). */
+export const textColumnCount = (v: number, field: string): number =>
+  boundedInt(v, 'columnCount', field);
+/** Bar/column series overlap percent — ST_OverlapByte (-100..100). */
+export const overlapPercent = (v: number, field: string): number => boundedInt(v, 'overlap', field);
+/** Bar/column gap width percent — ST_GapAmount (0..500). */
+export const gapAmountPercent = (v: number, field: string): number =>
+  boundedInt(v, 'gapAmount', field);
+/** Doughnut hole size percent — ST_HoleSizeUByte (1..90). */
+export const holeSizePercent = (v: number, field: string): number =>
+  boundedInt(v, 'holeSize', field);
+/** Pie/doughnut first-slice angle in degrees — ST_FirstSliceAng (0..360). */
+export const firstSliceAngle = (v: number, field: string): number =>
+  boundedInt(v, 'firstSliceAng', field);
+
+// ST_Guid requires UPPERCASE hex inside braces. PowerPoint emits uppercase, and
+// `crypto.randomUUID()` yields lowercase, so we accept either case and normalize
+// to upper rather than rejecting a perfectly good GUID over case alone. A value
+// that is not GUID-shaped at all is a caller error and throws.
+const GUID_RE = /^\{[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\}$/;
+export const normalizeGuid = (value: string, field: string): string => {
+  if (!GUID_RE.test(value)) {
+    throw new RangeError(
+      `${field}: ${JSON.stringify(value)} is not a GUID of the form {XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}`,
+    );
+  }
+  return value.toUpperCase();
+};
+
+// Generic enum-membership guard for attributes whose XSD type is an enumeration
+// (e.g. a pattern preset, a transition effect element name). Returns the value
+// narrowed to the allowed set, or throws naming the field and the legal tokens.
+export const oneOf = <T extends string>(value: string, allowed: readonly T[], field: string): T => {
+  if (!(allowed as readonly string[]).includes(value)) {
+    throw new RangeError(`${field}: ${JSON.stringify(value)} is not one of: ${allowed.join(', ')}`);
+  }
+  return value as T;
+};

--- a/src/internal/chartml/chart-builder.ts
+++ b/src/internal/chartml/chart-builder.ts
@@ -7,6 +7,13 @@
 // `<c:strCache>` / `<c:numCache>` blocks carry the values so PowerPoint
 // can render the chart without ever opening the workbook.
 
+import {
+  firstSliceAngle,
+  gapAmountPercent,
+  holeSizePercent,
+  lineWidthEmu as validateLineWidthEmu,
+  overlapPercent,
+} from '../bounds.ts';
 import { NS, type XmlDocument, type XmlElement, attr, elem, qname, text } from '../xml/index.ts';
 import type { ChartSpec, ChartTextStyle } from './types.ts';
 
@@ -150,7 +157,12 @@ const seriesSpPr = (
   const ln =
     lineWidthEmu !== undefined
       ? elem(a('ln'), {
-          attrs: [attr(qname('', 'w', ''), String(lineWidthEmu))],
+          attrs: [
+            attr(
+              qname('', 'w', ''),
+              String(validateLineWidthEmu(lineWidthEmu, 'chart series: lineWidthEmu')),
+            ),
+          ],
           children: lnChildren,
         })
       : elem(a('ln'), { children: lnChildren });
@@ -283,18 +295,35 @@ const seriesElement = (spec: ChartSpec, seriesIdx: number, sheet: string): XmlEl
   } else {
     children.push(solidFillSpPr(color));
   }
-  if (series.invertIfNegative === true) {
+  // invertIfNegative only exists on CT_BarSer (bar/column). Emitting it on a
+  // line/pie/area series is schema-invalid, so gate on the bar-family kinds.
+  if (series.invertIfNegative === true && (spec.kind === 'bar' || spec.kind === 'column')) {
     children.push(valNode(c('invertIfNegative'), '1'));
   }
-  const mk = markerElement(series.markerSymbol, series.markerSizePt);
-  if (mk !== null) children.push(mk);
+  // <c:marker> is only valid on the marker-bearing series types
+  // (CT_LineSer / CT_ScatterSer / CT_RadarSer). Emitting it on bar/column/
+  // pie/doughnut/area produces schema-invalid XML.
+  if (spec.kind === 'line' || spec.kind === 'scatter' || spec.kind === 'radar') {
+    const mk = markerElement(series.markerSymbol, series.markerSizePt);
+    if (mk !== null) children.push(mk);
+  }
   // <c:dPt> overrides go after invertIfNegative / marker per schema.
   for (const dPt of dPtElements(series.pointColors, series.pointExplosions)) {
     children.push(dPt);
   }
   const serDLbls = buildDLblsFromLabels(series.dataLabels);
   if (serDLbls !== null) children.push(serDLbls);
-  if (series.trendline) children.push(trendlineElement(series.trendline));
+  // <c:trendline> exists on CT_BarSer/LineSer/AreaSer/ScatterSer/BubbleSer but
+  // NOT on CT_PieSer (pie/doughnut) or CT_RadarSer — emitting it there is
+  // schema-invalid, so gate on the trendline-bearing kinds.
+  if (
+    series.trendline &&
+    spec.kind !== 'pie' &&
+    spec.kind !== 'doughnut' &&
+    spec.kind !== 'radar'
+  ) {
+    children.push(trendlineElement(series.trendline));
+  }
   children.push(elem(c('cat'), { children: [strRef(catRange, spec.categories)] }));
   children.push(elem(c('val'), { children: [numRef(valRange, paddedValues)] }));
   // Line series always get an explicit <c:smooth>: the schema default for an
@@ -305,8 +334,6 @@ const seriesElement = (spec: ChartSpec, seriesIdx: number, sheet: string): XmlEl
   // a bar/pie series would be schema-invalid.)
   if (spec.kind === 'line') {
     children.push(valNode(c('smooth'), series.smooth === true ? '1' : '0'));
-  } else if (series.smooth === true) {
-    children.push(valNode(c('smooth'), '1'));
   }
   return elem(c('ser'), { children });
 };
@@ -405,17 +432,19 @@ const catAxis = (spec: ChartSpec): XmlElement => {
 };
 
 const valAxis = (spec: ChartSpec): XmlElement => {
-  // <c:scaling> ordering matters: logBase, orientation, min, max.
+  // CT_Scaling sequence (dml-chart.xsd): logBase, orientation, max, min, extLst.
+  // `max` MUST precede `min` — emitting them in the other order is rejected by
+  // the schema ("element max: expected extLst").
   const scalingChildren: XmlElement[] = [];
   if (spec.valueAxis?.logBase !== undefined) {
     scalingChildren.push(valNode(c('logBase'), spec.valueAxis.logBase));
   }
   scalingChildren.push(valNode(c('orientation'), spec.valueAxisOrientation ?? 'minMax'));
-  if (spec.valueAxis?.min !== undefined) {
-    scalingChildren.push(valNode(c('min'), spec.valueAxis.min));
-  }
   if (spec.valueAxis?.max !== undefined) {
     scalingChildren.push(valNode(c('max'), spec.valueAxis.max));
+  }
+  if (spec.valueAxis?.min !== undefined) {
+    scalingChildren.push(valNode(c('min'), spec.valueAxis.min));
   }
   const children: XmlElement[] = [
     valNode(c('axId'), VAL_AX_ID),
@@ -536,7 +565,9 @@ const buildBarChart = (spec: ChartSpec, sheet: string, direction: 'col' | 'bar')
     ...ser,
     ...(dl ? [dl] : []),
   ];
-  if (spec.gapWidthPct !== undefined) children.push(valNode(c('gapWidth'), spec.gapWidthPct));
+  if (spec.gapWidthPct !== undefined) {
+    children.push(valNode(c('gapWidth'), gapAmountPercent(spec.gapWidthPct, 'chart: gapWidthPct')));
+  }
   // Stacked / 100%-stacked bars must overlap fully (overlap=100), otherwise
   // PowerPoint draws each series in its own sub-slot and the "stack" spreads
   // sideways across the category. PowerPoint always writes overlap=100 for
@@ -544,7 +575,9 @@ const buildBarChart = (spec: ChartSpec, sheet: string, direction: 'col' | 'bar')
   // overlap. Clustered keeps PowerPoint's own default (no element emitted).
   const overlapPct =
     spec.overlapPct ?? (grouping === 'stacked' || grouping === 'percentStacked' ? 100 : undefined);
-  if (overlapPct !== undefined) children.push(valNode(c('overlap'), overlapPct));
+  if (overlapPct !== undefined) {
+    children.push(valNode(c('overlap'), overlapPercent(overlapPct, 'chart: overlapPct')));
+  }
   children.push(valNode(c('axId'), CAT_AX_ID), valNode(c('axId'), VAL_AX_ID));
   return elem(c(direction === 'col' ? 'barChart' : 'barChart'), { children });
 };
@@ -579,7 +612,12 @@ const buildPieChart = (spec: ChartSpec, sheet: string): XmlElement => {
   const dl = dLblsElement(spec);
   const children: XmlElement[] = [valNode(c('varyColors'), '1'), ser, ...(dl ? [dl] : [])];
   if (spec.firstSliceAngleDeg !== undefined) {
-    children.push(valNode(c('firstSliceAng'), Math.round(spec.firstSliceAngleDeg)));
+    children.push(
+      valNode(
+        c('firstSliceAng'),
+        firstSliceAngle(spec.firstSliceAngleDeg, 'chart: firstSliceAngleDeg'),
+      ),
+    );
   }
   return elem(c('pieChart'), { children });
 };
@@ -592,9 +630,16 @@ const buildDoughnutChart = (spec: ChartSpec, sheet: string): XmlElement => {
   const dl = dLblsElement(spec);
   const children: XmlElement[] = [valNode(c('varyColors'), '1'), ser, ...(dl ? [dl] : [])];
   if (spec.firstSliceAngleDeg !== undefined) {
-    children.push(valNode(c('firstSliceAng'), Math.round(spec.firstSliceAngleDeg)));
+    children.push(
+      valNode(
+        c('firstSliceAng'),
+        firstSliceAngle(spec.firstSliceAngleDeg, 'chart: firstSliceAngleDeg'),
+      ),
+    );
   }
-  children.push(valNode(c('holeSize'), spec.holeSizePct ?? 50));
+  children.push(
+    valNode(c('holeSize'), holeSizePercent(spec.holeSizePct ?? 50, 'chart: holeSizePct')),
+  );
   return elem(c('doughnutChart'), { children });
 };
 

--- a/src/internal/chartml/types.ts
+++ b/src/internal/chartml/types.ts
@@ -196,6 +196,10 @@ export type ChartDataLabelPosition =
   | 'bestFit';
 
 export interface ChartDataLabels {
+  // `ChartSpec` is bidirectional (authored into `addSlideChart`, read back from
+  // `getShapeChartSpec`), and the reader always emits all four toggles, so they
+  // are required: a sparse `{ showValue: true }` would widen what every reader
+  // gets. Set the ones you want on and the rest to `false`.
   /** Numeric value of each data point. */
   readonly showValue: boolean;
   /** Category label of each data point. */

--- a/src/internal/drawingml/color.ts
+++ b/src/internal/drawingml/color.ts
@@ -1,9 +1,9 @@
 // Shared color parsing for the authoring APIs.
 //
 // Accepts the three forms PowerPoint emits: srgb hex (`#RRGGBB`,
-// `RRGGBB`), scheme tokens (`tx1`, `accent1`...), and an explicit `null`
-// to indicate "clear / no fill". Anything else throws so callers don't
-// silently emit `<a:srgbClr val="undefined"/>`.
+// `RRGGBB`), scheme tokens (`tx1`, `accent1`... — bare or `scheme:`-prefixed),
+// and an explicit `null` to indicate "clear / no fill". Anything else throws so
+// callers don't silently emit `<a:srgbClr val="undefined"/>`.
 
 import { type XmlElement, NS, attr, elem, qname } from '../xml/index.ts';
 
@@ -34,27 +34,50 @@ const SCHEME_TOKENS = new Set([
 export type ParsedColor = { kind: 'srgb'; hex: string } | { kind: 'scheme'; token: string };
 
 /**
- * Parses a user-supplied color string. Returns null on unrecognized input
- * so callers can decide whether to throw with a specific message.
+ * Normalizes an sRGB hex string to the canonical uppercase 6-digit form
+ * (no `#`), or returns `null` if it isn't a 3- or 6-digit hex. The CSS-style
+ * 3-digit shorthand (`#f00` → `FF0000`) is accepted because LLM authors reach
+ * for it constantly; 4-/8-digit (alpha) forms are rejected rather than
+ * silently dropping the alpha channel, which OOXML encodes separately.
  */
-export const parseColor = (value: string): ParsedColor | null => {
-  if (SCHEME_TOKENS.has(value)) return { kind: 'scheme', token: value };
+const normalizeSrgbHex = (value: string): string | null => {
   const hex = value.startsWith('#') ? value.slice(1) : value;
-  if (/^[0-9A-Fa-f]{6}$/.test(hex)) return { kind: 'srgb', hex: hex.toUpperCase() };
+  if (/^[0-9A-Fa-f]{6}$/.test(hex)) return hex.toUpperCase();
+  if (/^[0-9A-Fa-f]{3}$/.test(hex)) {
+    return Array.from(hex, (ch) => ch + ch)
+      .join('')
+      .toUpperCase();
+  }
   return null;
 };
 
 /**
- * Parses an sRGB hex color (`#RRGGBB` or `RRGGBB`), returning the
- * normalized uppercase 6-digit hex (no `#`). Returns `null` for anything
- * that isn't a 6-digit hex — including scheme tokens, which sRGB-only
+ * Parses a user-supplied color string. Returns null on unrecognized input
+ * so callers can decide whether to throw with a specific message.
+ *
+ * Scheme tokens are accepted both bare (`accent1`) and with the explicit
+ * `scheme:` prefix (`scheme:accent1`). The prefixed form is what the getters
+ * (`getShapeFillColor`, `getSlideBackground`, …) return, so accepting it here
+ * is what makes `setX(getX(...))` round-trip instead of throwing.
+ */
+export const parseColor = (value: string): ParsedColor | null => {
+  const token = value.startsWith('scheme:') ? value.slice('scheme:'.length) : value;
+  if (SCHEME_TOKENS.has(token)) return { kind: 'scheme', token };
+  // A `scheme:`-prefixed value is unambiguously a scheme reference; an unknown
+  // token there is an error, not a hex fallthrough.
+  if (value !== token) return null;
+  const hex = normalizeSrgbHex(value);
+  return hex === null ? null : { kind: 'srgb', hex };
+};
+
+/**
+ * Parses an sRGB hex color (`#RRGGBB`, `RRGGBB`, or the 3-digit `#RGB`
+ * shorthand), returning the normalized uppercase 6-digit hex (no `#`).
+ * Returns `null` for anything else — including scheme tokens, which sRGB-only
  * contexts (e.g. chart series fills) must reject rather than silently
  * emit as an invalid `<a:srgbClr val="accent1"/>`.
  */
-export const parseSrgbHex = (value: string): string | null => {
-  const hex = value.startsWith('#') ? value.slice(1) : value;
-  return /^[0-9A-Fa-f]{6}$/.test(hex) ? hex.toUpperCase() : null;
-};
+export const parseSrgbHex = (value: string): string | null => normalizeSrgbHex(value);
 
 /**
  * Returns the `<a:srgbClr>` or `<a:schemeClr>` element for `value`.

--- a/src/internal/drawingml/effects.ts
+++ b/src/internal/drawingml/effects.ts
@@ -5,6 +5,7 @@
 // effectLst → scene3d → sp3d → extLst`. Callers locate the right
 // insertion slot using `effectInsertionIndex`.
 
+import { emuExtent } from '../bounds.ts';
 import { NS, type XmlElement, attr, elem, qname } from '../xml/index.ts';
 import { buildColorElement } from './color.ts';
 
@@ -83,8 +84,11 @@ const colorWithAlpha = (color: string, opacity: number | undefined): XmlElement 
 export const setShadow = (host: XmlElement, options: ShadowOptions = {}): void => {
   removeEffectLst(host);
   const color = options.color ?? '#000000';
-  const blur = options.blurEmu ?? 50800;
-  const dist = options.offsetEmu ?? 38100;
+  // blurRad and dist are ST_PositiveCoordinate (EMU, 0..27273042316900); a
+  // fractional/negative/non-finite/over-max value would emit a schema-invalid
+  // `<a:outerShdw>`. Validate at this boundary like every other EMU input.
+  const blur = emuExtent(options.blurEmu ?? 50800, 'setShapeShadow: blurEmu');
+  const dist = emuExtent(options.offsetEmu ?? 38100, 'setShapeShadow: offsetEmu');
   const angleDeg = options.angleDeg ?? 45;
   const dir = String(Math.round((((angleDeg % 360) + 360) % 360) * 60000));
 
@@ -108,7 +112,8 @@ export const setShadow = (host: XmlElement, options: ShadowOptions = {}): void =
  */
 export const setGlow = (host: XmlElement, options: GlowOptions): void => {
   removeEffectLst(host);
-  const rad = String(options.radiusEmu ?? 63500);
+  // rad is ST_PositiveCoordinate — validate like the shadow EMU inputs above.
+  const rad = String(emuExtent(options.radiusEmu ?? 63500, 'setShapeGlow: radiusEmu'));
   const glow = elem(NAME_GLOW, {
     attrs: [attr(ATTR_RAD, rad)],
     children: [buildColorElement(options.color)],

--- a/src/internal/drawingml/fill.ts
+++ b/src/internal/drawingml/fill.ts
@@ -9,6 +9,7 @@
 // previous fill choice (`noFill`/`solidFill`/`gradFill`/`blipFill`/
 // `pattFill`/`grpFill`) before inserting the new `solidFill`.
 
+import { oneOf } from '../bounds.ts';
 import { NS, type XmlElement, attr, elem, qname } from '../xml/index.ts';
 import { buildColorElement } from './color.ts';
 
@@ -18,6 +19,9 @@ const NAME_GRAD_FILL = qname('a', 'gradFill', NS.dml);
 const NAME_GS_LST = qname('a', 'gsLst', NS.dml);
 const NAME_GS = qname('a', 'gs', NS.dml);
 const NAME_LIN = qname('a', 'lin', NS.dml);
+const NAME_PATH = qname('a', 'path', NS.dml);
+const NAME_FILL_TO_RECT = qname('a', 'fillToRect', NS.dml);
+const ATTR_PATH = qname('', 'path', '');
 const ATTR_POS = qname('', 'pos', '');
 const ATTR_ANG = qname('', 'ang', '');
 const ATTR_SCALED = qname('', 'scaled', '');
@@ -124,8 +128,66 @@ export interface GradientFillOptions {
   };
 }
 
+/** Every `ST_PresetPatternVal` token (ECMA-376 dml-main.xsd). */
+export const PATTERN_PRESETS = [
+  'pct5',
+  'pct10',
+  'pct20',
+  'pct25',
+  'pct30',
+  'pct40',
+  'pct50',
+  'pct60',
+  'pct70',
+  'pct75',
+  'pct80',
+  'pct90',
+  'horz',
+  'vert',
+  'ltHorz',
+  'ltVert',
+  'dkHorz',
+  'dkVert',
+  'narHorz',
+  'narVert',
+  'dashHorz',
+  'dashVert',
+  'cross',
+  'dnDiag',
+  'upDiag',
+  'ltDnDiag',
+  'ltUpDiag',
+  'dkDnDiag',
+  'dkUpDiag',
+  'wdDnDiag',
+  'wdUpDiag',
+  'dashDnDiag',
+  'dashUpDiag',
+  'diagCross',
+  'smCheck',
+  'lgCheck',
+  'smGrid',
+  'lgGrid',
+  'dotGrid',
+  'smConfetti',
+  'lgConfetti',
+  'horzBrick',
+  'diagBrick',
+  'solidDmnd',
+  'openDmnd',
+  'dotDmnd',
+  'plaid',
+  'sphere',
+  'weave',
+  'divot',
+  'shingle',
+  'wave',
+  'trellis',
+  'zigZag',
+] as const;
+
 /** One of ECMA-376's `ST_PresetPatternVal` tokens (`pct50`, `dkUpDiag`, ...). */
-export type PatternPreset = string;
+export type PatternPreset = (typeof PATTERN_PRESETS)[number];
 
 export interface PatternFillOptions {
   /** Preset pattern token, e.g. `'pct50'`, `'dkUpDiag'`, `'wave'`. */
@@ -147,8 +209,11 @@ const ATTR_PRST = qname('', 'prst', '');
  */
 export const setPatternFill = (host: XmlElement, options: PatternFillOptions): void => {
   removeAnyFill(host);
+  // `preset` is typed but authoring input is a boundary — reject an out-of-enum
+  // token rather than emitting a schema-invalid `prst`.
+  const preset = oneOf(options.preset, PATTERN_PRESETS, 'setShapePatternFill: preset');
   const pattFill = elem(NAME_PATT_FILL, {
-    attrs: [attr(ATTR_PRST, options.preset)],
+    attrs: [attr(ATTR_PRST, preset)],
     children: [
       elem(NAME_FG_CLR, { children: [buildColorElement(options.foreground)] }),
       elem(NAME_BG_CLR, { children: [buildColorElement(options.background)] }),
@@ -175,18 +240,43 @@ export const setGradientFill = (host: XmlElement, options: GradientFillOptions):
     });
   });
 
-  const angleDeg = options.angleDeg ?? 90;
-  // ECMA-376 ST_PositiveFixedAngle: 60000 units per degree, range
-  // [0, 21600000). Normalize negatives via modulo.
-  const norm = ((angleDeg % 360) + 360) % 360;
-  const angleAttr = String(Math.round(norm * 60000));
+  // The gradient direction is a choice: `<a:lin>` for a linear gradient (using
+  // angleDeg) or `<a:path path="circle|rect|shape">` for a non-linear one. When
+  // a path is requested we honor the documented `focus` fillToRect; emitting
+  // <a:lin> regardless (the prior behavior) silently downgraded radial/shape
+  // gradients to linear.
+  const pct = (n: number): string => String(Math.round(n * 100000));
+  const directionEl =
+    options.path === undefined || options.path === 'linear'
+      ? ((): XmlElement => {
+          const angleDeg = options.angleDeg ?? 90;
+          // ECMA-376 ST_PositiveFixedAngle: 60000 units per degree, range
+          // [0, 21600000). Normalize negatives via modulo.
+          const norm = ((angleDeg % 360) + 360) % 360;
+          return elem(NAME_LIN, {
+            attrs: [attr(ATTR_ANG, String(Math.round(norm * 60000))), attr(ATTR_SCALED, '0')],
+          });
+        })()
+      : elem(NAME_PATH, {
+          attrs: [attr(ATTR_PATH, options.path)],
+          children:
+            options.focus === undefined
+              ? []
+              : [
+                  elem(NAME_FILL_TO_RECT, {
+                    attrs: [
+                      attr(qname('', 'l', ''), pct(options.focus.left)),
+                      attr(qname('', 't', ''), pct(options.focus.top)),
+                      attr(qname('', 'r', ''), pct(options.focus.right)),
+                      attr(qname('', 'b', ''), pct(options.focus.bottom)),
+                    ],
+                  }),
+                ],
+        });
 
   const grad = elem(NAME_GRAD_FILL, {
     attrs: [attr(ATTR_FLIP, 'none'), attr(ATTR_ROT_WITH_SHAPE, '1')],
-    children: [
-      elem(NAME_GS_LST, { children: stops }),
-      elem(NAME_LIN, { attrs: [attr(ATTR_ANG, angleAttr), attr(ATTR_SCALED, '0')] }),
-    ],
+    children: [elem(NAME_GS_LST, { children: stops }), directionEl],
   });
   host.children.splice(fillInsertionIndex(host), 0, grad);
 };

--- a/src/internal/drawingml/geometry-mutation.ts
+++ b/src/internal/drawingml/geometry-mutation.ts
@@ -5,6 +5,7 @@
 // The shape-kind dispatch matches `geometry.ts` exactly — both modules
 // agree on where each shape kind keeps its transform.
 
+import { emuCoordinate, emuExtent } from '../bounds.ts';
 import { NS, attr, elem, firstChildElement, qname } from '../xml/index.ts';
 import type { XmlElement } from '../xml/index.ts';
 import type { ShapeKindForGeometry } from './geometry.ts';
@@ -71,7 +72,10 @@ export const setPosition = (
     off = elem(NAME_OFF);
     xfrm.children.unshift(off);
   }
-  off.attrs = [attr(ATTR_X, String(x)), attr(ATTR_Y, String(y))];
+  off.attrs = [
+    attr(ATTR_X, String(emuCoordinate(x, 'setShapePosition: x'))),
+    attr(ATTR_Y, String(emuCoordinate(y, 'setShapePosition: y'))),
+  ];
 };
 
 /** Sets the shape's `<a:ext>` to `(w, h)` in EMU. */
@@ -92,7 +96,10 @@ export const setSize = (
     if (offIdx >= 0) xfrm.children.splice(offIdx + 1, 0, ext);
     else xfrm.children.push(ext);
   }
-  ext.attrs = [attr(ATTR_CX, String(w)), attr(ATTR_CY, String(h))];
+  ext.attrs = [
+    attr(ATTR_CX, String(emuExtent(w, 'setShapeSize: w'))),
+    attr(ATTR_CY, String(emuExtent(h, 'setShapeSize: h'))),
+  ];
 };
 
 const ATTR_ROT = qname('', 'rot', '');

--- a/src/internal/drawingml/stroke.ts
+++ b/src/internal/drawingml/stroke.ts
@@ -1,11 +1,13 @@
 // Outline (line) mutation for shapes.
 //
 // `<a:ln>` sits inside `<p:spPr>` after the fill choice. ECMA-376 §20.1.2
-// surface: width (EMU), cap, dash, fill choice (solid/no/grad), head/tail
-// arrow markers. At this phase we expose width + solid color + noFill;
-// dashes and arrowheads land when the next feature batch needs them.
+// surface: width (EMU), cap, dash, fill choice (solid/no/grad), join
+// (round/bevel/miter), and head/tail arrow markers. We expose width, solid
+// color, noFill, preset dash, join, and head/tail arrowheads — each inserted at
+// its CT_LineProperties slot via LN_CHILD_RANK below.
 
-import { NS, type XmlElement, attr, elem, qname } from '../xml/index.ts';
+import { lineWidthEmu } from '../bounds.ts';
+import { NS, type XmlElement, attr, elem, insertChildByRank, qname } from '../xml/index.ts';
 import { buildColorElement } from './color.ts';
 
 const NAME_LN = qname('a', 'ln', NS.dml);
@@ -14,6 +16,29 @@ const NAME_NO_FILL = qname('a', 'noFill', NS.dml);
 const ATTR_W = qname('', 'w', '');
 
 const FILL_LOCALS = new Set(['noFill', 'solidFill', 'gradFill', 'pattFill']);
+
+// CT_LineProperties (a:ln) is an xsd:sequence: fill choice, then the dash,
+// then the join choice, then head/tail arrowheads, then extLst. Sub-element
+// setters must drop their element at the mandated slot rather than push to the
+// end, or combining (e.g.) a dash + arrowheads + join emits invalid order.
+const LN_CHILD_RANK: Record<string, number> = {
+  noFill: 0,
+  solidFill: 0,
+  gradFill: 0,
+  pattFill: 0,
+  prstDash: 1,
+  custDash: 1,
+  round: 2,
+  bevel: 2,
+  miter: 2,
+  headEnd: 3,
+  tailEnd: 4,
+  extLst: 5,
+};
+const lnChildRank = (el: XmlElement): number =>
+  el.name.namespaceURI === NS.dml ? (LN_CHILD_RANK[el.name.localName] ?? 99) : 99;
+const insertLnChild = (ln: XmlElement, el: XmlElement): void =>
+  insertChildByRank(ln, el, lnChildRank);
 
 const removeChildrenIn = (host: XmlElement, names: ReadonlySet<string>): void => {
   host.children = host.children.filter(
@@ -55,12 +80,12 @@ export const setSolidStroke = (spPr: XmlElement, options: StrokeOptions): void =
   const ln = ensureLn(spPr);
   if (options.widthEmu !== undefined) {
     ln.attrs = ln.attrs.filter((a) => a.name.localName !== 'w');
-    ln.attrs.push(attr(ATTR_W, String(Math.round(options.widthEmu))));
+    ln.attrs.push(attr(ATTR_W, String(lineWidthEmu(options.widthEmu, 'setShapeStroke: widthEmu'))));
   }
   // Replace any existing fill choice inside <a:ln>.
   removeChildrenIn(ln, FILL_LOCALS);
   if (options.color !== undefined) {
-    ln.children.unshift(elem(NAME_SOLID_FILL, { children: [buildColorElement(options.color)] }));
+    insertLnChild(ln, elem(NAME_SOLID_FILL, { children: [buildColorElement(options.color)] }));
   }
 };
 
@@ -68,7 +93,7 @@ export const setSolidStroke = (spPr: XmlElement, options: StrokeOptions): void =
 export const setNoStroke = (spPr: XmlElement): void => {
   const ln = ensureLn(spPr);
   removeChildrenIn(ln, FILL_LOCALS);
-  ln.children.unshift(elem(NAME_NO_FILL));
+  insertLnChild(ln, elem(NAME_NO_FILL));
 };
 
 /** Removes any `<a:ln>` from a shape's spPr (restores inheritance). */
@@ -108,7 +133,7 @@ export const setStrokeDash = (spPr: XmlElement, dash: LineDash): void => {
     (c) =>
       !(c.kind === 'element' && c.name.namespaceURI === NS.dml && c.name.localName === 'prstDash'),
   );
-  ln.children.push(elem(NAME_PRST_DASH, { attrs: [attr(ATTR_VAL, dash)] }));
+  insertLnChild(ln, elem(NAME_PRST_DASH, { attrs: [attr(ATTR_VAL, dash)] }));
 };
 
 /** ECMA-376 §20.1.10.39 `ST_LineEndType`. */
@@ -150,7 +175,7 @@ export const setStrokeArrow = (
   const attrs = [attr(ATTR_TYPE, options.type)];
   if (options.width !== undefined) attrs.push(attr(ATTR_W, options.width));
   if (options.length !== undefined) attrs.push(attr(ATTR_LEN, options.length));
-  ln.children.push(elem(qname('a', localName, NS.dml), { attrs }));
+  insertLnChild(ln, elem(qname('a', localName, NS.dml), { attrs }));
 };
 
 /** ECMA-376 §20.1.10.30 `ST_LineCap`. */
@@ -172,11 +197,8 @@ export const setStrokeJoin = (spPr: XmlElement, join: LineJoin | null): void => 
   const ln = ensureLn(spPr);
   removeChildrenIn(ln, JOIN_LOCALS);
   if (join !== null) {
-    // Join sits after `<a:prstDash>` and before `<a:headEnd>` per the
-    // CT_LineProperties schema. Append: the few siblings that follow
-    // (headEnd / tailEnd) tolerate trailing-only reordering in
-    // practice, and the renderers we care about read by name.
-    ln.children.push(elem(qname('a', join, NS.dml)));
+    // Join sits after <a:prstDash> and before <a:headEnd> per CT_LineProperties.
+    insertLnChild(ln, elem(qname('a', join, NS.dml)));
   }
 };
 

--- a/src/internal/drawingml/text-format.ts
+++ b/src/internal/drawingml/text-format.ts
@@ -22,8 +22,11 @@ import {
   attr,
   elem,
   firstChildElement,
+  insertChildByRank,
   qname,
 } from '../xml/index.ts';
+import { fontSizeHundredthPt, textPointSpacing } from '../bounds.ts';
+import { parseColor } from './color.ts';
 
 const NAME_R = qname('a', 'r', NS.dml);
 const NAME_RPR = qname('a', 'rPr', NS.dml);
@@ -45,6 +48,36 @@ const ATTR_CAP = qname('', 'cap', '');
 const ATTR_TYPEFACE = qname('', 'typeface', '');
 const ATTR_VAL = qname('', 'val', '');
 const NAME_HIGHLIGHT = qname('a', 'highlight', NS.dml);
+
+// CT_TextCharacterProperties (a:rPr) is an xsd:sequence: children must appear
+// in this order or the run fails dml/pml schema validation. Setters strip the
+// existing element then re-insert at the mandated slot via insertChildByRank.
+const RPR_CHILD_RANK: Record<string, number> = {
+  ln: 0,
+  noFill: 1,
+  solidFill: 1,
+  gradFill: 1,
+  blipFill: 1,
+  pattFill: 1,
+  grpFill: 1,
+  effectLst: 2,
+  effectDag: 2,
+  highlight: 3,
+  uLnTx: 4,
+  uLn: 4,
+  uFillTx: 5,
+  uFill: 5,
+  latin: 6,
+  ea: 7,
+  cs: 8,
+  sym: 9,
+  hlinkClick: 10,
+  hlinkMouseOver: 11,
+  rtl: 12,
+  extLst: 13,
+};
+const rprChildRank = (el: XmlElement): number =>
+  el.name.namespaceURI === NS.dml ? (RPR_CHILD_RANK[el.name.localName] ?? 99) : 99;
 
 export interface TextFormat {
   /** Latin font family (`Calibri`, `Arial`, ...). Sets `<a:latin>`. */
@@ -76,8 +109,9 @@ export interface TextFormat {
    */
   spc?: number;
   /**
-   * Kerning threshold in half-points (`0` disables kerning, `1200` =
-   * apply kerning for runs ≥12pt). Mirrors `<a:rPr kern="…"/>`.
+   * Kerning threshold in 1/100 points (`ST_TextNonNegativePoint`, the same
+   * unit as `spc`): `0` disables kerning, `1200` = apply kerning for runs
+   * ≥12pt. Mirrors `<a:rPr kern="…"/>`.
    */
   kern?: number;
   /**
@@ -97,35 +131,6 @@ export interface TextFormat {
    */
   highlight?: string | null;
 }
-
-const SCHEME_TOKENS = new Set([
-  'bg1',
-  'tx1',
-  'bg2',
-  'tx2',
-  'accent1',
-  'accent2',
-  'accent3',
-  'accent4',
-  'accent5',
-  'accent6',
-  'hlink',
-  'folHlink',
-  'phClr',
-  'lt1',
-  'dk1',
-  'lt2',
-  'dk2',
-]);
-
-const parseColor = (
-  value: string,
-): { kind: 'srgb'; hex: string } | { kind: 'scheme'; token: string } | null => {
-  if (SCHEME_TOKENS.has(value)) return { kind: 'scheme', token: value };
-  const hex = value.startsWith('#') ? value.slice(1) : value;
-  if (/^[0-9A-Fa-f]{6}$/.test(hex)) return { kind: 'srgb', hex: hex.toUpperCase() };
-  return null;
-};
 
 const setOrRemoveAttr = (
   attrs: XmlAttr[],
@@ -151,10 +156,7 @@ const setSolidFill = (rPr: XmlElement, value: string | null): void => {
       ? elem(NAME_SRGB_CLR, { attrs: [attr(ATTR_VAL, parsed.hex)] })
       : elem(NAME_SCHEME_CLR, { attrs: [attr(ATTR_VAL, parsed.token)] });
   const fill = elem(NAME_SOLID_FILL, { children: [inner] });
-  // Per the schema, fills come BEFORE typeface children. Insert after any
-  // text-decoration attrs but before latin/ea/cs. Easiest: prepend; xmllint
-  // accepts either placement since solidFill is a choice in CT_TextCharacterProperties.
-  rPr.children.unshift(fill);
+  insertChildByRank(rPr, fill, rprChildRank);
 };
 
 const setLatin = (rPr: XmlElement, font: string | null): void => {
@@ -163,7 +165,7 @@ const setLatin = (rPr: XmlElement, font: string | null): void => {
       !(c.kind === 'element' && c.name.namespaceURI === NS.dml && c.name.localName === 'latin'),
   );
   if (font === null) return;
-  rPr.children.push(elem(NAME_LATIN, { attrs: [attr(ATTR_TYPEFACE, font)] }));
+  insertChildByRank(rPr, elem(NAME_LATIN, { attrs: [attr(ATTR_TYPEFACE, font)] }), rprChildRank);
 };
 
 const setHighlight = (rPr: XmlElement, value: string | null): void => {
@@ -178,17 +180,15 @@ const setHighlight = (rPr: XmlElement, value: string | null): void => {
     parsed.kind === 'srgb'
       ? elem(NAME_SRGB_CLR, { attrs: [attr(ATTR_VAL, parsed.hex)] })
       : elem(NAME_SCHEME_CLR, { attrs: [attr(ATTR_VAL, parsed.token)] });
-  // highlight follows solidFill but precedes the typeface children in the
-  // schema. Insert near the start; xmllint accepts either placement.
-  rPr.children.unshift(elem(NAME_HIGHLIGHT, { children: [inner] }));
+  insertChildByRank(rPr, elem(NAME_HIGHLIGHT, { children: [inner] }), rprChildRank);
 };
 
 /** Mutates `rPr` in place per `format`. */
 export const applyRunFormat = (rPr: XmlElement, format: TextFormat): void => {
   let attrs = rPr.attrs;
   if (format.size !== undefined) {
-    // Hundredths of a point per the schema.
-    const sz = Math.round(format.size * 100);
+    // Hundredths of a point per the schema (ST_TextFontSize: 1..4000 pt).
+    const sz = fontSizeHundredthPt(format.size * 100, 'setShapeRunFormat: size');
     attrs = setOrRemoveAttr(attrs, ATTR_SZ, String(sz));
   }
   if (format.bold !== undefined) {
@@ -208,7 +208,8 @@ export const applyRunFormat = (rPr: XmlElement, format: TextFormat): void => {
     attrs = setOrRemoveAttr(attrs, ATTR_STRIKE, value);
   }
   if (format.spc !== undefined) {
-    attrs = setOrRemoveAttr(attrs, ATTR_SPC, String(Math.round(format.spc)));
+    const spc = textPointSpacing(format.spc, 'setShapeRunFormat: spc');
+    attrs = setOrRemoveAttr(attrs, ATTR_SPC, String(spc));
   }
   if (format.kern !== undefined) {
     attrs = setOrRemoveAttr(attrs, ATTR_KERN, String(Math.round(format.kern)));

--- a/src/internal/presentationml/animation-builder.ts
+++ b/src/internal/presentationml/animation-builder.ts
@@ -15,6 +15,7 @@
 // the actual `<p:set>` / `<p:anim>` is fixed; we just swap presetID,
 // presetClass, and the target spid.
 
+import { unsignedIntMs } from '../bounds.ts';
 import { NS, type XmlElement, attr, elem, qname } from '../xml/index.ts';
 
 const NAME_TIMING = qname('p', 'timing', NS.pml);
@@ -157,7 +158,12 @@ const buildOpacityAnim = (spid: number, durationMs: number, fadeIn: boolean): Xm
  */
 export const buildSingleEffectTiming = (spid: number, opts: AnimationOptions): XmlElement => {
   const preset = PRESETS[opts.effect];
-  const duration = opts.durationMs ?? 500;
+  // <p:cTn dur> is ST_TLTime (xsd:unsignedInt ms or "indefinite"); reject
+  // fractional/negative/out-of-range so we never emit an invalid dur.
+  const duration =
+    opts.durationMs === undefined
+      ? 500
+      : unsignedIntMs(opts.durationMs, 'setShapeAnimation: durationMs');
 
   const isFade = opts.effect === 'fadeIn' || opts.effect === 'fadeOut';
   const isEntrance = preset.presetClass === 'entr';

--- a/src/internal/presentationml/connector-builder.ts
+++ b/src/internal/presentationml/connector-builder.ts
@@ -6,6 +6,7 @@
 // `(|x2-x1|, |y2-y1|)`. Direction (which end is "from" and which is
 // "to") is captured via `flipH` / `flipV` on the xfrm.
 
+import { emuCoordinate, emuExtent, lineWidthEmu } from '../bounds.ts';
 import { type XmlElement, NS, attr, elem, qname } from '../xml/index.ts';
 import { buildColorElement } from '../drawingml/color.ts';
 
@@ -22,6 +23,14 @@ const NAME_PRST_GEOM = qname('a', 'prstGeom', NS.dml);
 const NAME_AV_LST = qname('a', 'avLst', NS.dml);
 const NAME_LN = qname('a', 'ln', NS.dml);
 const NAME_SOLID_FILL = qname('a', 'solidFill', NS.dml);
+const NAME_STYLE = qname('p', 'style', NS.pml);
+const NAME_LN_REF = qname('a', 'lnRef', NS.dml);
+const NAME_FILL_REF = qname('a', 'fillRef', NS.dml);
+const NAME_EFFECT_REF = qname('a', 'effectRef', NS.dml);
+const NAME_FONT_REF = qname('a', 'fontRef', NS.dml);
+const NAME_SCHEME_CLR = qname('a', 'schemeClr', NS.dml);
+const ATTR_IDX = qname('', 'idx', '');
+const ATTR_VAL = qname('', 'val', '');
 const ATTR_ID = qname('', 'id', '');
 const ATTR_NAME = qname('', 'name', '');
 const ATTR_X = qname('', 'x', '');
@@ -77,10 +86,16 @@ export const buildConnector = (opts: ConnectorOptions): XmlElement => {
     children: [
       // Round to whole EMU; fractional ST_Coordinate values corrupt the file.
       elem(NAME_OFF, {
-        attrs: [attr(ATTR_X, String(Math.round(x))), attr(ATTR_Y, String(Math.round(y)))],
+        attrs: [
+          attr(ATTR_X, String(emuCoordinate(x, 'addSlideLine: x'))),
+          attr(ATTR_Y, String(emuCoordinate(y, 'addSlideLine: y'))),
+        ],
       }),
       elem(NAME_EXT, {
-        attrs: [attr(ATTR_CX, String(Math.round(cx))), attr(ATTR_CY, String(Math.round(cy)))],
+        attrs: [
+          attr(ATTR_CX, String(emuExtent(cx, 'addSlideLine: width'))),
+          attr(ATTR_CY, String(emuExtent(cy, 'addSlideLine: height'))),
+        ],
       }),
     ],
   });
@@ -89,10 +104,14 @@ export const buildConnector = (opts: ConnectorOptions): XmlElement => {
     children: [elem(NAME_AV_LST)],
   });
 
+  const hasExplicitLine = opts.color !== undefined || opts.widthEmu !== undefined;
   const spPrChildren: XmlElement[] = [xfrm, prstGeom];
-  if (opts.color !== undefined || opts.widthEmu !== undefined) {
+  if (hasExplicitLine) {
     const ln = elem(NAME_LN, {
-      attrs: opts.widthEmu !== undefined ? [attr(ATTR_W, String(Math.round(opts.widthEmu)))] : [],
+      attrs:
+        opts.widthEmu !== undefined
+          ? [attr(ATTR_W, String(lineWidthEmu(opts.widthEmu, 'addSlideLine: widthEmu')))]
+          : [],
       children:
         opts.color !== undefined
           ? [elem(NAME_SOLID_FILL, { children: [buildColorElement(opts.color)] })]
@@ -102,5 +121,28 @@ export const buildConnector = (opts: ConnectorOptions): XmlElement => {
   }
   const spPr = elem(NAME_SP_PR, { children: spPrChildren });
 
-  return elem(NAME_CXN_SP, { children: [nvCxnSpPr, spPr] });
+  const children: XmlElement[] = [nvCxnSpPr, spPr];
+  // A connector is a stroke-only open path. With no explicit <a:ln> AND no
+  // <p:style>, PowerPoint has no outline to draw and the line is invisible.
+  // Emit PowerPoint's default connector style (lnRef idx="1" → the theme's
+  // first line style in accent1) so an unstyled line still renders.
+  if (!hasExplicitLine) {
+    const styleRef = (name: typeof NAME_LN_REF, idx: string, clr: string): XmlElement =>
+      elem(name, {
+        attrs: [attr(ATTR_IDX, idx)],
+        children: [elem(NAME_SCHEME_CLR, { attrs: [attr(ATTR_VAL, clr)] })],
+      });
+    children.push(
+      elem(NAME_STYLE, {
+        children: [
+          styleRef(NAME_LN_REF, '1', 'accent1'),
+          styleRef(NAME_FILL_REF, '0', 'accent1'),
+          styleRef(NAME_EFFECT_REF, '0', 'accent1'),
+          styleRef(NAME_FONT_REF, 'minor', 'tx1'),
+        ],
+      }),
+    );
+  }
+
+  return elem(NAME_CXN_SP, { children });
 };

--- a/src/internal/presentationml/notes-slide-builder.ts
+++ b/src/internal/presentationml/notes-slide-builder.ts
@@ -1,4 +1,9 @@
-// Builds the canonical empty `<p:notesSlide>` shape PowerPoint emits.
+// Builds the canonical empty notes-slide part PowerPoint emits.
+//
+// The part's root element is `<p:notes>` (ECMA-376 §19.3.1.26 — the global
+// element for CT_NotesSlide is named `notes`, not `notesSlide`; the
+// `notesSlide` token only appears in the part name and content type). Emitting
+// `<p:notesSlide>` here makes the part fail pml.xsd validation.
 //
 // Notes slides carry two placeholders: a `sldImg` placeholder that
 // PowerPoint renders as the slide thumbnail, and a `body` placeholder
@@ -15,7 +20,7 @@ import {
   text as textNode,
 } from '../xml/index.ts';
 
-const NAME_NOTES_SLIDE = qname('p', 'notesSlide', NS.pml);
+const NAME_NOTES_SLIDE = qname('p', 'notes', NS.pml);
 const NAME_CSLD = qname('p', 'cSld', NS.pml);
 const NAME_SP_TREE = qname('p', 'spTree', NS.pml);
 const NAME_NV_GRP_SP_PR = qname('p', 'nvGrpSpPr', NS.pml);
@@ -100,7 +105,7 @@ const buildNotesBodyPlaceholder = (id: number, notes: string): XmlElement => {
 };
 
 /**
- * Returns a fresh `<p:notesSlide>` document with the given notes text in
+ * Returns a fresh `<p:notes>` document with the given notes text in
  * the body placeholder. Designed for callers that need to create the
  * notesSlide part from scratch (no existing notes file yet for the
  * slide).

--- a/src/internal/presentationml/picture-builder.ts
+++ b/src/internal/presentationml/picture-builder.ts
@@ -21,6 +21,7 @@
 // The `r:embed` rId is allocated by the caller and must already exist as
 // a relationship on the slide's `.rels` part pointing at a media part.
 
+import { emuCoordinate, emuExtent } from '../bounds.ts';
 import { type XmlElement, NS, attr, elem, qname } from '../xml/index.ts';
 
 const NAME_PIC = qname('p', 'pic', NS.pml);
@@ -85,10 +86,16 @@ export const buildPicture = (opts: PictureOptions): XmlElement => {
   // Round to whole EMU — `fit: 'contain'` scaling produces fractional offsets
   // (`as Emu` cast), and fractional ST_Coordinate values corrupt the file.
   const off = elem(NAME_OFF, {
-    attrs: [attr(ATTR_X, String(Math.round(opts.x))), attr(ATTR_Y, String(Math.round(opts.y)))],
+    attrs: [
+      attr(ATTR_X, String(emuCoordinate(opts.x, 'addSlideImage: x'))),
+      attr(ATTR_Y, String(emuCoordinate(opts.y, 'addSlideImage: y'))),
+    ],
   });
   const ext = elem(NAME_EXT, {
-    attrs: [attr(ATTR_CX, String(Math.round(opts.w))), attr(ATTR_CY, String(Math.round(opts.h)))],
+    attrs: [
+      attr(ATTR_CX, String(emuExtent(opts.w, 'addSlideImage: w'))),
+      attr(ATTR_CY, String(emuExtent(opts.h, 'addSlideImage: h'))),
+    ],
   });
   const xfrm = elem(NAME_A_XFRM, { children: [off, ext] });
   const prstGeom = elem(NAME_PRST_GEOM, {

--- a/src/internal/presentationml/shape-builder.ts
+++ b/src/internal/presentationml/shape-builder.ts
@@ -10,6 +10,7 @@
 // Like `text-box-builder`, multi-line text splits on `\n` into paragraphs
 // so each `<a:t>` holds a single line (strict schema friendly).
 
+import { emuCoordinate, emuExtent } from '../bounds.ts';
 import { type XmlElement, NS, attr, elem, qname, text as textNode } from '../xml/index.ts';
 
 const NAME_SP = qname('p', 'sp', NS.pml);
@@ -100,11 +101,15 @@ export type PresetShape =
   | 'donut'
   | 'noSmoking'
   | 'plus'
-  | 'minus'
-  | 'mult'
-  | 'div'
-  | 'equal'
-  | 'notEqual';
+  // ECMA-376 ST_ShapeType spells the math operators `math*`; the bare
+  // `minus`/`mult`/`div`/`equal`/`notEqual` are not in the enum and emitted a
+  // `prstGeom` PowerPoint silently dropped (the shape vanished on open).
+  | 'mathPlus'
+  | 'mathMinus'
+  | 'mathMultiply'
+  | 'mathDivide'
+  | 'mathEqual'
+  | 'mathNotEqual';
 
 export interface ShapeOptions {
   id: number;
@@ -121,11 +126,13 @@ export interface ShapeOptions {
    */
   text?: string;
   /**
-   * Vertical anchor of any text body. Defaults to `'ctr'` (center) so
-   * preset shapes render with centered text, which is what PowerPoint
-   * does when you "insert shape → type text".
+   * Vertical anchor of any text body (`ST_TextAnchoringType`: `t` top,
+   * `ctr` middle, `b` bottom). Defaults to `'ctr'` so preset shapes render
+   * with centered text, which is what PowerPoint does when you "insert shape
+   * → type text". For horizontal alignment, set the paragraph alignment via
+   * `setShapeAlignment` / `setParagraphAlignment` after creating the shape.
    */
-  textAnchor?: 'l' | 'ctr' | 'r' | 't' | 'b';
+  textAnchor?: 'ctr' | 't' | 'b';
 }
 
 const buildTextBody = (
@@ -169,10 +176,16 @@ export const buildShape = (opts: ShapeOptions): XmlElement => {
   // out so a fractional value from EMU arithmetic (e.g. an `as Emu` cast on a
   // computed fit/translate) can't reach the XML and trip PowerPoint's repair.
   const off = elem(NAME_OFF, {
-    attrs: [attr(ATTR_X, String(Math.round(opts.x))), attr(ATTR_Y, String(Math.round(opts.y)))],
+    attrs: [
+      attr(ATTR_X, String(emuCoordinate(opts.x, 'addSlideShape: x'))),
+      attr(ATTR_Y, String(emuCoordinate(opts.y, 'addSlideShape: y'))),
+    ],
   });
   const ext = elem(NAME_EXT, {
-    attrs: [attr(ATTR_CX, String(Math.round(opts.w))), attr(ATTR_CY, String(Math.round(opts.h)))],
+    attrs: [
+      attr(ATTR_CX, String(emuExtent(opts.w, 'addSlideShape: w'))),
+      attr(ATTR_CY, String(emuExtent(opts.h, 'addSlideShape: h'))),
+    ],
   });
   const xfrm = elem(NAME_A_XFRM, { children: [off, ext] });
   const prstGeom = elem(NAME_PRST_GEOM, {

--- a/src/internal/presentationml/table-builder.ts
+++ b/src/internal/presentationml/table-builder.ts
@@ -9,6 +9,7 @@
 // Column widths and row heights are in EMU. When the caller omits widths,
 // we divide the total width equally; same for heights.
 
+import { emuCoordinate, emuExtent, normalizeGuid } from '../bounds.ts';
 import { type XmlElement, NS, attr, elem, qname, text as textNode } from '../xml/index.ts';
 
 const TABLE_URI = 'http://schemas.openxmlformats.org/drawingml/2006/table';
@@ -71,7 +72,6 @@ const ATTR_H = qname('', 'h', '');
 const ATTR_FIRST_ROW = qname('', 'firstRow', '');
 const ATTR_BAND_ROW = qname('', 'bandRow', '');
 const ATTR_LANG = qname('', 'lang', '');
-const ATTR_XML_SPACE = qname('xml', 'space', NS.xml);
 
 export interface TableOptions {
   id: number;
@@ -117,26 +117,31 @@ const buildCellRunProps = (textColorHex: string | undefined): XmlElement => {
   return elem(NAME_RPR, { attrs: [langAttr], children: [solidFill] });
 };
 
-const buildTextCellBody = (value: string, textColorHex: string | undefined): XmlElement => {
-  const needsPreserve =
-    value.length > 0 && (value.startsWith(' ') || value.endsWith(' ') || /[\t\n]/.test(value));
-  const t = elem(NAME_T, {
-    attrs: needsPreserve ? [attr(ATTR_XML_SPACE, 'preserve')] : [],
-    children: value.length > 0 ? [textNode(value)] : [],
-  });
-  const r = elem(NAME_R, {
-    children: [buildCellRunProps(textColorHex), t],
-  });
-  // `<a:pPr marL="0" indent="0"><a:buNone/></a:pPr>` suppresses any inherited
-  // list bullet on the cell paragraph — what PowerPoint and PptxGenJS both
-  // emit. Renders the same as omitting it (table cells inherit no bullet), but
-  // makes the cell self-describing.
+// `<a:pPr marL="0" indent="0"><a:buNone/></a:pPr>` suppresses any inherited
+// list bullet on the cell paragraph — what PowerPoint and PptxGenJS both emit.
+// Renders the same as omitting it (table cells inherit no bullet), but makes the
+// cell self-describing.
+const buildCellParagraph = (line: string, textColorHex: string | undefined): XmlElement => {
   const pPr = elem(NAME_PPR, {
     attrs: [attr(ATTR_MAR_L, '0'), attr(ATTR_INDENT, '0')],
     children: [elem(NAME_BU_NONE)],
   });
-  const p = elem(NAME_P, { children: [pPr, r] });
-  return elem(NAME_TX_BODY, { children: [elem(NAME_BODY_PR), elem(NAME_LST_STYLE), p] });
+  // `<a:t>` is type xsd:string and cannot carry attributes — xml:space in
+  // particular is schema-invalid here. xsd:string preserves whitespace by
+  // default, so leading/trailing spaces and tabs survive without the hint.
+  const t = elem(NAME_T, { children: line.length > 0 ? [textNode(line)] : [] });
+  const r = elem(NAME_R, { children: [buildCellRunProps(textColorHex), t] });
+  return elem(NAME_P, { children: [pPr, r] });
+};
+
+const buildTextCellBody = (value: string, textColorHex: string | undefined): XmlElement => {
+  // A newline in `<a:t>` is not a line break — PowerPoint needs one paragraph
+  // per line. Split on '\n' so multi-line cell text renders as multiple rows.
+  const lines = value.length === 0 ? [''] : value.split('\n');
+  const paragraphs = lines.map((line) => buildCellParagraph(line, textColorHex));
+  return elem(NAME_TX_BODY, {
+    children: [elem(NAME_BODY_PR), elem(NAME_LST_STYLE), ...paragraphs],
+  });
 };
 
 // PowerPoint's default cell insets (0.1in horizontal, 0.05in vertical).
@@ -164,7 +169,7 @@ export const buildTableRow = (
   textColorHex?: string,
 ): XmlElement =>
   elem(NAME_TR, {
-    attrs: [attr(ATTR_H, String(Math.round(h)))],
+    attrs: [attr(ATTR_H, String(emuExtent(h, 'addSlideTable: row height')))],
     children: cells.map((value) => buildTableCell(value, textColorHex)),
   });
 
@@ -227,10 +232,16 @@ export const buildTable = (opts: TableOptions): XmlElement => {
   // Geometry. Round to whole EMU (matches the grid-col / row-height rounding
   // below); fractional ST_Coordinate values corrupt the file.
   const off = elem(NAME_OFF, {
-    attrs: [attr(ATTR_X, String(Math.round(opts.x))), attr(ATTR_Y, String(Math.round(opts.y)))],
+    attrs: [
+      attr(ATTR_X, String(emuCoordinate(opts.x, 'addSlideTable: x'))),
+      attr(ATTR_Y, String(emuCoordinate(opts.y, 'addSlideTable: y'))),
+    ],
   });
   const ext = elem(NAME_EXT, {
-    attrs: [attr(ATTR_CX, String(Math.round(opts.w))), attr(ATTR_CY, String(Math.round(opts.h)))],
+    attrs: [
+      attr(ATTR_CX, String(emuExtent(opts.w, 'addSlideTable: w'))),
+      attr(ATTR_CY, String(emuExtent(opts.h, 'addSlideTable: h'))),
+    ],
   });
   const xfrm = elem(NAME_P_XFRM, { children: [off, ext] });
 
@@ -239,7 +250,13 @@ export const buildTable = (opts: TableOptions): XmlElement => {
   // (§21.1.3.15): any fill/effect children precede it; we author none, so it
   // is the sole child.
   const tableStyleId = elem(NAME_TABLE_STYLE_ID, {
-    children: [textNode(opts.styleId ?? DEFAULT_TABLE_STYLE_ID)],
+    children: [
+      textNode(
+        opts.styleId === undefined
+          ? DEFAULT_TABLE_STYLE_ID
+          : normalizeGuid(opts.styleId, 'addSlideTable: styleId'),
+      ),
+    ],
   });
   const tblPr = elem(NAME_TBL_PR, {
     attrs: [
@@ -250,7 +267,9 @@ export const buildTable = (opts: TableOptions): XmlElement => {
   });
   const tblGrid = elem(NAME_TBL_GRID, {
     children: colWidths.map((w) =>
-      elem(NAME_GRID_COL, { attrs: [attr(ATTR_W, String(Math.round(w)))] }),
+      elem(NAME_GRID_COL, {
+        attrs: [attr(ATTR_W, String(emuExtent(w, 'addSlideTable: column width')))],
+      }),
     ),
   });
   const tableRows = rows.map((row, i) => buildTableRow(row, rowHeights[i] ?? 0, opts.textColorHex));

--- a/src/internal/presentationml/text-box-builder.ts
+++ b/src/internal/presentationml/text-box-builder.ts
@@ -6,6 +6,7 @@
 // the caller in EMU. Text properties beyond a single run are deferred to
 // future iterations.
 
+import { emuCoordinate, emuExtent } from '../bounds.ts';
 import { type XmlElement, NS, attr, elem, qname, text as textNode } from '../xml/index.ts';
 
 const NAME_SP = qname('p', 'sp', NS.pml);
@@ -79,10 +80,16 @@ export const buildTextBox = (opts: TextBoxOptions): XmlElement => {
 
   // Round to whole EMU; fractional ST_Coordinate values corrupt the file.
   const off = elem(NAME_OFF, {
-    attrs: [attr(ATTR_X, String(Math.round(opts.x))), attr(ATTR_Y, String(Math.round(opts.y)))],
+    attrs: [
+      attr(ATTR_X, String(emuCoordinate(opts.x, 'addSlideTextBox: x'))),
+      attr(ATTR_Y, String(emuCoordinate(opts.y, 'addSlideTextBox: y'))),
+    ],
   });
   const ext = elem(NAME_EXT, {
-    attrs: [attr(ATTR_CX, String(Math.round(opts.w))), attr(ATTR_CY, String(Math.round(opts.h)))],
+    attrs: [
+      attr(ATTR_CX, String(emuExtent(opts.w, 'addSlideTextBox: w'))),
+      attr(ATTR_CY, String(emuExtent(opts.h, 'addSlideTextBox: h'))),
+    ],
   });
   const xfrm = elem(NAME_A_XFRM, { children: [off, ext] });
   const prstGeom = elem(NAME_PRST_GEOM, {

--- a/src/internal/presentationml/transition-builder.ts
+++ b/src/internal/presentationml/transition-builder.ts
@@ -9,10 +9,13 @@
 //     cover, wipe, split, cut, dissolve, checker, blinds, randomBar,
 //     zoom, circle, diamond, plus, wedge, ...).
 //
-// Some effects accept a direction attribute (`dir`); the schema constrains
-// the legal values per element. We don't enforce that — let the user pass
-// what they want; xmllint will catch invalid combos in the test layer.
+// The effect attributes are not interchangeable: each effect element maps to a
+// distinct CT type that only permits certain attributes (CT_OptionalBlackTransition
+// → thruBlk; CT_SplitTransition → orient + dir; the direction families → dir).
+// Emitting an attribute on an effect that doesn't allow it is schema-invalid, so
+// buildEffectElement gates each attribute by the effect that accepts it.
 
+import { oneOf, unsignedIntMs } from '../bounds.ts';
 import { type XmlElement, NS, attr, elem, qname } from '../xml/index.ts';
 
 const NAME_TRANSITION = qname('p', 'transition', NS.pml);
@@ -52,7 +55,17 @@ export interface TransitionOptions {
   effect: TransitionEffect | string;
   /** Effect speed. Defaults to omitted (PowerPoint treats absence as `med`). */
   speed?: 'slow' | 'med' | 'fast';
-  /** Direction hint accepted by some effects (`l`/`r`/`u`/`d`/`in`/`out`/...). */
+  /**
+   * Direction, valid only for effects that carry a `dir` attribute and only
+   * within that effect's domain (validated on write):
+   *   - `blinds`/`checker`/`comb`/`randomBar`: `horz` | `vert`
+   *   - `push`/`wipe`: `l` | `r` | `u` | `d`
+   *   - `cover`/`pull`: the above plus `lu` | `ru` | `ld` | `rd`
+   *   - `strips`: `lu` | `ru` | `ld` | `rd`
+   *   - `zoom`/`split`: `in` | `out`
+   * A mismatched effect/direction pair throws; on any other effect a stray
+   * `direction` is ignored.
+   */
   direction?: string;
   /** For `split`: orientation token (`horz` / `vert`). */
   orientation?: 'horz' | 'vert';
@@ -67,12 +80,90 @@ export interface TransitionOptions {
   advanceAfterMs?: number;
 }
 
-const buildEffectElement = (opts: TransitionOptions): XmlElement => {
-  const name = qname('p', opts.effect, NS.pml);
+// Per-effect `dir` value domains (ECMA-376 Part 1, pml.xsd). The effect
+// element's CT type fixes which direction tokens are legal — they are NOT
+// interchangeable: blinds wants horz/vert, push wants l/r/u/d, zoom wants
+// in/out, etc. Emitting a token outside the effect's domain is schema-invalid,
+// so we validate `direction` against the effect here (a boundary).
+const DIR_ORIENT = new Set(['horz', 'vert']); // ST_Direction (CT_OrientationTransition)
+const DIR_SIDE = new Set(['l', 'u', 'r', 'd']); // ST_TransitionSideDirectionType
+const DIR_CORNER = new Set(['lu', 'ru', 'ld', 'rd']); // ST_TransitionCornerDirectionType
+const DIR_EIGHT = new Set([...DIR_SIDE, ...DIR_CORNER]); // ST_TransitionEightDirectionType
+const DIR_IN_OUT = new Set(['in', 'out']); // ST_TransitionInOutDirectionType
+const DIR_DOMAINS: Readonly<Record<string, ReadonlySet<string>>> = {
+  blinds: DIR_ORIENT,
+  checker: DIR_ORIENT,
+  comb: DIR_ORIENT,
+  randomBar: DIR_ORIENT,
+  push: DIR_SIDE,
+  wipe: DIR_SIDE,
+  cover: DIR_EIGHT,
+  pull: DIR_EIGHT,
+  strips: DIR_CORNER,
+  zoom: DIR_IN_OUT,
+  split: DIR_IN_OUT,
+};
+// Effects whose CT type carries `thruBlk` (CT_OptionalBlackTransition).
+const THRU_BLK_EFFECTS = new Set(['fade', 'cut']);
+
+// Every transition effect element name in CT_SlideTransition's choice
+// (ECMA-376 pml.xsd). `effect` is typed `TransitionEffect | string` for
+// forward-compat, so the raw token reaches the wire — validate it against the
+// full spec set, or an empty/unknown string yields non-well-formed or
+// schema-invalid XML. `none` is handled before this and is intentionally absent.
+const TRANSITION_EFFECTS: ReadonlyArray<string> = [
+  'blinds',
+  'checker',
+  'circle',
+  'dissolve',
+  'comb',
+  'cover',
+  'cut',
+  'diamond',
+  'fade',
+  'newsflash',
+  'plus',
+  'pull',
+  'push',
+  'random',
+  'randomBar',
+  'split',
+  'strips',
+  'wedge',
+  'wheel',
+  'wipe',
+  'zoom',
+];
+
+// Returns the single effect child, or null for the "no transition effect"
+// sentinel ('none' is not a valid effect element name — CT_SlideTransition's
+// choice has no `none` member).
+const buildEffectElement = (opts: TransitionOptions): XmlElement | null => {
+  if (opts.effect === 'none') return null;
+  const effect = oneOf(opts.effect, TRANSITION_EFFECTS, 'setSlideTransition: effect');
+  const name = qname('p', effect, NS.pml);
   const attrs = [];
-  if (opts.direction !== undefined) attrs.push(attr(ATTR_DIR, opts.direction));
-  if (opts.orientation !== undefined) attrs.push(attr(ATTR_ORIENT, opts.orientation));
-  if (opts.thruBlack) attrs.push(attr(ATTR_THRU_BLK, '1'));
+  if (opts.direction !== undefined) {
+    // Only effects with a `dir` attribute carry a domain; for any other effect
+    // a stray `direction` is ignored (it has nowhere valid to go).
+    const domain = DIR_DOMAINS[opts.effect];
+    if (domain !== undefined) {
+      if (!domain.has(opts.direction)) {
+        throw new Error(
+          `setSlideTransition: direction "${opts.direction}" is not valid for effect ` +
+            `"${opts.effect}" (allowed: ${[...domain].join(', ')})`,
+        );
+      }
+      attrs.push(attr(ATTR_DIR, opts.direction));
+    }
+  }
+  // `orient` only exists on CT_SplitTransition.
+  if (opts.orientation !== undefined && opts.effect === 'split') {
+    attrs.push(attr(ATTR_ORIENT, opts.orientation));
+  }
+  if (opts.thruBlack && THRU_BLK_EFFECTS.has(opts.effect)) {
+    attrs.push(attr(ATTR_THRU_BLK, '1'));
+  }
   return elem(name, { attrs });
 };
 
@@ -82,10 +173,13 @@ export const buildTransition = (opts: TransitionOptions): XmlElement => {
   if (opts.speed !== undefined) attrs.push(attr(ATTR_SPD, opts.speed));
   if (opts.advanceOnClick === false) attrs.push(attr(ATTR_ADV_CLICK, '0'));
   if (opts.advanceAfterMs !== undefined) {
-    attrs.push(attr(ATTR_ADV_TM, String(Math.round(opts.advanceAfterMs))));
+    // advTm is xsd:unsignedInt (0..4294967295 ms).
+    const advTm = unsignedIntMs(opts.advanceAfterMs, 'setSlideTransition: advanceAfterMs');
+    attrs.push(attr(ATTR_ADV_TM, String(advTm)));
   }
+  const effect = buildEffectElement(opts);
   return elem(NAME_TRANSITION, {
     attrs,
-    children: [buildEffectElement(opts)],
+    children: effect === null ? [] : [effect],
   });
 };

--- a/src/internal/xml/ast.ts
+++ b/src/internal/xml/ast.ts
@@ -114,3 +114,37 @@ export const pi = (target: string, data: string): XmlPI => ({ kind: 'pi', target
 // detail) but is preserved on the values themselves.
 export const qnameEquals = (a: QName, b: QName): boolean =>
   a.localName === b.localName && a.namespaceURI === b.namespaceURI;
+
+/**
+ * Inserts `element` into `parent.children` at the slot dictated by `rankOf`,
+ * keeping element children ordered by ascending rank (stable for equal ranks).
+ *
+ * Many OOXML complex types are `xsd:sequence`s: a child must appear in a fixed
+ * order relative to its siblings or the part fails schema validation. Setters
+ * that `push`/`unshift` produce valid output only when the caller happens to
+ * invoke them in schema order — fragile across independent mutation calls.
+ * Callers should strip any pre-existing same-element first, then use this to
+ * drop the new element at its mandated position regardless of call order.
+ *
+ * `rankOf` returns the sibling's sequence position; return a large number for
+ * trailing/unknown children so they sort to the end. Non-element nodes are
+ * skipped when scanning, and the new element lands before the first existing
+ * element whose rank is strictly greater.
+ */
+export const insertChildByRank = (
+  parent: XmlElement,
+  element: XmlElement,
+  rankOf: (el: XmlElement) => number,
+): void => {
+  const rank = rankOf(element);
+  let idx = parent.children.length;
+  for (let i = 0; i < parent.children.length; i++) {
+    const child = parent.children[i];
+    if (child?.kind !== 'element') continue;
+    if (rankOf(child) > rank) {
+      idx = i;
+      break;
+    }
+  }
+  parent.children.splice(idx, 0, element);
+};

--- a/src/internal/xml/index.ts
+++ b/src/internal/xml/index.ts
@@ -14,7 +14,17 @@ export type {
   XmlPI,
   XmlText,
 } from './ast.ts';
-export { attr, cdata, comment, elem, pi, qname, qnameEquals, text } from './ast.ts';
+export {
+  attr,
+  cdata,
+  comment,
+  elem,
+  insertChildByRank,
+  pi,
+  qname,
+  qnameEquals,
+  text,
+} from './ast.ts';
 export { NS, SUGGESTED_PREFIX } from './namespaces.ts';
 export { XmlParseError, parseFragment, parseXml } from './parse.ts';
 export {

--- a/src/internal/xml/serialize.ts
+++ b/src/internal/xml/serialize.ts
@@ -9,9 +9,10 @@
 //     element than where the parser placed them.
 //   - Predictable output for hand-built ASTs. Authoring-time code can assume
 //     the same input element produces the same byte sequence.
-//   - Escape rules tight enough for PowerPoint to accept the output. The five
-//     predefined entities, plus numeric references for control characters
-//     PowerPoint does not allow literally.
+//   - Escape rules tight enough for PowerPoint to accept the output: the
+//     predefined entities, numeric references for the whitespace controls that
+//     attribute-value normalization would otherwise eat (tab / LF / CR), and a
+//     hard reject for the C0 control characters XML 1.0 forbids outright.
 //
 // Out of scope:
 //
@@ -21,6 +22,23 @@
 
 import type { XmlAttr, XmlDocument, XmlElement, XmlNode } from './ast.ts';
 
+// XML 1.0 forbids the C0 control characters except tab (0x09), LF (0x0A), and
+// CR (0x0D). Unlike most escapable characters these cannot be rescued with a
+// numeric reference either — `&#0;` … `&#8;` are themselves illegal because the
+// referenced code point is not a legal `Char` (XML 1.0 §2.2). A value carrying
+// one can only have entered through authoring input (a parsed document could not
+// have held it), so we reject loudly: emitting it raw produces a non-well-formed
+// part that corrupts the entire .pptx, and silently dropping it would be a
+// surprise data loss. Strip the character upstream before authoring.
+const rejectForbiddenControlChar = (c: number): void => {
+  if (c < 0x20 && c !== 0x09 && c !== 0x0a && c !== 0x0d) {
+    const hex = c.toString(16).toUpperCase().padStart(4, '0');
+    throw new Error(
+      `XML-illegal control character U+${hex} in text; strip control characters before authoring`,
+    );
+  }
+};
+
 const escapeAttr = (s: string): string => {
   // Attribute values: escape <, &, and the quote char we use. We always use
   // double quotes, so single quotes pass through. CR and LF must be encoded
@@ -28,6 +46,7 @@ const escapeAttr = (s: string): string => {
   let out = '';
   for (let i = 0; i < s.length; i++) {
     const c = s.charCodeAt(i);
+    rejectForbiddenControlChar(c);
     if (c === 38) out += '&amp;';
     else if (c === 60) out += '&lt;';
     else if (c === 62) out += '&gt;';
@@ -44,6 +63,7 @@ const escapeText = (s: string): string => {
   let out = '';
   for (let i = 0; i < s.length; i++) {
     const c = s.charCodeAt(i);
+    rejectForbiddenControlChar(c);
     if (c === 38) out += '&amp;';
     else if (c === 60) out += '&lt;';
     else if (c === 62) out += '&gt;';

--- a/test/architecture.test.ts
+++ b/test/architecture.test.ts
@@ -14,13 +14,27 @@ type Module = 'api' | `internal/${string}`;
 const allowed: Record<Module, ReadonlyArray<Module> | 'any-internal'> = {
   api: 'any-internal',
   'internal/xml': [],
+  // Leaf utility: ECMA-376 simple-type bounds validation. Imports nothing, so
+  // every authoring layer may depend on it (like internal/xml).
+  'internal/bounds': [],
   'internal/opc': ['internal/xml'],
   'internal/parts': ['internal/opc', 'internal/xml'],
-  'internal/drawingml': ['internal/xml'],
-  'internal/presentationml': ['internal/drawingml', 'internal/parts', 'internal/xml'],
+  'internal/drawingml': ['internal/bounds', 'internal/xml'],
+  'internal/presentationml': [
+    'internal/bounds',
+    'internal/drawingml',
+    'internal/parts',
+    'internal/xml',
+  ],
   // chartml additionally needs `internal/opc` for the ZIP writer it uses to
   // emit the embedded xlsx workbook each chart wraps.
-  'internal/chartml': ['internal/drawingml', 'internal/opc', 'internal/parts', 'internal/xml'],
+  'internal/chartml': [
+    'internal/bounds',
+    'internal/drawingml',
+    'internal/opc',
+    'internal/parts',
+    'internal/xml',
+  ],
   'internal/diagram': ['internal/drawingml', 'internal/parts', 'internal/xml'],
   'internal/io': [
     'internal/opc',
@@ -54,6 +68,10 @@ const moduleOf = (absPath: string): Module | null => {
   if (rel.startsWith('api/')) return 'api';
   const m = rel.match(/^internal\/([^/]+)\//);
   if (m) return `internal/${m[1]}` as Module;
+  // A leaf utility may live as a single top-level file under internal/
+  // (e.g. internal/bounds.ts) rather than its own directory.
+  const top = rel.match(/^internal\/([^/]+)\.ts$/);
+  if (top) return `internal/${top[1]}` as Module;
   return null;
 };
 

--- a/test/bounds-validation.test.ts
+++ b/test/bounds-validation.test.ts
@@ -1,0 +1,292 @@
+// Regression net for the boundary-validation bug class: a batch of authoring
+// setters used to serialize caller-supplied numbers/strings straight into
+// constrained OOXML attributes, so an out-of-range value produced a `.pptx`
+// PowerPoint marks corrupt. Each authoring entry point now validates at the
+// boundary (src/internal/bounds.ts). These tests pin that an out-of-range value
+// THROWS (instead of emitting invalid XML), and that a valid extreme stays
+// schema-valid. See the fuzz-sweep findings these came from.
+
+import { describe, expect, it } from 'vitest';
+import {
+  _internalPackageOf,
+  addBlankSlide,
+  addSlideChart,
+  addSlideImage,
+  addSlideLine,
+  addSlideShape,
+  addSlideTable,
+  addSlideTextBox,
+  createPresentation,
+  getTableCell,
+  inches,
+  loadPresentation,
+  pt,
+  savePresentation,
+  setShapeAnimation,
+  setShapePatternFill,
+  setShapeRunFormat,
+  setShapeStroke,
+  setShapeTextBodyRotationDeg,
+  setShapeTextColumns,
+  setShapeTextMargins,
+  setSlideTransition,
+  setTableCellBorders,
+  setTableCellMargins,
+  setTableColumnWidth,
+  setTableRowHeight,
+  setTableStyleId,
+} from '../src/api/index.ts';
+import { buildPng } from './lib/build-png.ts';
+import {
+  expectSchemaValid,
+  isSchemaValidationAvailable,
+  type SchemaKind,
+} from './lib/expect-schema-valid.ts';
+
+const skipIfNoXmllint = isSchemaValidationAvailable() ? it : it.skip;
+const decode = (b: Uint8Array): string => new TextDecoder().decode(b);
+
+const kindFor = (name: string): SchemaKind | null => {
+  if (/\/(slides|notesSlides)\/[^/]*\.xml$/.test(name)) return 'pml';
+  if (/\/charts\/chart\d+\.xml$/.test(name)) return 'chart';
+  return null;
+};
+
+// Saves + reloads `pres` and validates every authored part against its schema.
+const expectDeckSchemaValid = async (
+  pres: ReturnType<typeof createPresentation>,
+): Promise<void> => {
+  const bytes = await savePresentation(pres);
+  const pkg = _internalPackageOf(await loadPresentation(bytes));
+  for (const part of pkg.parts) {
+    const kind = kindFor(part.name);
+    if (kind) expectSchemaValid(decode(part.data), kind);
+  }
+};
+
+const rect = (pres: ReturnType<typeof createPresentation>) =>
+  addSlideShape(addBlankSlide(pres), {
+    preset: 'rect',
+    x: inches(1),
+    y: inches(1),
+    w: inches(3),
+    h: inches(2),
+    text: 'X',
+  });
+
+const table = (pres: ReturnType<typeof createPresentation>) =>
+  addSlideTable(addBlankSlide(pres), {
+    x: inches(1),
+    y: inches(1),
+    w: inches(6),
+    h: inches(3),
+    rows: [
+      ['a', 'b'],
+      ['c', 'd'],
+    ],
+  });
+
+describe('bounds: text run formatting', () => {
+  it('rejects out-of-range font size and char spacing', () => {
+    const s = rect(createPresentation());
+    expect(() => setShapeRunFormat(s, 0, 0, { size: 0.5 })).toThrow(RangeError);
+    expect(() => setShapeRunFormat(s, 0, 0, { size: 5000 })).toThrow(RangeError);
+    expect(() => setShapeRunFormat(s, 0, 0, { spc: 9_999_999 })).toThrow(RangeError);
+    expect(() => setShapeRunFormat(s, 0, 0, { spc: -500_000 })).toThrow(RangeError);
+  });
+
+  it('accepts the 3-digit hex shorthand for run color and highlight', () => {
+    const s = rect(createPresentation());
+    expect(() => setShapeRunFormat(s, 0, 0, { color: '#f00' })).not.toThrow();
+    expect(() => setShapeRunFormat(s, 0, 0, { highlight: '#abc' })).not.toThrow();
+  });
+
+  skipIfNoXmllint('a valid extreme font size stays schema-valid', async () => {
+    const pres = createPresentation();
+    setShapeRunFormat(rect(pres), 0, 0, { size: 4000 });
+    await expectDeckSchemaValid(pres);
+  });
+});
+
+describe('bounds: tables', () => {
+  it('normalizes a lowercase GUID and rejects non-GUID style ids', () => {
+    const t = table(createPresentation());
+    // Lowercase is accepted and normalized (no throw).
+    expect(() => setTableStyleId(t, '{c8de2e6a-6fb6-4bfa-acec-8d87b36ff2c3}')).not.toThrow();
+    expect(() => setTableStyleId(t, 'MyCoolStyle')).toThrow(RangeError);
+    expect(() => setTableStyleId(t, '')).toThrow(RangeError);
+  });
+
+  it('rejects out-of-range cell border width, column width, row height, margins', () => {
+    const t = table(createPresentation());
+    const c = getTableCell(t, 0, 0);
+    expect(() => setTableCellBorders(c, { left: { color: '#000000', widthEmu: -5 } })).toThrow(
+      RangeError,
+    );
+    expect(() =>
+      setTableCellBorders(c, { left: { color: '#000000', widthEmu: 99_999_999 } }),
+    ).toThrow(RangeError);
+    expect(() => setTableColumnWidth(t, 0, 3e13 as ReturnType<typeof inches>)).toThrow(RangeError);
+    expect(() => setTableRowHeight(t, 0, 3e13 as ReturnType<typeof inches>)).toThrow(RangeError);
+    expect(() => setTableCellMargins(c, { left: 3e9 })).toThrow(RangeError);
+  });
+
+  it('rejects a table with negative width/height', () => {
+    const pres = createPresentation();
+    expect(() =>
+      addSlideTable(addBlankSlide(pres), {
+        x: inches(1),
+        y: inches(1),
+        w: -inches(3) as ReturnType<typeof inches>,
+        h: inches(2),
+        rows: [['a', 'b']],
+      }),
+    ).toThrow(RangeError);
+  });
+
+  skipIfNoXmllint('a normalized lowercase GUID is schema-valid', async () => {
+    const pres = createPresentation();
+    setTableStyleId(table(pres), '{c8de2e6a-6fb6-4bfa-acec-8d87b36ff2c3}');
+    await expectDeckSchemaValid(pres);
+  });
+});
+
+describe('bounds: charts', () => {
+  it('rejects out-of-range overlap and series line width', () => {
+    const pres = createPresentation();
+    expect(() =>
+      addSlideChart(addBlankSlide(pres), {
+        x: inches(0.5),
+        y: inches(0.5),
+        w: inches(8),
+        h: inches(4.5),
+        spec: {
+          kind: 'column',
+          categories: ['A', 'B'],
+          series: [{ name: 'S', values: [1, 2] }],
+          overlapPct: 101,
+        },
+      }),
+    ).toThrow(RangeError);
+    expect(() =>
+      addSlideChart(addBlankSlide(pres), {
+        x: inches(0.5),
+        y: inches(0.5),
+        w: inches(8),
+        h: inches(4.5),
+        spec: {
+          kind: 'line',
+          categories: ['A', 'B'],
+          series: [{ name: 'S', values: [1, 2], lineWidthEmu: -5 }],
+        },
+      }),
+    ).toThrow(RangeError);
+  });
+});
+
+describe('bounds: animations and transitions', () => {
+  it('rounds fractional but rejects negative/huge animation duration', () => {
+    const s = rect(createPresentation());
+    // A fractional ms is rounded to a valid integer (dur is unsignedInt), not rejected.
+    expect(() => setShapeAnimation(s, { effect: 'fadeIn', durationMs: 500.5 })).not.toThrow();
+    expect(() => setShapeAnimation(s, { effect: 'fadeIn', durationMs: -100 })).toThrow(RangeError);
+    expect(() => setShapeAnimation(s, { effect: 'fadeIn', durationMs: 5e9 })).toThrow(RangeError);
+  });
+
+  it('rejects out-of-range advance time and unknown/empty transition effect', () => {
+    const pres = createPresentation();
+    const slide = addBlankSlide(pres);
+    expect(() => setSlideTransition(slide, { effect: 'fade', advanceAfterMs: -100 })).toThrow(
+      RangeError,
+    );
+    expect(() => setSlideTransition(slide, { effect: 'fade', advanceAfterMs: 5e9 })).toThrow(
+      RangeError,
+    );
+    expect(() => setSlideTransition(slide, { effect: '' })).toThrow(RangeError);
+    expect(() => setSlideTransition(slide, { effect: 'bogusEffect' })).toThrow(RangeError);
+  });
+});
+
+describe('bounds: connectors and strokes', () => {
+  it('rejects out-of-range line / stroke width', () => {
+    const pres = createPresentation();
+    const slide = addBlankSlide(pres);
+    expect(() =>
+      addSlideLine(slide, {
+        from: { x: inches(1), y: inches(1) },
+        to: { x: inches(5), y: inches(3) },
+        widthEmu: -pt(2),
+      }),
+    ).toThrow(RangeError);
+    expect(() =>
+      addSlideLine(slide, {
+        from: { x: inches(1), y: inches(1) },
+        to: { x: inches(5), y: inches(3) },
+        widthEmu: 20_116_801,
+      }),
+    ).toThrow(RangeError);
+    const sh = rect(pres);
+    expect(() => setShapeStroke(sh, { color: '#000', widthEmu: -5 })).toThrow(RangeError);
+  });
+});
+
+describe('bounds: text box columns / margins / rotation', () => {
+  const textBox = (pres: ReturnType<typeof createPresentation>) =>
+    addSlideTextBox(addBlankSlide(pres), {
+      x: inches(1),
+      y: inches(1),
+      w: inches(4),
+      h: inches(2),
+      text: 'Hi',
+    });
+
+  it('rejects column count > 16, fractional count, negative gap', () => {
+    const s = textBox(createPresentation());
+    expect(() => setShapeTextColumns(s, { count: 20 })).toThrow(RangeError);
+    expect(() => setShapeTextColumns(s, { count: 2, gapEmu: -500 })).toThrow(RangeError);
+  });
+
+  it('rejects out-of-range text margins and body rotation', () => {
+    const s = textBox(createPresentation());
+    expect(() => setShapeTextMargins(s, { left: 3_000_000_000 })).toThrow(RangeError);
+    expect(() => setShapeTextBodyRotationDeg(s, 40_000)).toThrow(RangeError);
+  });
+});
+
+describe('bounds: fills and shape geometry', () => {
+  it('rejects an out-of-enum pattern preset', () => {
+    const s = rect(createPresentation());
+    expect(() =>
+      setShapePatternFill(s, {
+        preset: 'bogusPreset' as never,
+        foreground: '#000000',
+        background: '#FFFFFF',
+      }),
+    ).toThrow(RangeError);
+  });
+
+  it('rejects a shape positioned/sized out of range', () => {
+    const pres = createPresentation();
+    expect(() =>
+      addSlideShape(addBlankSlide(pres), {
+        preset: 'rect',
+        x: inches(1),
+        y: inches(1),
+        w: 3e13 as ReturnType<typeof inches>,
+        h: inches(2),
+      }),
+    ).toThrow(RangeError);
+  });
+
+  it('rejects an image sized out of range', () => {
+    const pres = createPresentation();
+    expect(() =>
+      addSlideImage(addBlankSlide(pres), buildPng(8, 8, [1, 2, 3]), {
+        x: inches(1),
+        y: inches(1),
+        w: -inches(3) as ReturnType<typeof inches>,
+        h: inches(2),
+      }),
+    ).toThrow(RangeError);
+  });
+});

--- a/test/fn-animation.test.ts
+++ b/test/fn-animation.test.ts
@@ -4,10 +4,14 @@ import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import {
+  addBlankSlide,
+  addSlideShape,
   clearSlideAnimations,
+  createPresentation,
   getSlideShapes,
   getSlideXmlString,
   getSlides,
+  inches,
   loadPresentation,
   savePresentation,
   setShapeAnimation,
@@ -62,7 +66,7 @@ describe('fn API: animations (v1 — single click-effect)', () => {
     expect(xml).toContain('val="hidden"');
   });
 
-  it('setShapeAnimation replaces any existing timing on the slide', async () => {
+  it('setShapeAnimation merges a second effect into the existing timing', async () => {
     const pres = await loadPresentation(await readFile(fixture('one-text-slide.pptx')));
     const slide = getSlides(pres)[0]!;
     const shape = getSlideShapes(slide)[0]!;
@@ -70,10 +74,38 @@ describe('fn API: animations (v1 — single click-effect)', () => {
     setShapeAnimation(shape, { effect: 'fadeOut', durationMs: 1000 });
 
     const xml = await slideXml(await savePresentation(pres), 0);
-    // Only one <p:timing> block, and it's the exit effect.
+    // A second call merges rather than replaces: still a single <p:timing>, but
+    // both the entrance and the exit effect survive (a replace implementation
+    // would drop the fadeIn). Two build entries, both preset classes present.
     expect(xml.match(/<p:timing>/g)?.length).toBe(1);
+    expect(xml).toContain('presetClass="entr"');
     expect(xml).toContain('presetClass="exit"');
+    expect((xml.match(/<p:bldP/g) ?? []).length).toBe(2);
     expect(xml).toContain('dur="1000"');
+  });
+
+  it('keeps grpId unique across several animated shapes', async () => {
+    const pres = createPresentation();
+    const slide = addBlankSlide(pres);
+    for (let i = 0; i < 3; i++) {
+      const shape = addSlideShape(slide, {
+        preset: 'rect',
+        x: inches(1 + i),
+        y: inches(1),
+        w: inches(1),
+        h: inches(1),
+        text: `s${i}`,
+      });
+      setShapeAnimation(shape, { effect: 'fadeIn' });
+    }
+    const xml = getSlideXmlString(getSlides(pres)[0]!);
+    const grpIds = [...xml.matchAll(/grpId="(\d+)"/g)].map((m) => m[1]);
+    // Each shape's build group must carry a distinct grpId — a duplicate would
+    // make PowerPoint fold two shapes' effects into one group.
+    const bldGrpIds = [...xml.matchAll(/<p:bldP[^>]*grpId="(\d+)"/g)].map((m) => m[1]);
+    expect(bldGrpIds.length).toBe(3);
+    expect(new Set(bldGrpIds).size).toBe(3);
+    expect(grpIds.length).toBeGreaterThan(0);
   });
 
   it('clearSlideAnimations removes the timing block', async () => {

--- a/test/fn-authoring-input-validation.test.ts
+++ b/test/fn-authoring-input-validation.test.ts
@@ -45,7 +45,7 @@ describe('addSlideChart: series color validation', () => {
   it('rejects a malformed hex (wrong length / non-hex digits)', () => {
     const pres = createPresentation();
     const slide = addBlankSlide(pres);
-    for (const bad of ['#FFF', '#GGGGGG', 'rgb(0,0,0)', '#12345']) {
+    for (const bad of ['#GGGGGG', 'rgb(0,0,0)', '#12345', '#FFFF']) {
       expect(() =>
         addSlideChart(slide, {
           x: inches(1),
@@ -91,6 +91,22 @@ describe('addSlideChart: series color validation', () => {
         w: inches(4),
         h: inches(3),
         spec: columnSpec('4472C4'),
+      }),
+    ).not.toThrow();
+  });
+
+  it('accepts the 3-digit hex shorthand', () => {
+    const pres = createPresentation();
+    const slide = addBlankSlide(pres);
+    // `#4cf` is the CSS-style shorthand LLM authors reach for; it must be
+    // accepted (and expanded to `44CCFF` internally), not rejected.
+    expect(() =>
+      addSlideChart(slide, {
+        x: inches(1),
+        y: inches(1),
+        w: inches(4),
+        h: inches(3),
+        spec: columnSpec('#4cf'),
       }),
     ).not.toThrow();
   });

--- a/test/fn-compact-package.test.ts
+++ b/test/fn-compact-package.test.ts
@@ -8,6 +8,7 @@ import {
   addSlideImage,
   compactPackage,
   getMediaParts,
+  getOrphanMediaPartNames,
   getSlides,
   inches,
   loadPresentation,
@@ -73,6 +74,35 @@ describe('fn API: compactPackage', () => {
     const reloaded = await loadPresentation(await savePresentation(pres));
     const before = getMediaParts(reloaded).length;
     expect(before).toBeGreaterThan(0);
+    expect(compactPackage(reloaded).removed).toEqual([]);
+    expect(getMediaParts(reloaded).length).toBe(before);
+  });
+
+  it('keeps media whose rel target case differs from the stored part name', async () => {
+    // OPC part names compare case-insensitively (ECMA-376 Part 2 §9.1.1), so a
+    // rel pointing at `../media/IMAGE1.PNG` still references the stored
+    // `/ppt/media/image1.png`. A case-sensitive compaction would wrongly drop it.
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    addSlideImage(getSlides(pres)[0]!, tinyPng(), {
+      x: inches(0),
+      y: inches(0),
+      w: inches(1),
+      h: inches(1),
+      format: 'png',
+    });
+    const reloaded = await loadPresentation(await savePresentation(pres));
+    const pkg = _internalPackageOf(reloaded);
+    const slideRels = pkg.getRels(partName('/ppt/slides/slide1.xml'))!;
+    // Uppercase only the media rel's target; leave layout/other rels untouched.
+    pkg.setRels(partName('/ppt/slides/slide1.xml'), {
+      items: slideRels.items.map((r) =>
+        r.target.includes('/media/') ? { ...r, target: r.target.toUpperCase() } : r,
+      ),
+    });
+    const before = getMediaParts(reloaded).length;
+    expect(before).toBeGreaterThan(0);
+
+    expect(getOrphanMediaPartNames(reloaded)).toEqual([]);
     expect(compactPackage(reloaded).removed).toEqual([]);
     expect(getMediaParts(reloaded).length).toBe(before);
   });

--- a/test/fn-image-brightness.test.ts
+++ b/test/fn-image-brightness.test.ts
@@ -1,4 +1,4 @@
-// Picture brightness via <a:lumOff>.
+// Picture brightness via the shared <a:blip><a:lum bright="…"/>.
 
 import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';

--- a/test/fn-image-contrast.test.ts
+++ b/test/fn-image-contrast.test.ts
@@ -1,14 +1,16 @@
-// Picture contrast via <a:lumMod>.
+// Picture contrast via the shared <a:blip><a:lum contrast="…"/>.
 
 import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import {
+  getShapeImageBrightness,
   getShapeImageContrast,
   getShapeKind,
   getSlideShapes,
   getSlides,
   loadPresentation,
+  setShapeImageBrightness,
   setShapeImageContrast,
 } from '../src/api/index.ts';
 
@@ -23,12 +25,26 @@ describe('fn API: setShapeImageContrast', () => {
     expect(getShapeImageContrast(picture)).toBeNull();
     setShapeImageContrast(picture, 0.5);
     expect(getShapeImageContrast(picture)).toBeCloseTo(0.5);
-    setShapeImageContrast(picture, 1.5);
-    expect(getShapeImageContrast(picture)).toBeCloseTo(1.5);
+    setShapeImageContrast(picture, -0.5);
+    expect(getShapeImageContrast(picture)).toBeCloseTo(-0.5);
     setShapeImageContrast(picture, null);
     expect(getShapeImageContrast(picture)).toBeNull();
-    setShapeImageContrast(picture, 1);
-    expect(getShapeImageContrast(picture)).toBeNull(); // value 1 is identity → cleared
+    setShapeImageContrast(picture, 0);
+    expect(getShapeImageContrast(picture)).toBeNull(); // value 0 is identity → cleared
+  });
+
+  it('shares one <a:lum> element with brightness', async () => {
+    const pres = await loadPresentation(await readFile(fixture('one-image-slide.pptx')));
+    const picture = getSlideShapes(getSlides(pres)[0]!).find((s) => getShapeKind(s) === 'picture')!;
+    setShapeImageBrightness(picture, 0.3);
+    setShapeImageContrast(picture, -0.2);
+    // Both corrections survive together.
+    expect(getShapeImageBrightness(picture)).toBeCloseTo(0.3);
+    expect(getShapeImageContrast(picture)).toBeCloseTo(-0.2);
+    // Clearing one leaves the other intact.
+    setShapeImageBrightness(picture, null);
+    expect(getShapeImageBrightness(picture)).toBeNull();
+    expect(getShapeImageContrast(picture)).toBeCloseTo(-0.2);
   });
 
   it('rejects non-pictures and out-of-range values', async () => {
@@ -41,7 +57,7 @@ describe('fn API: setShapeImageContrast', () => {
     const picture = getSlideShapes(getSlides(pres2)[0]!).find(
       (s) => getShapeKind(s) === 'picture',
     )!;
-    expect(() => setShapeImageContrast(picture, -0.1)).toThrow(RangeError);
+    expect(() => setShapeImageContrast(picture, -1.5)).toThrow(RangeError);
     expect(() => setShapeImageContrast(picture, 2.5)).toThrow(RangeError);
   });
 });

--- a/test/fn-import-slide.test.ts
+++ b/test/fn-import-slide.test.ts
@@ -4,6 +4,7 @@ import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import {
+  _internalPackageOf,
   addSlide,
   addSlideImage,
   findSlideLayout,
@@ -18,6 +19,7 @@ import {
   loadPresentation,
   savePresentation,
 } from '../src/api/index.ts';
+import { partName } from '../src/internal/opc/index.ts';
 
 const fixture = (name: string): string =>
   fileURLToPath(new URL(`./fixtures/minimal/${name}`, import.meta.url));
@@ -70,6 +72,49 @@ describe('fn API: importSlide', () => {
     const media = getMediaParts(target);
     expect(media.length).toBeGreaterThan(0);
     expect(media.some((m) => m.contentType.includes('png'))).toBe(true);
+  });
+
+  it('gives the layout rel a unique id when the source layout rel is not rId1', async () => {
+    // Real templates often store the layout rel at rId3 with an image at rId1.
+    // The new slide's layout rel must not collide with a preserved image rel id —
+    // a hardcoded "rId1" would emit two relationships with the same Id.
+    const src0 = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    addSlideImage(getSlides(src0)[0]!, tinyPng(), {
+      x: inches(0),
+      y: inches(0),
+      w: inches(2),
+      h: inches(2),
+      format: 'png',
+    });
+    const source = await loadPresentation(await savePresentation(src0));
+    const srcPkg = _internalPackageOf(source);
+    const srcSlide = partName('/ppt/slides/slide1.xml');
+    const srcRels = srcPkg.getRels(srcSlide)!;
+    // Move the image rel onto rId1 and the layout rel onto rId3, recreating the
+    // collision the old hardcoded-rId1 code produced.
+    srcPkg.setRels(srcSlide, {
+      items: srcRels.items.map((r) =>
+        r.target.includes('/media/')
+          ? { ...r, id: 'rId1' }
+          : r.target.includes('slideLayout')
+            ? { ...r, id: 'rId3' }
+            : r,
+      ),
+    });
+
+    const target = await loadPresentation(await readFile(fixture('blank.pptx')));
+    const layout = findSlideLayout(target, 'Title and Content')!;
+    importSlide(target, getSlides(source)[0]!, layout);
+
+    // Target started blank, so the only slide rels part is the imported slide.
+    const relsPart = _internalPackageOf(target).parts.find((p) =>
+      /\/ppt\/slides\/_rels\/slide\d+\.xml\.rels$/.test(p.name),
+    )!;
+    const ids = [...new TextDecoder().decode(relsPart.data).matchAll(/Id="([^"]+)"/g)].map(
+      (m) => m[1],
+    );
+    expect(ids.length).toBeGreaterThanOrEqual(2);
+    expect(new Set(ids).size).toBe(ids.length);
   });
 
   it('binds the imported slide to the supplied layout', async () => {

--- a/test/fn-package-introspect.test.ts
+++ b/test/fn-package-introspect.test.ts
@@ -27,4 +27,13 @@ describe('fn API: listPackageParts / readPackagePart', () => {
     expect(bytes!.byteLength).toBeGreaterThan(0);
     expect(readPackagePart(pres, '/nope.xml')).toBeNull();
   });
+
+  it('readPackagePart resolves the name case-insensitively (OPC part-name semantics)', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const exact = readPackagePart(pres, '/ppt/presentation.xml');
+    // A differently-cased name must resolve the same part (ECMA-376 Part 2 §9.1.1).
+    const mixed = readPackagePart(pres, '/ppt/Presentation.XML');
+    expect(mixed).not.toBeNull();
+    expect(mixed).toEqual(exact);
+  });
 });

--- a/test/fn-set-media-bytes.test.ts
+++ b/test/fn-set-media-bytes.test.ts
@@ -53,4 +53,19 @@ describe('fn API: setMediaPartBytes', () => {
     const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
     expect(setMediaPartBytes(pres, '/ppt/media/missing.png', tinyPng())).toBe(false);
   });
+
+  it('resolves the part name case-insensitively (OPC part-name semantics)', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    addSlideImage(getSlides(pres)[0]!, tinyPng(), {
+      x: inches(0),
+      y: inches(0),
+      w: inches(1),
+      h: inches(1),
+      format: 'png',
+    });
+    const target = getMediaParts(pres)[0]!;
+    // A differently-cased name must hit the same part (ECMA-376 Part 2 §9.1.1).
+    expect(setMediaPartBytes(pres, target.name.toUpperCase(), otherPng())).toBe(true);
+    expect(getMediaParts(pres)[0]!.data).toEqual(otherPng());
+  });
 });

--- a/test/generative-fuzz.test.ts
+++ b/test/generative-fuzz.test.ts
@@ -1,0 +1,342 @@
+// Generative schema-validity fuzzing — the exhaustive net behind the per-setter
+// regression tests. It composes many random-but-valid decks from the public
+// authoring API (random combinations of shapes, formatting, tables, charts,
+// images, transitions, animations) and asserts that EVERY emitted part is
+// schema-valid against the ECMA-376 XSDs. Hand-written examples cover known
+// cases; this covers the combinatorial space where "feature A + feature B emits
+// invalid child order / an attribute on the wrong type" bugs hide.
+//
+// Deterministic: a fixed seed drives a small PRNG, so a failure reproduces and
+// CI is stable. The failing iteration's seed/index is reported. Bump ITERATIONS
+// locally to fuzz harder.
+
+import { describe, it } from 'vitest';
+import {
+  _internalPackageOf,
+  addBlankSlide,
+  addContentSlide,
+  addSlideChart,
+  addSlideImage,
+  addSlideLine,
+  addSlideShape,
+  addSlideTable,
+  addSlideTextBox,
+  addTitleSlide,
+  createPresentation,
+  getTableCell,
+  inches,
+  loadPresentation,
+  pt,
+  type PresentationData,
+  savePresentation,
+  setShapeAnimation,
+  setShapeFill,
+  setShapeGradientFill,
+  setShapePatternFill,
+  setShapeRunFormat,
+  setShapeShadow,
+  setShapeStroke,
+  setShapeTextColumns,
+  setSlideNotes,
+  setSlideTransition,
+  setTableCellBorders,
+  setTableCellFill,
+} from '../src/api/index.ts';
+import { buildPng } from './lib/build-png.ts';
+import {
+  expectSchemaValid,
+  isSchemaValidationAvailable,
+  type SchemaKind,
+} from './lib/expect-schema-valid.ts';
+
+const skipIfNoXmllint = isSchemaValidationAvailable() ? it : it.skip;
+const decode = (b: Uint8Array): string => new TextDecoder().decode(b);
+
+const kindFor = (name: string): SchemaKind | null => {
+  if (/\/(slides|slideLayouts|slideMasters|notesSlides|notesMasters)\/[^/]*\.xml$/.test(name)) {
+    return 'pml';
+  }
+  if (name === '/ppt/presentation.xml') return 'pml';
+  if (/\/charts\/chart\d+\.xml$/.test(name)) return 'chart';
+  if (/\/theme\/theme\d+\.xml$/.test(name)) return 'dml';
+  return null;
+};
+
+// mulberry32 — tiny deterministic PRNG so failures reproduce.
+const makeRng = (seed: number): (() => number) => {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+};
+
+const HEX = '0123456789abcdef';
+const SCHEME = ['accent1', 'accent2', 'accent3', 'tx1', 'bg1', 'dk1', 'lt1'];
+const PATTERNS = ['pct50', 'dkUpDiag', 'wave', 'cross', 'horzBrick', 'zigZag'] as const;
+const TRANSITIONS = [
+  { effect: 'fade' as const },
+  { effect: 'fade' as const, thruBlack: true },
+  { effect: 'push' as const, direction: 'l' },
+  { effect: 'wipe' as const, direction: 'd' },
+  { effect: 'blinds' as const, direction: 'horz' },
+  { effect: 'split' as const, orientation: 'horz' as const },
+  { effect: 'cover' as const, direction: 'ru' },
+  { effect: 'zoom' as const, direction: 'in' },
+  { effect: 'dissolve' as const },
+  { effect: 'none' as const },
+];
+const ANIMS = ['fadeIn', 'fadeOut', 'appear', 'disappear'] as const;
+// Authorable chart kinds (scatter / radar / bubble are read-only for now).
+const CHART_KINDS = ['bar', 'column', 'line', 'pie', 'doughnut', 'area'] as const;
+
+const validateDeck = (pres: PresentationData): void => {
+  const pkg = _internalPackageOf(pres);
+  for (const part of pkg.parts) {
+    const kind = kindFor(part.name);
+    if (kind) expectSchemaValid(decode(part.data), kind);
+  }
+};
+
+describe('generative fuzz: every authored part is schema-valid', () => {
+  // Each iteration saves a deck and shells out to xmllint per part, so keep the
+  // count modest for CI; bump locally to fuzz harder. Generous timeout covers
+  // the per-part process spawns.
+  const ITERATIONS = 40;
+
+  skipIfNoXmllint(
+    'random valid decks validate against the ECMA-376 XSDs',
+    async () => {
+      for (let iter = 0; iter < ITERATIONS; iter++) {
+        const seed = 0x9e3779b9 ^ (iter * 0x85ebca77);
+        const rng = makeRng(seed);
+        const pick = <T>(arr: ReadonlyArray<T>): T => arr[Math.floor(rng() * arr.length)]!;
+        const chance = (p: number): boolean => rng() < p;
+        const color = (): string => {
+          if (chance(0.3)) {
+            const token = pick(SCHEME);
+            // Exercise both spellings the API accepts: bare and `scheme:`-prefixed
+            // (the latter is what the read-back getters emit, so it must round-trip).
+            return chance(0.5) ? `scheme:${token}` : token;
+          }
+          let s = '#';
+          const n = chance(0.5) ? 3 : 6;
+          for (let i = 0; i < n; i++) s += HEX[Math.floor(rng() * 16)];
+          return s;
+        };
+        const emu = (lo: number, hi: number) => inches(lo + rng() * (hi - lo));
+
+        let pres: PresentationData;
+        try {
+          pres = createPresentation(chance(0.5) ? { size: '16:9' } : { size: '4:3' });
+
+          const slideCount = 1 + Math.floor(rng() * 3);
+          for (let s = 0; s < slideCount; s++) {
+            const flavor = rng();
+            if (flavor < 0.2) {
+              addTitleSlide(pres, `Deck ${iter} slide ${s}`);
+              continue;
+            }
+            if (flavor < 0.35) {
+              addContentSlide(pres, { title: `T${s}` });
+              continue;
+            }
+            const slide = addBlankSlide(pres);
+
+            // A handful of random shapes with stacked random formatting.
+            const shapeCount = 1 + Math.floor(rng() * 4);
+            for (let k = 0; k < shapeCount; k++) {
+              const hasText = chance(0.7);
+              const sh = addSlideShape(slide, {
+                preset: pick([
+                  'rect',
+                  'roundRect',
+                  'ellipse',
+                  'triangle',
+                  'diamond',
+                  'mathMinus',
+                  'mathMultiply',
+                  'mathNotEqual',
+                ]),
+                x: emu(0.2, 4),
+                y: emu(0.2, 3),
+                w: emu(0.5, 4),
+                h: emu(0.5, 3),
+                ...(hasText ? { text: `s${k}` } : {}),
+                textAnchor: pick(['t', 'ctr', 'b']),
+              });
+              const fillRoll = rng();
+              if (fillRoll < 0.4) {
+                setShapeFill(sh, color());
+              } else if (fillRoll < 0.7) {
+                setShapeGradientFill(sh, {
+                  stops: [
+                    { offset: 0, color: color() },
+                    { offset: 1, color: color() },
+                  ],
+                  angleDeg: Math.floor(rng() * 360),
+                  ...(chance(0.4) ? { path: pick(['circle', 'rect'] as const) } : {}),
+                });
+              } else {
+                setShapePatternFill(sh, {
+                  preset: pick(PATTERNS),
+                  foreground: color(),
+                  background: color(),
+                });
+              }
+              if (chance(0.5)) {
+                setShapeStroke(sh, {
+                  color: color(),
+                  widthEmu: pt(0.5 + rng() * 4),
+                  ...(chance(0.5) ? { dash: pick(['dash', 'dot', 'dashDot']) } : {}),
+                });
+              }
+              if (chance(0.4)) {
+                setShapeShadow(sh, {
+                  color: '#000000',
+                  blurEmu: pt(rng() * 10),
+                  offsetEmu: pt(rng() * 6),
+                  angleDeg: Math.floor(rng() * 360),
+                  opacity: rng(),
+                });
+              }
+              if (hasText && chance(0.6)) {
+                setShapeRunFormat(sh, 0, 0, {
+                  bold: chance(0.5),
+                  italic: chance(0.5),
+                  size: 8 + Math.floor(rng() * 40),
+                  color: color(),
+                  ...(chance(0.3) ? { underline: true } : {}),
+                  ...(chance(0.3) ? { highlight: color() } : {}),
+                });
+              }
+              if (hasText && chance(0.2))
+                setShapeTextColumns(sh, { count: 2 + Math.floor(rng() * 3) });
+              if (chance(0.3)) setShapeAnimation(sh, { effect: pick(ANIMS) });
+            }
+
+            // Random extras.
+            if (chance(0.4)) {
+              addSlideTextBox(slide, {
+                x: emu(0.3, 3),
+                y: emu(0.3, 3),
+                w: emu(1, 4),
+                h: emu(0.5, 2),
+                text: `box ${iter}-${s}`,
+              });
+            }
+            if (chance(0.4)) {
+              addSlideLine(slide, {
+                from: { x: emu(0.2, 2), y: emu(0.2, 2) },
+                to: { x: emu(2, 5), y: emu(2, 4) },
+                ...(chance(0.6) ? { color: color(), widthEmu: pt(0.5 + rng() * 3) } : {}),
+              });
+            }
+            if (chance(0.35)) {
+              const t = addSlideTable(slide, {
+                x: emu(0.3, 2),
+                y: emu(0.3, 2),
+                w: emu(3, 7),
+                h: emu(1, 3),
+                rows: [
+                  ['H1', 'H2', 'H3'],
+                  ['a', 'b', 'c'],
+                  ['d', 'e', 'f'],
+                ],
+                firstRow: chance(0.7),
+                bandRow: chance(0.7),
+              });
+              if (chance(0.5)) {
+                const cell = getTableCell(t, 1, 1);
+                setTableCellFill(cell, color());
+                if (chance(0.5)) {
+                  setTableCellBorders(cell, {
+                    top: { color: color(), widthEmu: pt(0.5 + rng() * 2) },
+                    bottom: { color: color(), widthEmu: pt(0.5 + rng() * 2) },
+                  });
+                }
+              }
+            }
+            if (chance(0.3)) {
+              const kind = pick(CHART_KINDS);
+              // pie / doughnut take exactly one series.
+              const single = kind === 'pie' || kind === 'doughnut';
+              const series = single
+                ? [{ name: 'A', values: [1, 2, 3, 4], ...(chance(0.5) ? { color: '4472C4' } : {}) }]
+                : [
+                    {
+                      name: 'A',
+                      values: [1, 2, 3, 4],
+                      ...(chance(0.5) ? { color: '4472C4' } : {}),
+                    },
+                    { name: 'B', values: [4, 3, 2, 1] },
+                  ];
+              addSlideChart(slide, {
+                x: emu(0.3, 2),
+                y: emu(0.3, 2),
+                w: emu(4, 7),
+                h: emu(2, 4),
+                spec: {
+                  kind,
+                  categories: ['Q1', 'Q2', 'Q3', 'Q4'],
+                  series,
+                  // Random-but-valid percentages for the kinds that take them, so
+                  // the bounds wrappers (gap 0..500, hole 1..90, angle 0..360) are
+                  // exercised at real values rather than only at the defaults.
+                  ...((kind === 'bar' || kind === 'column') && chance(0.5)
+                    ? { gapWidthPct: Math.floor(rng() * 501) }
+                    : {}),
+                  ...(kind === 'doughnut' && chance(0.5)
+                    ? { holeSizePct: 1 + Math.floor(rng() * 90) }
+                    : {}),
+                  ...((kind === 'pie' || kind === 'doughnut') && chance(0.5)
+                    ? { firstSliceAngleDeg: Math.floor(rng() * 361) }
+                    : {}),
+                  ...(chance(0.5)
+                    ? {
+                        dataLabels: {
+                          showValue: true,
+                          showCategory: false,
+                          showSeriesName: false,
+                          showPercent: false,
+                        },
+                      }
+                    : {}),
+                },
+              });
+            }
+            if (chance(0.3)) {
+              addSlideImage(slide, buildPng(32, 24, [Math.floor(rng() * 255), 10, 200]), {
+                x: emu(0.3, 3),
+                y: emu(0.3, 3),
+                w: emu(1, 3),
+                h: emu(1, 3),
+                fit: pick(['contain', 'fill'] as const),
+              });
+            }
+            if (chance(0.5)) setSlideTransition(slide, pick(TRANSITIONS));
+            if (chance(0.3)) setSlideNotes(slide, `notes for ${iter}-${s} <&> "ok"`);
+          }
+        } catch (err) {
+          // A thrown boundary error is acceptable (rejecting bad input is correct);
+          // only schema-INVALID *output* is a failure. But our generators only emit
+          // valid ranges, so a throw here is an unexpected bug — surface it.
+          throw new Error(`iteration ${iter} (seed ${seed}) threw unexpectedly: ${String(err)}`);
+        }
+
+        try {
+          const bytes = await savePresentation(pres);
+          validateDeck(await loadPresentation(bytes));
+        } catch (err) {
+          throw new Error(
+            `iteration ${iter} (seed ${seed}) produced invalid output: ${String(err)}`,
+          );
+        }
+      }
+    },
+    120_000,
+  );
+});

--- a/test/l3-connectors.test.ts
+++ b/test/l3-connectors.test.ts
@@ -58,7 +58,7 @@ describe('L3: addSlideLine', () => {
     expect(xml).toContain('flipV="1"');
   });
 
-  it('omits the ln element when no color or width is given', async () => {
+  it('gives an unstyled connector a visible default line style', async () => {
     const { pres, slide } = await newSlide();
     addSlideLine(slide, {
       from: { x: inches(0), y: inches(0) },
@@ -67,7 +67,11 @@ describe('L3: addSlideLine', () => {
     const xml = getSlideXmlString(getSlides(pres).at(-1)!);
     expect(xml).toContain('<p:cxnSp>');
     expect(xml).toContain('prst="line"');
-    expect((xml.match(/<a:ln/g) ?? []).length).toBe(0);
+    // No explicit <a:ln> (inherits width), but a <p:style><a:lnRef idx="1"> so
+    // the line still renders — without it the connector would be invisible.
+    expect((xml.match(/<a:ln[ >]/g) ?? []).length).toBe(0);
+    expect(xml).toContain('<p:style>');
+    expect(xml).toContain('<a:lnRef idx="1">');
   });
 
   skipIfNoXmllint('connector validates against pml.xsd', async () => {

--- a/test/l3-transitions.test.ts
+++ b/test/l3-transitions.test.ts
@@ -38,6 +38,50 @@ describe('L3: setSlideTransition', () => {
     expect(xml).toContain('spd="fast"');
   });
 
+  it("rejects a direction outside the effect's domain", async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    // `blinds` is CT_OrientationTransition (dir = horz|vert); the side token `l`
+    // would emit schema-invalid XML, so it must be rejected at the boundary.
+    expect(() => setSlideTransition(slide, { effect: 'blinds', direction: 'l' })).toThrow(
+      /not valid for effect/,
+    );
+  });
+
+  skipIfNoXmllint('an orientation-family direction (blinds horz) is schema-valid', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    setSlideTransition(slide, { effect: 'blinds', direction: 'horz' });
+    const xml = getSlideXmlString(getSlides(pres)[0]!);
+    expect(xml).toContain('<p:blinds dir="horz"/>');
+    expectSchemaValid(xml, 'pml');
+  });
+
+  it('drops orientation on non-split and thruBlack on non-fade/cut effects', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    // `orient` exists only on CT_SplitTransition; `thruBlk` only on
+    // CT_OptionalBlackTransition (fade/cut). On `wipe` neither may appear.
+    setSlideTransition(slide, { effect: 'wipe', orientation: 'horz', thruBlack: true });
+    const xml = getSlideXmlString(getSlides(pres)[0]!);
+    expect(xml).toContain('<p:wipe/>');
+    expect(xml).not.toContain('orient');
+    expect(xml).not.toContain('thruBlk');
+  });
+
+  skipIfNoXmllint('emits orient on split and thruBlk on fade (schema-valid)', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    setSlideTransition(getSlides(pres)[0]!, { effect: 'split', orientation: 'horz' });
+    const splitXml = getSlideXmlString(getSlides(pres)[0]!);
+    expect(splitXml).toContain('<p:split orient="horz"/>');
+    expectSchemaValid(splitXml, 'pml');
+
+    setSlideTransition(getSlides(pres)[1]!, { effect: 'fade', thruBlack: true });
+    const fadeXml = getSlideXmlString(getSlides(pres)[1]!);
+    expect(fadeXml).toContain('thruBlk="1"');
+    expectSchemaValid(fadeXml, 'pml');
+  });
+
   it('emits advClick / advTm only when not default', async () => {
     const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
     const slide = getSlides(pres)[0]!;

--- a/test/preview-render-svg.test.ts
+++ b/test/preview-render-svg.test.ts
@@ -21,6 +21,7 @@ import {
   getSlides,
   inches,
   loadPresentation,
+  type PatternPreset,
   savePresentation,
   setShapeFill,
   setShapeGradientFill,
@@ -113,7 +114,7 @@ describe('renderSlideToSvg', () => {
   });
 
   it('pattern fill density scales with the pct preset', async () => {
-    const cells = async (preset: string): Promise<number> => {
+    const cells = async (preset: PatternPreset): Promise<number> => {
       const { pres, slide } = await blankSlide();
       const shape = addSlideShape(slide, {
         preset: 'rect',
@@ -126,10 +127,11 @@ describe('renderSlideToSvg', () => {
       const svg = renderSlideToSvg(pres, slide);
       return (svg.match(/width="2" height="2"/g) ?? []).length;
     };
-    // 4/16 Bayer cells lit at 25%, 8 at 50%; pct0 lights none.
+    // 4/16 Bayer cells lit at 25%, 8 at 50%; the sparsest preset lights fewer
+    // than 25%. (pct0 is not a valid ST_PresetPatternVal, so it can't be tested.)
     expect(await cells('pct25')).toBe(4);
     expect(await cells('pct50')).toBe(8);
-    expect(await cells('pct0')).toBe(0);
+    expect(await cells('pct5')).toBeLessThan(4);
   });
 
   it('foreignObject mode wraps text body in <foreignObject>', async () => {

--- a/test/schema-authoring-coverage.test.ts
+++ b/test/schema-authoring-coverage.test.ts
@@ -1,0 +1,361 @@
+// Schema coverage for the from-scratch authoring API.
+//
+// Regression net for a batch of "generates but is schema-invalid / wrong"
+// defects: every probe builds a deck through the public API, saves + reloads,
+// and runs each authored part (slides / charts / notes) through `xmllint`
+// against the ECMA-376 XSDs. Spec-deviations the schema can't catch (a radial
+// gradient silently emitted as linear, etc.) are pinned with content checks.
+
+import { describe, expect, it } from 'vitest';
+import {
+  _internalPackageOf,
+  addBlankSlide,
+  addSlideChart,
+  addSlideImage,
+  addSlideLine,
+  addSlideShape,
+  addSlideTable,
+  createPresentation,
+  getParagraphLineSpacing,
+  getSlideShapes,
+  getSlides,
+  inches,
+  loadPresentation,
+  pt,
+  savePresentation,
+  setParagraphLineSpacing,
+  setParagraphSpacing,
+  setShapeAnimation,
+  setShapeFill,
+  setShapeGradientFill,
+  setShapeImageBrightness,
+  setShapeImageContrast,
+  setShapeRunFormat,
+  setShapeStroke,
+  setShapeStrokeArrow,
+  setShapeStrokeDash,
+  setShapeStrokeJoin,
+  setShapeText,
+  setSlideNotes,
+  setSlideTransition,
+  getTableCell,
+  setTableCellBorders,
+  setTableCellFill,
+} from '../src/api/index.ts';
+import { buildPng } from './lib/build-png.ts';
+import {
+  expectSchemaValid,
+  isSchemaValidationAvailable,
+  type SchemaKind,
+} from './lib/expect-schema-valid.ts';
+
+const skipIfNoXmllint = isSchemaValidationAvailable() ? it : it.skip;
+const decode = (b: Uint8Array): string => new TextDecoder().decode(b);
+
+const kindFor = (name: string): SchemaKind | null => {
+  if (/\/(slides|notesSlides)\/[^/]*\.xml$/.test(name)) return 'pml';
+  if (/\/charts\/chart\d+\.xml$/.test(name)) return 'chart';
+  return null;
+};
+
+// Saves + reloads `pres`, validates each authored part against its schema, and
+// returns the concatenated XML of those parts for content assertions.
+const authoredXml = async (pres: ReturnType<typeof createPresentation>): Promise<string> => {
+  const bytes = await savePresentation(pres);
+  const pkg = _internalPackageOf(await loadPresentation(bytes));
+  let combined = '';
+  for (const part of pkg.parts) {
+    const kind = kindFor(part.name);
+    if (kind === null) continue;
+    const xml = decode(part.data);
+    expectSchemaValid(xml, kind);
+    combined += `\n<!-- ${part.name} -->\n${xml}`;
+  }
+  return combined;
+};
+
+const shape = (pres: ReturnType<typeof createPresentation>, preset = 'rect') =>
+  addSlideShape(addBlankSlide(pres), {
+    preset,
+    x: inches(1),
+    y: inches(1),
+    w: inches(3),
+    h: inches(2),
+    text: 'X',
+  });
+
+describe('schema coverage: text run + paragraph ordering', () => {
+  skipIfNoXmllint('color + highlight on one run stays in schema order', async () => {
+    const pres = createPresentation();
+    setShapeRunFormat(shape(pres), 0, 0, { color: '#112233', highlight: '#FFFF00', font: 'Arial' });
+    await authoredXml(pres);
+  });
+
+  skipIfNoXmllint('paragraph spacing after a bullet stays in schema order', async () => {
+    const pres = createPresentation();
+    const s = shape(pres);
+    setShapeText(s, 'a\nb\nc', { bullets: 'bullet' });
+    setParagraphSpacing(s, 0, { beforePts: 6, afterPts: 6 });
+    await authoredXml(pres);
+  });
+
+  skipIfNoXmllint('setParagraphLineSpacing writes lnSpc first', async () => {
+    const pres = createPresentation();
+    const s = shape(pres);
+    setShapeText(s, 'a\nb', { bullets: 'bullet' });
+    setParagraphLineSpacing(s, 0, { kind: 'pct', value: 1.5 });
+    const xml = await authoredXml(pres);
+    expect(xml).toContain('<a:lnSpc>');
+    // 1.5x → `<a:spcPct val="150000"/>` (val is 1000ths of a percent).
+    expect(xml).toContain('<a:spcPct val="150000"/>');
+  });
+
+  it('setParagraphLineSpacing converts both modes, clears, and rejects bad input', () => {
+    const pres = createPresentation();
+    const s = shape(pres);
+    setShapeText(s, 'a\nb', { bullets: 'bullet' });
+
+    // pct mode round-trips through the getter (1.5x).
+    setParagraphLineSpacing(s, 0, { kind: 'pct', value: 1.5 });
+    expect(getParagraphLineSpacing(s, 0)).toEqual({ kind: 'pct', value: 1.5 });
+
+    // pts mode: 24pt is stored as `<a:spcPts val="2400">` (×100) and reads back
+    // as 24 — a wrong write factor would fail this round-trip.
+    setParagraphLineSpacing(s, 0, { kind: 'pts', value: 24 });
+    expect(getParagraphLineSpacing(s, 0)).toEqual({ kind: 'pts', value: 24 });
+
+    // null clears the override.
+    setParagraphLineSpacing(s, 0, null);
+    expect(getParagraphLineSpacing(s, 0)).toBeNull();
+
+    // Negative / non-finite values are rejected at the boundary.
+    expect(() => setParagraphLineSpacing(s, 0, { kind: 'pct', value: -1 })).toThrow(RangeError);
+    expect(() => setParagraphLineSpacing(s, 0, { kind: 'pts', value: Number.NaN })).toThrow(
+      RangeError,
+    );
+  });
+});
+
+describe('schema coverage: stroke sub-element ordering', () => {
+  skipIfNoXmllint('dash + arrowheads + join combine in schema order', async () => {
+    const pres = createPresentation();
+    const s = shape(pres);
+    setShapeStroke(s, { color: '#000000', widthEmu: pt(2) });
+    setShapeStrokeDash(s, 'dash');
+    setShapeStrokeArrow(s, 'tail', { type: 'triangle', width: 'med', length: 'med' });
+    setShapeStrokeArrow(s, 'head', { type: 'oval' });
+    setShapeStrokeJoin(s, 'round');
+    await authoredXml(pres);
+  });
+});
+
+describe('schema coverage: fills', () => {
+  skipIfNoXmllint('3-digit hex shorthand is accepted', async () => {
+    const pres = createPresentation();
+    setShapeFill(shape(pres), '#f0a');
+    await authoredXml(pres);
+  });
+
+  skipIfNoXmllint('radial gradient emits <a:path>, not a downgraded <a:lin>', async () => {
+    const pres = createPresentation();
+    setShapeGradientFill(shape(pres), {
+      stops: [
+        { offset: 0, color: '#FFFFFF' },
+        { offset: 1, color: '#000000' },
+      ],
+      path: 'circle',
+      focus: { left: 0.5, top: 0.5, right: 0.5, bottom: 0.5 },
+    });
+    const xml = await authoredXml(pres);
+    expect(xml).toContain('<a:path');
+    expect(xml).toContain('<a:fillToRect');
+  });
+});
+
+describe('schema coverage: tables', () => {
+  skipIfNoXmllint('whitespace-padded / multi-line cells stay valid', async () => {
+    const pres = createPresentation();
+    addSlideTable(addBlankSlide(pres), {
+      x: inches(1),
+      y: inches(1),
+      w: inches(6),
+      h: inches(3),
+      rows: [
+        [' leading', 'trailing '],
+        ['mid\tdle', 'two\nlines'],
+      ],
+    });
+    const xml = await authoredXml(pres);
+    expect(xml).not.toContain('xml:space');
+    // A `\n` splits the cell into separate paragraphs — each line is its own
+    // `<a:t>`, not one run carrying an embedded newline (the old behavior).
+    expect(xml).toContain('<a:t>two</a:t>');
+    expect(xml).toContain('<a:t>lines</a:t>');
+  });
+
+  skipIfNoXmllint('cell fill then border keeps tcPr children ordered', async () => {
+    const pres = createPresentation();
+    const t = addSlideTable(addBlankSlide(pres), {
+      x: inches(1),
+      y: inches(1),
+      w: inches(6),
+      h: inches(3),
+      rows: [
+        ['a', 'b'],
+        ['1', '2'],
+      ],
+    });
+    const c = getTableCell(t, 0, 0)!;
+    setTableCellFill(c, '#FFEEAA');
+    setTableCellBorders(c, {
+      left: { color: '#000000', widthEmu: pt(1) },
+      bottom: { color: '#FF0000', widthEmu: pt(2) },
+    });
+    await authoredXml(pres);
+  });
+});
+
+describe('schema coverage: transitions', () => {
+  skipIfNoXmllint("effect 'none' emits no effect child", async () => {
+    const pres = createPresentation();
+    setSlideTransition(addBlankSlide(pres), { effect: 'none' });
+    const xml = await authoredXml(pres);
+    expect(xml).not.toContain('<p:none');
+  });
+
+  skipIfNoXmllint('an incompatible attribute is dropped, not emitted', async () => {
+    const pres = createPresentation();
+    // `dir` is invalid on a fade (CT_OptionalBlackTransition) — must be dropped.
+    setSlideTransition(addBlankSlide(pres), { effect: 'fade', direction: 'l' });
+    const xml = await authoredXml(pres);
+    expect(xml).not.toContain('<p:fade dir');
+  });
+});
+
+describe('schema coverage: charts', () => {
+  const chart = (
+    pres: ReturnType<typeof createPresentation>,
+    spec: Parameters<typeof addSlideChart>[1]['spec'],
+  ) =>
+    addSlideChart(addBlankSlide(pres), {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(8),
+      h: inches(4.5),
+      spec,
+    });
+
+  skipIfNoXmllint('valueAxis min/max emit in max-before-min order', async () => {
+    const pres = createPresentation();
+    chart(pres, {
+      kind: 'column',
+      categories: ['A', 'B'],
+      series: [{ name: 'S', values: [1, 2] }],
+      valueAxis: { min: 0, max: 10 },
+    });
+    const xml = await authoredXml(pres);
+    expect(xml.indexOf('<c:max')).toBeGreaterThan(-1);
+    expect(xml.indexOf('<c:max')).toBeLessThan(xml.indexOf('<c:min'));
+  });
+
+  skipIfNoXmllint('marker/smooth/invertIfNegative are gated to valid kinds', async () => {
+    const pres = createPresentation();
+    chart(pres, {
+      kind: 'area',
+      categories: ['A', 'B'],
+      series: [
+        {
+          name: 'S',
+          values: [1, -2],
+          smooth: true,
+          invertIfNegative: true,
+          markerSymbol: 'circle',
+        },
+      ],
+    });
+    const xml = await authoredXml(pres);
+    expect(xml).not.toContain('<c:smooth');
+    expect(xml).not.toContain('invertIfNegative');
+    expect(xml).not.toContain('<c:marker');
+  });
+
+  skipIfNoXmllint('trendline is dropped on pie series (CT_PieSer has no trendline)', async () => {
+    const pres = createPresentation();
+    chart(pres, {
+      kind: 'pie',
+      categories: ['A', 'B'],
+      series: [{ name: 'S', values: [1, 2], trendline: { type: 'linear' } }],
+    });
+    const xml = await authoredXml(pres);
+    // CT_PieSer permits no <c:trendline>; emitting it would fail dml-chart.xsd.
+    expect(xml).not.toContain('<c:trendline');
+  });
+});
+
+describe('schema coverage: images, notes, connectors, animation', () => {
+  skipIfNoXmllint('brightness + contrast share one valid <a:lum>', async () => {
+    const pres = createPresentation();
+    const p = addSlideImage(addBlankSlide(pres), buildPng(32, 32, [9, 9, 9]), {
+      x: inches(1),
+      y: inches(1),
+      w: inches(3),
+      h: inches(2),
+    });
+    setShapeImageBrightness(p, 0.2);
+    setShapeImageContrast(p, -0.3);
+    const xml = await authoredXml(pres);
+    expect(xml).toContain('<a:lum');
+    expect(xml).not.toContain('lumOff');
+    expect(xml).not.toContain('lumMod');
+  });
+
+  skipIfNoXmllint('notes slide part root is <p:notes>', async () => {
+    const pres = createPresentation();
+    setSlideNotes(addBlankSlide(pres), 'speaker notes');
+    const xml = await authoredXml(pres);
+    expect(xml).toContain('<p:notes');
+    expect(xml).not.toContain('<p:notesSlide');
+  });
+
+  skipIfNoXmllint('an unstyled connector is visible (lnRef style)', async () => {
+    const pres = createPresentation();
+    addSlideLine(addBlankSlide(pres), {
+      from: { x: inches(1), y: inches(1) },
+      to: { x: inches(4), y: inches(2) },
+    });
+    const xml = await authoredXml(pres);
+    expect(xml).toContain('<a:lnRef');
+  });
+
+  skipIfNoXmllint('animating two shapes merges into one valid timing tree', async () => {
+    const pres = createPresentation();
+    const slide = addBlankSlide(pres);
+    const a = addSlideShape(slide, {
+      preset: 'rect',
+      x: inches(1),
+      y: inches(1),
+      w: inches(2),
+      h: inches(1),
+      text: 'A',
+    });
+    const b = addSlideShape(slide, {
+      preset: 'ellipse',
+      x: inches(4),
+      y: inches(1),
+      w: inches(2),
+      h: inches(1),
+      text: 'B',
+    });
+    setShapeAnimation(a, { effect: 'fadeIn' });
+    setShapeAnimation(b, { effect: 'fadeOut' });
+    expect(getSlideShapes(slide).length).toBe(2);
+    expect(getSlides(pres).length).toBe(1);
+    const xml = await authoredXml(pres);
+    // The merge must keep BOTH shapes' effects — a replace-on-write
+    // implementation would drop shape A's entrance and still be schema-valid,
+    // so assert both build entries and both preset classes survive.
+    expect((xml.match(/<p:bldP/g) ?? []).length).toBe(2);
+    expect(xml).toContain('presetClass="entr"');
+    expect(xml).toContain('presetClass="exit"');
+  });
+});

--- a/test/skill-example.test.ts
+++ b/test/skill-example.test.ts
@@ -1,0 +1,203 @@
+// Keeps the agent skill's worked example honest: builds the same business deck
+// the skill documents (skill/examples/business-deck.md), then asserts it is
+// structurally valid, schema-valid, and round-trips. If this fails, the skill's
+// example is wrong and must be updated alongside it.
+
+import { describe, expect, it } from 'vitest';
+import {
+  _internalPackageOf,
+  addBlankSlide,
+  addContentSlide,
+  addSectionHeaderSlide,
+  addSlideShape,
+  addSlideChart,
+  addSlideImage,
+  addSlideTable,
+  addSlideTextBox,
+  addTitleSlide,
+  createPresentation,
+  findSlidePlaceholder,
+  getPresentationText,
+  getSlides,
+  inches,
+  loadPresentation,
+  pt,
+  savePresentation,
+  setShapeFill,
+  setShapeGradientFill,
+  setShapeRunFormat,
+  setShapeShadow,
+  setShapeStroke,
+  setShapeText,
+  setSlideNotes,
+  setSlideTransition,
+  validatePresentation,
+  type PresentationData,
+} from '../src/api/index.ts';
+import { buildPng } from './lib/build-png.ts';
+import {
+  expectSchemaValid,
+  isSchemaValidationAvailable,
+  type SchemaKind,
+} from './lib/expect-schema-valid.ts';
+
+const skipIfNoXmllint = isSchemaValidationAvailable() ? it : it.skip;
+
+// A consistent two-color palette, defined once and reused — exactly what the
+// design rules in the skill ask for.
+const BRAND = '#2563EB';
+const BRAND_DARK = '#1E3A8A';
+const INK = '#1F2937';
+
+// Builds the deck documented in skill/examples/business-deck.md.
+const buildBusinessDeck = async (): Promise<PresentationData> => {
+  const pres = createPresentation();
+
+  // 1. Title slide.
+  const cover = addTitleSlide(pres, 'FY26 Business Review');
+  const subtitle = findSlidePlaceholder(cover, 'subTitle');
+  if (subtitle) setShapeText(subtitle, 'Strategy, results, and the road ahead');
+
+  // 2. Agenda — bulleted body.
+  const agenda = addContentSlide(pres, { title: 'Agenda' });
+  const body = findSlidePlaceholder(agenda, 'body');
+  if (body) setShapeText(body, 'Highlights\nFinancials\nRoadmap\nRisks', { bullets: 'bullet' });
+
+  // 3. Section divider.
+  addSectionHeaderSlide(pres, 'Highlights');
+
+  // 4. Stat cards on a free-form blank slide.
+  const cards = addBlankSlide(pres);
+  const heading = addSlideTextBox(cards, {
+    x: inches(0.6),
+    y: inches(0.4),
+    w: inches(8),
+    h: inches(0.9),
+    text: 'A strong year',
+  });
+  setShapeRunFormat(heading, 0, 0, { bold: true, size: 32, color: INK });
+  const statCard = (x: ReturnType<typeof inches>, text: string) =>
+    addSlideShape(cards, {
+      preset: 'roundRect',
+      x,
+      y: inches(1.6),
+      w: inches(3.6),
+      h: inches(2.2),
+      text,
+      textAnchor: 'ctr',
+    });
+  const cardA = statCard(inches(0.6), 'Revenue +38%');
+  setShapeGradientFill(cardA, {
+    stops: [
+      { offset: 0, color: BRAND },
+      { offset: 1, color: BRAND_DARK },
+    ],
+    angleDeg: 90,
+  });
+  setShapeShadow(cardA, {
+    color: '#000000',
+    blurEmu: pt(8),
+    offsetEmu: pt(3),
+    angleDeg: 90,
+    opacity: 0.35,
+  });
+  const cardB = statCard(inches(4.6), 'NPS 62');
+  setShapeFill(cardB, '#059669');
+  setShapeStroke(cardB, { color: '#065F46', widthEmu: pt(1.5) });
+
+  // 5. Financials table.
+  const fin = addContentSlide(pres, { title: 'Financials' });
+  addSlideTable(fin, {
+    x: inches(0.6),
+    y: inches(1.6),
+    w: inches(8.2),
+    h: inches(2.5),
+    rows: [
+      ['Metric', 'FY25', 'FY26', 'Δ'],
+      ['Revenue', '$120M', '$166M', '+38%'],
+      ['Gross margin', '64%', '67%', '+3pt'],
+    ],
+    firstRow: true,
+    bandRow: true,
+  });
+
+  // 6. Chart-led slide.
+  const chartSlide = addBlankSlide(pres);
+  addSlideTextBox(chartSlide, {
+    x: inches(0.6),
+    y: inches(0.3),
+    w: inches(8),
+    h: inches(0.7),
+    text: 'Quarterly revenue',
+  });
+  addSlideChart(chartSlide, {
+    x: inches(0.6),
+    y: inches(1.1),
+    w: inches(8.2),
+    h: inches(4.2),
+    spec: {
+      kind: 'column',
+      categories: ['Q1', 'Q2', 'Q3', 'Q4'],
+      series: [
+        { name: 'Revenue', values: [120, 138, 152, 166], color: BRAND },
+        { name: 'Plan', values: [115, 130, 148, 160] },
+      ],
+      title: 'Revenue vs plan ($M)',
+      valueAxisTitle: 'USD (millions)',
+      dataLabels: {
+        showValue: true,
+        showCategory: false,
+        showSeriesName: false,
+        showPercent: false,
+      },
+    },
+  });
+
+  // 7. Image slide + closing notes/transition.
+  const imgSlide = addBlankSlide(pres);
+  addSlideImage(imgSlide, buildPng(640, 360, [37, 99, 235]), {
+    x: inches(0.6),
+    y: inches(1.1),
+    w: inches(8.2),
+    h: inches(4.2),
+    fit: 'contain',
+  });
+  setSlideTransition(imgSlide, { effect: 'fade' });
+  setSlideNotes(imgSlide, 'Wrap in under two minutes, then open Q&A.');
+
+  return pres;
+};
+
+const kindFor = (name: string): SchemaKind | null => {
+  if (/\/(slides|notesSlides)\/[^/]*\.xml$/.test(name)) return 'pml';
+  if (/\/charts\/chart\d+\.xml$/.test(name)) return 'chart';
+  return null;
+};
+
+describe('skill worked example: business deck', () => {
+  it('builds, validates structurally, and round-trips', async () => {
+    const pres = await buildBusinessDeck();
+    expect(getSlides(pres).length).toBe(7);
+
+    const errors = validatePresentation(pres).filter((i) => i.severity === 'error');
+    expect(errors).toEqual([]);
+
+    const bytes = await savePresentation(pres);
+    const reloaded = await loadPresentation(bytes);
+    expect(getSlides(reloaded).length).toBe(7);
+
+    // No leftover placeholder tokens.
+    expect(getPresentationText(reloaded)).not.toMatch(/\{\{|lorem|TODO/i);
+  });
+
+  skipIfNoXmllint('every authored part is schema-valid', async () => {
+    const pres = await buildBusinessDeck();
+    const bytes = await savePresentation(pres);
+    const pkg = _internalPackageOf(await loadPresentation(bytes));
+    const decode = (b: Uint8Array): string => new TextDecoder().decode(b);
+    for (const part of pkg.parts) {
+      const kind = kindFor(part.name);
+      if (kind) expectSchemaValid(decode(part.data), kind);
+    }
+  });
+});

--- a/test/sweep-criticals.test.ts
+++ b/test/sweep-criticals.test.ts
@@ -1,0 +1,258 @@
+// Regression net for the final generative-sweep findings (the batch after the
+// boundary-validation pass): each test pins one defect where the writer emitted
+// a `.pptx` PowerPoint marks corrupt — XML-illegal control characters, chart
+// percentages outside their ECMA-376 simple-type ranges, unvalidated effect
+// EMU, a scheme-color round-trip the setter rejected, importSlide leaving a
+// dangling chart relationship, and invalid `ST_ShapeType` math tokens.
+
+import { describe, expect, it } from 'vitest';
+import {
+  _internalPackageOf,
+  addBlankSlide,
+  addSlideChart,
+  addSlideShape,
+  createPresentation,
+  findSlideLayout,
+  getShapeFillColor,
+  getSlides,
+  importSlide,
+  inches,
+  loadPresentation,
+  savePresentation,
+  setShapeFill,
+  setShapeGlow,
+  setShapeShadow,
+  setSlideNotes,
+} from '../src/api/index.ts';
+import {
+  expectSchemaValid,
+  isSchemaValidationAvailable,
+  type SchemaKind,
+} from './lib/expect-schema-valid.ts';
+
+const skipIfNoXmllint = isSchemaValidationAvailable() ? it : it.skip;
+const decode = (b: Uint8Array): string => new TextDecoder().decode(b);
+// Build control-char strings from char codes rather than embedding raw illegal
+// bytes in this source file (which tooling and editors mangle).
+const ctrl = (code: number): string => String.fromCharCode(code);
+
+const rect = (pres: ReturnType<typeof createPresentation>, text?: string) =>
+  addSlideShape(addBlankSlide(pres), {
+    preset: 'rect',
+    x: inches(1),
+    y: inches(1),
+    w: inches(3),
+    h: inches(2),
+    ...(text === undefined ? {} : { text }),
+  });
+
+const validateParts = (pres: ReturnType<typeof createPresentation>): void => {
+  const pkg = _internalPackageOf(pres);
+  for (const part of pkg.parts) {
+    let kind: SchemaKind | null = null;
+    if (/\/slides\/[^/]*\.xml$/.test(part.name)) kind = 'pml';
+    else if (/\/charts\/chart\d+\.xml$/.test(part.name)) kind = 'chart';
+    if (kind) expectSchemaValid(decode(part.data), kind);
+  }
+};
+
+describe('sweep: XML-illegal control characters', () => {
+  // Serialization is synchronous (an authoring call re-serializes its part, and
+  // `savePresentation` wraps a sync `.save()`), so an illegal character surfaces
+  // as a synchronous throw. Wrap author-then-save so the assertion holds wherever
+  // the serializer first sees the character.
+  it('rejects a NUL (and other C0 controls) in shape text', () => {
+    expect(() => {
+      const pres = createPresentation();
+      rect(pres, `before${ctrl(0x00)}after`);
+      return savePresentation(pres);
+    }).toThrow(/control character/i);
+  });
+
+  it('rejects a control character in slide notes', () => {
+    expect(() => {
+      const pres = createPresentation();
+      setSlideNotes(addBlankSlide(pres), `note${ctrl(0x08)}body`); // backspace (U+0008)
+      return savePresentation(pres);
+    }).toThrow(/control character/i);
+  });
+
+  it('allows the three XML-legal whitespace controls (tab / LF / CR)', async () => {
+    const pres = createPresentation();
+    rect(pres, `a${ctrl(0x09)}b${ctrl(0x0a)}c${ctrl(0x0d)}d`);
+    await expect(savePresentation(pres)).resolves.toBeInstanceOf(Uint8Array);
+  });
+});
+
+describe('sweep: chart percentage ranges', () => {
+  const chart = (
+    pres: ReturnType<typeof createPresentation>,
+    spec: Parameters<typeof addSlideChart>[1]['spec'],
+  ) =>
+    addSlideChart(addBlankSlide(pres), {
+      x: inches(0.5),
+      y: inches(0.5),
+      w: inches(8),
+      h: inches(4.5),
+      spec,
+    });
+
+  it('rejects gapWidthPct above 500 (ST_GapAmount)', () => {
+    expect(() =>
+      chart(createPresentation(), {
+        kind: 'column',
+        categories: ['A', 'B'],
+        series: [{ name: 'S', values: [1, 2] }],
+        gapWidthPct: 600,
+      }),
+    ).toThrow(RangeError);
+  });
+
+  it('rejects holeSizePct outside 1..90 (ST_HoleSize)', () => {
+    expect(() =>
+      chart(createPresentation(), {
+        kind: 'doughnut',
+        categories: ['A', 'B'],
+        series: [{ name: 'S', values: [1, 2] }],
+        holeSizePct: 95,
+      }),
+    ).toThrow(RangeError);
+    expect(() =>
+      chart(createPresentation(), {
+        kind: 'doughnut',
+        categories: ['A', 'B'],
+        series: [{ name: 'S', values: [1, 2] }],
+        holeSizePct: 0,
+      }),
+    ).toThrow(RangeError);
+  });
+
+  it('rejects firstSliceAngleDeg outside 0..360 (ST_FirstSliceAng)', () => {
+    expect(() =>
+      chart(createPresentation(), {
+        kind: 'pie',
+        categories: ['A', 'B'],
+        series: [{ name: 'S', values: [1, 2] }],
+        firstSliceAngleDeg: 361,
+      }),
+    ).toThrow(RangeError);
+  });
+
+  skipIfNoXmllint('valid extremes (gap 500, hole 90, angle 360) stay schema-valid', async () => {
+    const pres = createPresentation();
+    chart(pres, {
+      kind: 'column',
+      categories: ['A', 'B'],
+      series: [{ name: 'S', values: [1, 2] }],
+      gapWidthPct: 500,
+    });
+    chart(pres, {
+      kind: 'doughnut',
+      categories: ['A', 'B'],
+      series: [{ name: 'S', values: [1, 2] }],
+      holeSizePct: 90,
+      firstSliceAngleDeg: 360,
+    });
+    validateParts(await loadPresentation(await savePresentation(pres)));
+  });
+});
+
+describe('sweep: shape effect EMU validation', () => {
+  it('rejects negative / non-finite / over-max shadow EMU', () => {
+    expect(() => setShapeShadow(rect(createPresentation()), { blurEmu: -1 })).toThrow(RangeError);
+    expect(() => setShapeShadow(rect(createPresentation()), { offsetEmu: Number.NaN })).toThrow(
+      RangeError,
+    );
+    expect(() => setShapeShadow(rect(createPresentation()), { blurEmu: 27273042316901 })).toThrow(
+      RangeError,
+    );
+    // Fractional EMU is rounded to a valid integer, not rejected.
+    expect(() => setShapeShadow(rect(createPresentation()), { blurEmu: 50800.5 })).not.toThrow();
+  });
+
+  it('rejects out-of-range glow radius', () => {
+    expect(() =>
+      setShapeGlow(rect(createPresentation()), { color: '#FF0000', radiusEmu: -5 }),
+    ).toThrow(RangeError);
+  });
+});
+
+describe('sweep: scheme-color round-trip', () => {
+  it('accepts the scheme:<token> string the getter returns', () => {
+    const r = rect(createPresentation());
+    setShapeFill(r, 'accent1');
+    const read = getShapeFillColor(r);
+    expect(read).toBe('scheme:accent1');
+    // The whole point: feeding the getter's output back to the setter must work.
+    expect(() => setShapeFill(r, read!)).not.toThrow();
+    expect(getShapeFillColor(r)).toBe('scheme:accent1');
+  });
+
+  it('still rejects an unknown scheme token', () => {
+    expect(() => setShapeFill(rect(createPresentation()), 'scheme:bogus')).toThrow();
+  });
+});
+
+describe('sweep: importSlide drops charts without a dangling relationship', () => {
+  it('produces a valid package when the source slide has a chart', async () => {
+    const source = createPresentation();
+    addSlideChart(addBlankSlide(source), {
+      x: inches(1),
+      y: inches(1),
+      w: inches(6),
+      h: inches(4),
+      spec: {
+        kind: 'bar',
+        categories: ['A', 'B'],
+        series: [{ name: 'S', values: [1, 2] }],
+      },
+    });
+    const sourceReloaded = await loadPresentation(await savePresentation(source));
+
+    const target = createPresentation();
+    const layout = findSlideLayout(target, 'Blank') ?? findSlideLayout(target, 'Title and Content');
+    expect(layout).not.toBeNull();
+    importSlide(target, getSlides(sourceReloaded)[0]!, layout!);
+
+    const bytes = await savePresentation(target);
+    const reloaded = await loadPresentation(bytes);
+    expect(getSlides(reloaded)).toHaveLength(1);
+
+    // No body r:id may reference a relationship the imported slide doesn't carry.
+    const pkg = _internalPackageOf(reloaded);
+    const slidePart = pkg.parts.find((p) => /\/ppt\/slides\/slide\d+\.xml$/.test(p.name))!;
+    const relsPart = pkg.parts.find((p) =>
+      /\/ppt\/slides\/_rels\/slide\d+\.xml\.rels$/.test(p.name),
+    );
+    const relIds = new Set(
+      relsPart ? [...decode(relsPart.data).matchAll(/Id="([^"]+)"/g)].map((m) => m[1]) : [],
+    );
+    const bodyRefs = [...decode(slidePart.data).matchAll(/r:(?:id|embed|link)="([^"]+)"/g)].map(
+      (m) => m[1],
+    );
+    for (const ref of bodyRefs) expect(relIds.has(ref)).toBe(true);
+  });
+});
+
+describe('sweep: ST_ShapeType math presets', () => {
+  skipIfNoXmllint('emits schema-valid prstGeom for the math operator presets', async () => {
+    const pres = createPresentation();
+    for (const preset of [
+      'mathPlus',
+      'mathMinus',
+      'mathMultiply',
+      'mathDivide',
+      'mathEqual',
+      'mathNotEqual',
+    ] as const) {
+      addSlideShape(addBlankSlide(pres), {
+        preset,
+        x: inches(1),
+        y: inches(1),
+        w: inches(2),
+        h: inches(2),
+      });
+    }
+    validateParts(await loadPresentation(await savePresentation(pres)));
+  });
+});


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

A deterministic generative schema-validation sweep (compose random-but-valid decks from the public API, validate every emitted part against the ECMA-376 XSDs) surfaced a whole class of defects where a caller-supplied number or string was serialized straight into a constrained OOXML attribute. The result opened in PowerPoint but was silently "repaired" (i.e. corrupt). This PR validates those inputs at the authoring boundary so they throw a clear `RangeError` instead of emitting invalid XML, closes a final batch of related correctness bugs found by the same sweep, adds the generative fuzzer + regression suites that keep them fixed, and ships a self-contained skill so an LLM agent can drive the library correctly.

## Motivation

The library's goal is output that is schema-valid everywhere (PowerPoint, Keynote, Google Slides, LibreOffice), not "valid enough." But many authoring setters trusted caller input and serialized it verbatim into attributes with tight ECMA-376 simple-type ranges (`ST_Coordinate`, `ST_LineWidth`, `ST_TextFontSize`, `ST_GapAmount`, `ST_Angle`, …). An out-of-range value produced a `.pptx` that PowerPoint marks corrupt — the worst kind of bug for an LLM-driven authoring tool, because the model gets no signal that it produced garbage. CLAUDE.md's rule is "validate at boundaries, trust internally"; this brings the authoring surface in line with that.

No tracking issue — found by tooling built in this branch, not reported externally.

## Changes

- **New `src/internal/bounds.ts`** — central ECMA-376 simple-type bounds validation (a leaf module). Authoring inputs are rounded + range-checked once at the boundary; out-of-range throws `RangeError` naming the field and range. Wired into run/text formatting, tables, charts, animations, transitions, connectors, strokes, text boxes, fills, and shape/image/chart geometry.
- **XML-illegal control characters** in any text field (shape text, table cells, notes, chart titles/categories/series, hyperlink tooltip/URL, section names, comments) now throw at serialization instead of emitting a non-well-formed part that corrupts the whole package. The XML-legal whitespace controls (tab/LF/CR) still pass through.
- **Chart percentages** range-checked: `gapWidthPct` 0..500 (`ST_GapAmount`), doughnut `holeSizePct` 1..90, pie/doughnut `firstSliceAngleDeg` 0..360.
- **Shadow/glow EMU** (`setShapeShadow`, `setShapeGlow`) validated as `ST_PositiveCoordinate`.
- **Scheme-color round-trip**: `setShapeFill` / `setShapeStroke` / `setSlideBackground` now accept the `scheme:<token>` string the read-back getters return, so `setX(getX(...))` round-trips. Unknown scheme tokens still throw.
- **`importSlide` / `mergePresentations`**: importing a slide that contained a chart left a dangling relationship id (corrupt package); the orphaned graphic frame is now dropped, matching the documented "charts are not imported in v1" behavior.
- **`addSlideShape` presets**: the math-operator tokens were misspelled and not in `ST_ShapeType` (the shape silently vanished on open); corrected to `mathMinus`/`mathMultiply`/`mathDivide`/`mathEqual`/`mathNotEqual` (plus `mathPlus`).
- **QA infrastructure**: `test/generative-fuzz.test.ts` (deterministic, seeded, validates every part against the XSDs) and per-fix regression suites (`test/bounds-validation.test.ts`, `test/sweep-criticals.test.ts`) that fail without their fix.
- **`skill/SKILL.md`** — an AI-agent authoring guide, with a worked example (`skill/examples/business-deck.md`) exercised by `test/skill-example.test.ts`, referenced from the README.

## Testing

- `pnpm lint && pnpm typecheck && pnpm build && pnpm test` — all green (1249 passed, 89 skipped).
- The new regression tests assert that out-of-range inputs throw and that valid extremes stay schema-valid (verified with `xmllint` against the vendored ECMA-376 XSDs); each was confirmed to fail without its corresponding fix.
- The generative fuzzer composes random valid decks and validates every emitted part against the schema, so feature-combination bugs (invalid child order / wrong-type attribute) are caught in CI without external services.

## Breaking changes

No *valid* usage breaks. Inputs that previously serialized into invalid/corrupt XML now throw `RangeError` at the authoring call instead — a loud failure replacing a silent one. Pre-1.0; captured in changesets as `minor`.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, this PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->
