### PR TITLE
feat: support a per-run East Asian typeface override (fontEastAsian)

### DIFF
--- a/.changeset/east-asian-run-font.md
+++ b/.changeset/east-asian-run-font.md
@@ -1,0 +1,12 @@
+---
+'pptx-kit': minor
+---
+
+`setShapeRunFormat` / `getShapeRunFormat` / `getShapeRunFormatEffective` now
+support `fontEastAsian`, a per-run East Asian typeface override (`<a:ea>`),
+alongside the existing `font` (`<a:latin>`). Previously a run's CJK glyphs
+always fell back to whichever East Asian font the theme's major/minor font
+scheme happened to carry, with no way to set a distinct typeface (e.g. a
+serif headline vs. a sans-serif body) on an individual run. `fontEastAsian`
+resolves theme `+mj-ea`/`+mn-ea` tokens and falls back to the theme's major/
+minor East Asian font the same way `font` already does for Latin text.

--- a/src/api/fn/shape-color.ts
+++ b/src/api/fn/shape-color.ts
@@ -398,6 +398,11 @@ export const parseRPrLikeElement = (
     const t = getAttrValue(latin, qname('', 'typeface', ''));
     if (t !== null) out.font = t;
   }
+  const ea = firstChildElement(rPr, qname('a', 'ea', NS.dml));
+  if (ea !== null) {
+    const t = getAttrValue(ea, qname('', 'typeface', ''));
+    if (t !== null) out.fontEastAsian = t;
+  }
   return out;
 };
 

--- a/src/api/fn/shape-paragraph.ts
+++ b/src/api/fn/shape-paragraph.ts
@@ -74,6 +74,9 @@ const NAME_P_OTHER_STYLE = qname('p', 'otherStyle', NS.pml);
 
 const mergeRPrLayer = (base: Partial<TextFormat>, layer: Partial<TextFormat>): void => {
   if (base.font === undefined && layer.font !== undefined) base.font = layer.font;
+  if (base.fontEastAsian === undefined && layer.fontEastAsian !== undefined) {
+    base.fontEastAsian = layer.fontEastAsian;
+  }
   if (base.size === undefined && layer.size !== undefined) base.size = layer.size;
   if (base.color === undefined && layer.color !== undefined) base.color = layer.color;
   if (base.bold === undefined && layer.bold !== undefined) base.bold = layer.bold;
@@ -331,6 +334,15 @@ export const getShapeRunFormatEffective = (
       const useMajor = phType === 'title' || phType === 'ctrTitle';
       const fallback = useMajor ? fonts.majorLatin : fonts.minorLatin;
       if (fallback) result.font = fallback;
+    }
+    if (typeof result.fontEastAsian === 'string' && result.fontEastAsian.startsWith('+')) {
+      const resolved = resolveThemeToken(result.fontEastAsian);
+      if (resolved) result.fontEastAsian = resolved;
+    }
+    if (result.fontEastAsian === undefined) {
+      const useMajor = phType === 'title' || phType === 'ctrTitle';
+      const fallback = useMajor ? fonts.majorEastAsian : fonts.minorEastAsian;
+      if (fallback) result.fontEastAsian = fallback;
     }
   }
 

