### PR TITLE
feat: add setShapeAdjustValues (author preset-geometry adjust handles, e.g. roundRect corner radius)

### DIFF
--- a/.changeset/shape-adjust-values.md
+++ b/.changeset/shape-adjust-values.md
@@ -1,0 +1,5 @@
+---
+"pptx-kit": minor
+---
+
+Add `setShapeAdjustValues(shape, values)` to author a preset shape's adjust-handle guides (`<a:prstGeom><a:avLst>`). It's the mutating companion to the existing `getShapeAdjustValues` reader — pass raw ECMA-376 guide values keyed by guide name. The common use is the `roundRect` corner radius via the `adj` guide (`0..50000`; `setShapeAdjustValues(shape, { adj: 5000 })` gives a subtle 5% rounding). Throws when the shape has no preset geometry.

--- a/src/api/fn/shape-fill-stroke.ts
+++ b/src/api/fn/shape-fill-stroke.ts
@@ -9,6 +9,7 @@ import {
   type StrokeOptions,
   clearFill as clearFillImpl,
   clearStroke as clearStrokeImpl,
+  setAdjustValues as writeAdjustValues,
   setFlip as writeFlip,
   setGradientFill,
   setPatternFill,
@@ -76,6 +77,31 @@ export const setShapeSize = (shape: SlideShapeData, w: Emu, h: Emu): void => {
  */
 export const setShapeRotation = (shape: SlideShapeData, degrees: number): void => {
   writeRotation(shape[SHAPE_ELEMENT], shape[SHAPE_SNAPSHOT].kind, degrees);
+  commitAndRefresh(shape);
+};
+
+/**
+ * Sets the shape's preset-geometry adjust values (`<a:prstGeom><a:avLst>`),
+ * replacing any guides already authored. Keys are ECMA-376 guide names and
+ * values are the raw guide numbers (rounded to integers). The companion
+ * reader is {@link getShapeAdjustValues}.
+ *
+ * The common use is the corner radius of the `roundRect` preset, whose `adj`
+ * guide runs `0..50000` (thousandths of a percent of the shorter side;
+ * `16667` ≈ the PowerPoint default, `0` = square corners, `50000` = fully
+ * rounded). For example, `setShapeAdjustValues(shape, { adj: 5000 })` gives a
+ * subtle 5% rounding.
+ *
+ * Throws when the shape has no preset geometry (`<a:prstGeom>`) — a custom or
+ * inherited geometry has no adjust list to author.
+ */
+export const setShapeAdjustValues = (
+  shape: SlideShapeData,
+  values: Readonly<Record<string, number>>,
+): void => {
+  if (!writeAdjustValues(shape[SHAPE_ELEMENT], values)) {
+    throw new Error('setShapeAdjustValues: shape has no preset geometry (<a:prstGeom>)');
+  }
   commitAndRefresh(shape);
 };
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -444,6 +444,7 @@ export {
   setCoreProperties,
   setExtendedProperties,
   setMediaPartBytes,
+  setShapeAdjustValues,
   setShapeAlignment,
   setShapeAltTitle,
   setShapeAnimation,

--- a/src/internal/drawingml/geometry-mutation.ts
+++ b/src/internal/drawingml/geometry-mutation.ts
@@ -142,3 +142,45 @@ export const setFlip = (
     if (options.vertical) xfrm.attrs.push(attr(ATTR_FLIP_V, '1'));
   }
 };
+
+const NAME_PRST_GEOM = qname('a', 'prstGeom', NS.dml);
+const NAME_AV_LST = qname('a', 'avLst', NS.dml);
+const NAME_GD = qname('a', 'gd', NS.dml);
+const ATTR_NAME = qname('', 'name', '');
+const ATTR_FMLA = qname('', 'fmla', '');
+
+/**
+ * Writes the preset geometry's adjust-handle values (`<a:prstGeom><a:avLst>
+ * <a:gd name=".." fmla="val N"/></a:avLst>`), replacing any guides already in
+ * the `<a:avLst>`. Values are the raw ECMA-376 guide numbers and are rounded
+ * to integers on the way out (guide values are stored as integers). For the
+ * `roundRect` preset the `adj` guide runs `0..50000` (thousandths of a
+ * percent of the shorter side; `50000` = fully rounded).
+ *
+ * Returns `false` — writing nothing — when the shape carries no
+ * `<a:prstGeom>` (it uses custom or inherited geometry, so there is no
+ * adjust list to author). Mirrors `getShapeAdjustValues`, which reads the
+ * same `val`-form guides.
+ */
+export const setAdjustValues = (
+  shape: XmlElement,
+  values: Readonly<Record<string, number>>,
+): boolean => {
+  const spPr = firstChildElement(shape, NAME_SP_PR);
+  if (spPr === null) return false;
+  const prstGeom = firstChildElement(spPr, NAME_PRST_GEOM);
+  if (prstGeom === null) return false;
+
+  let avLst = firstChildElement(prstGeom, NAME_AV_LST);
+  if (avLst === null) {
+    avLst = elem(NAME_AV_LST);
+    prstGeom.children.push(avLst);
+  }
+
+  avLst.children = Object.entries(values).map(([name, value]) =>
+    elem(NAME_GD, {
+      attrs: [attr(ATTR_NAME, name), attr(ATTR_FMLA, `val ${String(Math.round(value))}`)],
+    }),
+  );
+  return true;
+};

--- a/src/internal/drawingml/index.ts
+++ b/src/internal/drawingml/index.ts
@@ -57,4 +57,10 @@ export { applyHyperlinkToAllRuns } from './hyperlink.ts';
 export { getPictureEmbedRId } from './picture-mutation.ts';
 export type { Position, ShapeKindForGeometry, Size } from './geometry.ts';
 export { readFlip, readPosition, readRotation, readSize } from './geometry.ts';
-export { setFlip, setPosition, setRotation, setSize } from './geometry-mutation.ts';
+export {
+  setAdjustValues,
+  setFlip,
+  setPosition,
+  setRotation,
+  setSize,
+} from './geometry-mutation.ts';

--- a/test/l3-preset-shapes.test.ts
+++ b/test/l3-preset-shapes.test.ts
@@ -6,7 +6,9 @@ import { describe, expect, it } from 'vitest';
 import {
   addSlide,
   addSlideShape,
+  addSlideTable,
   findSlideLayout,
+  getShapeAdjustValues,
   getShapeKind,
   getShapePosition,
   getSlideShapes,
@@ -14,6 +16,7 @@ import {
   getSlides,
   inches,
   loadPresentation,
+  setShapeAdjustValues,
   setShapeFill,
   setShapeRotation,
   setShapeStroke,
@@ -124,6 +127,72 @@ describe('L3: addSlideShape', () => {
       h: inches(1),
       text: 'next',
     });
+    expectSchemaValid(getSlideXmlString(getSlides(pres).at(-1)!), 'pml');
+  });
+});
+
+describe('L3: setShapeAdjustValues', () => {
+  const roundRect = async () => {
+    const pres = await loadPresentation(await readFile(fixture('blank.pptx')));
+    const layout = findSlideLayout(pres, 'Blank');
+    if (!layout) throw new Error('expected layout');
+    const slide = addSlide(pres, { layout });
+    const shape = addSlideShape(slide, {
+      preset: 'roundRect',
+      x: inches(1),
+      y: inches(1),
+      w: inches(3),
+      h: inches(2),
+    });
+    return { pres, slide, shape };
+  };
+
+  it('authors the roundRect corner-radius guide and reads it back', async () => {
+    const { pres, shape } = await roundRect();
+    setShapeAdjustValues(shape, { adj: 5000 });
+
+    expect(getShapeAdjustValues(shape)).toEqual({ adj: 5000 });
+    const xml = getSlideXmlString(getSlides(pres).at(-1)!);
+    expect(xml).toContain('<a:gd name="adj" fmla="val 5000"/>');
+  });
+
+  it('replaces guides already present in the avLst instead of appending', async () => {
+    const { pres, shape } = await roundRect();
+    setShapeAdjustValues(shape, { adj: 20000 });
+    setShapeAdjustValues(shape, { adj: 3000 });
+
+    expect(getShapeAdjustValues(shape)).toEqual({ adj: 3000 });
+    const xml = getSlideXmlString(getSlides(pres).at(-1)!);
+    expect(xml).toContain('fmla="val 3000"');
+    expect(xml).not.toContain('fmla="val 20000"');
+  });
+
+  it('rounds fractional guide values to integers', async () => {
+    const { shape } = await roundRect();
+    setShapeAdjustValues(shape, { adj: 5000.7 });
+
+    expect(getShapeAdjustValues(shape)).toEqual({ adj: 5001 });
+  });
+
+  it('throws for shapes without preset geometry', async () => {
+    const pres = await loadPresentation(await readFile(fixture('blank.pptx')));
+    const layout = findSlideLayout(pres, 'Blank');
+    if (!layout) throw new Error('expected layout');
+    const slide = addSlide(pres, { layout });
+    // A table renders as a `<p:graphicFrame>` — it has no `<a:prstGeom>`.
+    const table = addSlideTable(slide, {
+      x: inches(1),
+      y: inches(1),
+      w: inches(4),
+      h: inches(2),
+      rows: [['a', 'b']],
+    });
+    expect(() => setShapeAdjustValues(table, { adj: 5000 })).toThrow(/preset geometry/);
+  });
+
+  skipIfNoXmllint('roundRect with an authored adj validates against pml.xsd', async () => {
+    const { pres, shape } = await roundRect();
+    setShapeAdjustValues(shape, { adj: 5000 });
     expectSchemaValid(getSlideXmlString(getSlides(pres).at(-1)!), 'pml');
   });
 });


### PR DESCRIPTION
## What

Adds **`setShapeAdjustValues(shape, values)`** — the mutating companion to the existing `getShapeAdjustValues` reader. It authors a preset shape's adjust-handle guides into `<a:prstGeom><a:avLst>` (`<a:gd name=".." fmla="val N"/>`), replacing any already present.

## Why

There was no public way to set a preset geometry's adjust handles. The concrete gap: the **`roundRect` corner radius** (`adj` guide) could only render at PowerPoint's rounded default (~16.7% of the shorter side). Authors who want tighter, more "corporate" rounding (e.g. a subtle 5%) had no lever.

```ts
const card = addSlideShape(slide, { preset: 'roundRect', x, y, w, h });
setShapeAdjustValues(card, { adj: 5000 }); // 5% corner radius
```

## Design

- Values are **raw ECMA-376 guide numbers** keyed by guide name, mirroring what `getShapeAdjustValues` returns — so `set` round-trips with `get`. Fractional values round to integers (guides are integers).
- `roundRect` `adj` runs `0..50000` (thousandths of a percent of the shorter side; `0` = square, `50000` = fully rounded).
- **Throws** when the shape has no `<a:prstGeom>` (custom or inherited geometry — nothing to author).
- Internal helper `setAdjustValues` lives alongside the other geometry mutations in `internal/drawingml/geometry-mutation.ts`; the public wrapper sits next to `setShapeRotation` / `setShapeFlip`.

## Tests

`test/l3-preset-shapes.test.ts` — round-trip read-back, avLst replacement (no duplicate guides), fractional rounding, throw on non-preset geometry, and an `xmllint` pml.xsd schema-validity check.

`typecheck` / `lint` / `format:check` / `build` all green. New public API → **minor** changeset included.

> Note: 3 pre-existing failures in `test/corpus/pptxgenjs-parity.test.ts` (line-plain / line-arrow `<p:style>` divergence) reproduce locally due to a dirty `references/PptxGenJS` submodule working tree and are unrelated to this change — the `shape-roundrect-stroke` corpus case stays `divergence 0`, confirming shape output is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017yzUn9Scc8VLAc5vPtbzG4