--- a/src/internal/drawingml/text-format.ts
+++ b/src/internal/drawingml/text-format.ts
@@ -82,6 +82,13 @@ const rprChildRank = (el: XmlElement): number =>
 export interface TextFormat {
   /** Latin font family (`Calibri`, `Arial`, ...). Sets `<a:latin>`. */
   font?: string;
+  /**
+   * East Asian font family (`游明朝`, `メイリオ`, ...). Sets `<a:ea>`.
+   * Renderers pick this typeface for CJK glyphs independently of `font`
+   * (which only governs Latin glyphs) — set both when a run mixes Latin
+   * and CJK text and needs a consistent look across the whole run.
+   */
+  fontEastAsian?: string;
   /** Font size in points; fractional values allowed (`12`, `12.5`). */
   size?: number;
   /**
@@ -168,6 +175,14 @@ const setLatin = (rPr: XmlElement, font: string | null): void => {
   insertChildByRank(rPr, elem(NAME_LATIN, { attrs: [attr(ATTR_TYPEFACE, font)] }), rprChildRank);
 };
 
+const setEastAsian = (rPr: XmlElement, font: string | null): void => {
+  rPr.children = rPr.children.filter(
+    (c) => !(c.kind === 'element' && c.name.namespaceURI === NS.dml && c.name.localName === 'ea'),
+  );
+  if (font === null) return;
+  insertChildByRank(rPr, elem(NAME_EA, { attrs: [attr(ATTR_TYPEFACE, font)] }), rprChildRank);
+};
+
 const setHighlight = (rPr: XmlElement, value: string | null): void => {
   rPr.children = rPr.children.filter(
     (c) =>
@@ -226,10 +241,10 @@ export const applyRunFormat = (rPr: XmlElement, format: TextFormat): void => {
   rPr.attrs = attrs;
 
   if (format.font !== undefined) setLatin(rPr, format.font);
+  if (format.fontEastAsian !== undefined) setEastAsian(rPr, format.fontEastAsian);
   if (format.color !== undefined) setSolidFill(rPr, format.color);
   if (format.highlight !== undefined) setHighlight(rPr, format.highlight);
 
-  void NAME_EA;
   void NAME_CS;
 };
 

--- a/test/fn-run-format-effective.test.ts
+++ b/test/fn-run-format-effective.test.ts
@@ -10,14 +10,17 @@ import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import {
+  addBlankSlide,
   addSlideTextBox,
   addTitleSlide,
+  createPresentation,
   findSlidePlaceholder,
   getShapeRunFormat,
   getShapeRunFormatEffective,
   getSlides,
   inches,
   loadPresentation,
+  setPresentationFonts,
   setShapeRunFormat,
 } from '../src/api/index.ts';
 
@@ -60,6 +63,26 @@ describe('fn API: getShapeRunFormatEffective', () => {
     // Office theme, which sets both major and minor to Calibri.
     const fmt = getShapeRunFormatEffective(pres, tb, 0, 0);
     expect(fmt.font).toBe('Calibri');
+  });
+
+  it('falls back to the theme East Asian font independently of the Latin font', () => {
+    const pres = createPresentation();
+    setPresentationFonts(pres, { majorEastAsian: '游明朝', minorEastAsian: 'メイリオ' });
+    const slide = addBlankSlide(pres);
+    const tb = addSlideTextBox(slide, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(3),
+      h: inches(2),
+      text: 'plain',
+    });
+    expect(getShapeRunFormat(tb, 0, 0)?.fontEastAsian).toBeUndefined();
+    const fmt = getShapeRunFormatEffective(pres, tb, 0, 0);
+    expect(fmt.fontEastAsian).toBe('メイリオ');
+
+    setShapeRunFormat(tb, 0, 0, { fontEastAsian: '游明朝' });
+    const overridden = getShapeRunFormatEffective(pres, tb, 0, 0);
+    expect(overridden.fontEastAsian).toBe('游明朝');
   });
 
   it('inherits placeholder size from the master title style', async () => {

--- a/test/fn-run-format-read.test.ts
+++ b/test/fn-run-format-read.test.ts
@@ -54,6 +54,23 @@ describe('fn API: getShapeRunFormat', () => {
     expect(fmt!.size).toBeCloseTo(18);
   });
 
+  it('round-trips font and fontEastAsian independently', async () => {
+    const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
+    const slide = getSlides(pres)[0]!;
+    const tb = addSlideTextBox(slide, {
+      x: inches(0),
+      y: inches(0),
+      w: inches(3),
+      h: inches(2),
+      text: '見出し',
+    });
+    setShapeRunFormat(tb, 0, 0, { font: 'Georgia', fontEastAsian: '游明朝' });
+    const fmt = getShapeRunFormat(tb, 0, 0);
+    expect(fmt).not.toBeNull();
+    expect(fmt!.font).toBe('Georgia');
+    expect(fmt!.fontEastAsian).toBe('游明朝');
+  });
+
   it('underline encodes both boolean and explicit token', async () => {
     const pres = await loadPresentation(await readFile(fixture('two-slides.pptx')));
     const slide = getSlides(pres)[0]!;


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

`setShapeRunFormat`'s `font` field only ever wrote `<a:latin>`, so a run's CJK glyphs always fell back to whichever East Asian font the theme's major/minor font scheme happened to carry — there was no way to give a single run its own East Asian typeface distinct from the theme default (e.g. a serif headline vs. a sans-serif body in the same deck). This adds `fontEastAsian` alongside `font`.

## Motivation

Found while building a McKinsey-style sample deck: real decks pair a serif headline face with a sans-serif body face, and for Japanese content that distinction has to happen on the East Asian typeface (`<a:ea>`), not the Latin one (`<a:latin>`) — `font` alone can't express it. `NAME_EA` was already declared in `text-format.ts` (stubbed with `void NAME_EA` to silence the linter), so this closes out a capability the code was clearly reaching toward but hadn't finished.

## Changes

- `TextFormat.fontEastAsian?: string` — sets `<a:ea>` the same way `font` sets `<a:latin>`.
- `setShapeRunFormat` / `applyRunFormat` write it via a new `setEastAsian` helper mirroring `setLatin`.
- `getShapeRunFormat` (literal read) parses `<a:ea>` back into `fontEastAsian`.
- `getShapeRunFormatEffective` (inheritance cascade) resolves `+mj-ea`/`+mn-ea` theme tokens and falls back to the theme's major/minor East Asian font when no layer sets one — mirroring the existing Latin-font cascade logic exactly.

## Testing

- `test/fn-run-format-read.test.ts`: round-trips `font` and `fontEastAsian` independently on the same run.
- `test/fn-run-format-effective.test.ts`: falls back to the theme's East Asian font independently of the Latin font, and confirms an explicit per-run override wins over the theme fallback.
- Full suite (`pnpm vitest run`), `pnpm typecheck`, `pnpm lint`, `pnpm format:check` all pass.

## Breaking changes

None — additive field, existing `font` behavior unchanged.

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed (changeset).
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, the PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->

---

Note for merge order: PR #278 (consulting-deck-design skill update) documents `fontEastAsian` as the mechanism for serif/sans headline-vs-body typography. That PR should merge **after** this one, or the skill will reference a field that doesn't exist on `main` yet.

https://claude.ai/code/session_019F7FmCXx1ThFVK2RnqYEuu