### PR TITLE
feat(preview): add auditTextLayout — text overflow and soft-wrap detection

### DIFF
--- a/.changeset/warm-poems-audit.md
+++ b/.changeset/warm-poems-audit.md
@@ -1,0 +1,15 @@
+---
+'@office-kit/pptx-preview': minor
+---
+
+feat: add `auditTextLayout` — detect text overflowing its box (はみ出し) and unintended soft wraps (段落ち)
+
+`auditTextLayout(pres, options)` measures every shape's text with the same
+layout engine the preview renders with and reports `overflow-x` / `overflow-y`
+issues (plus opt-in `soft-wrap` reports via `reportSoftWraps`). Results carry
+an `approximate` flag when widths were estimated rather than measured.
+
+`buildFontkitMeasurer` (the `/node` entry) now accepts `{ fonts }` to register
+the deck's actual font files by their authored family names; registered fonts
+also serve as glyph fallbacks, and glyphs no font covers are estimated
+per-character (CJK ≈ 1em) instead of measured against missing-glyph advances.

--- a/packages/preview/README.md
+++ b/packages/preview/README.md
@@ -66,6 +66,57 @@ Cambria, Liberation ≈ Arial/Times/Courier; OFL / Apache-2.0, see
 all reference the same fonts, so wrap/positioning math agrees with the painted
 glyphs and the result is deterministic (no system fonts).
 
+### Text-layout audit (overflow / soft-wrap detection)
+
+```ts
+import { auditTextLayout } from '@office-kit/pptx-preview';
+import { buildFontkitMeasurer } from '@office-kit/pptx-preview/node';
+
+// Register the fonts the deck actually uses (especially CJK) for accurate widths.
+const measureText = buildFontkitMeasurer({
+  fonts: [{ family: '游ゴシック', source: 'fonts/YuGothic.ttf' }],
+});
+
+const issues = auditTextLayout(pres, { measureText, reportSoftWraps: true });
+// → [{ kind: 'overflow-y', slideIndex: 2, shapeName: 'Title 1', overflowPx: 14.3, approximate: false }, …]
+```
+
+`auditTextLayout` measures every shape's text body — placeholders, text boxes,
+autoshapes, shapes inside groups — with the same engine the preview renders
+with, honouring the effective bodyPr cascade (insets, wrap, anchor, vertical
+text, columns) and `normAutofit` shrinking. It returns one issue per finding:
+
+| `kind`       | Meaning                                                                       | Extra fields                   |
+| ------------ | ----------------------------------------------------------------------------- | ------------------------------ |
+| `overflow-x` | Text ink escapes the box horizontally (typically `wrap="none"`)               | `overflowPx`                   |
+| `overflow-y` | Wrapped text is taller than the box (or escapes the top when bottom-anchored) | `overflowPx`                   |
+| `soft-wrap`  | A paragraph wrapped onto more lines than its authored `<a:br>` count (段落ち) | `paragraphIndex`, `extraLines` |
+
+Every issue also carries `slideIndex`, `shapeName`, and `approximate` —
+`true` when a width had to be estimated (the heuristic measurer, or glyphs the
+available fonts don't cover), in which case treat borderline verdicts as
+advisory.
+
+Options:
+
+- `measureText` — the measurer. Defaults to the browser-safe heuristic
+  (≈0.55 em per Latin glyph, 1 em per CJK glyph, always `approximate`); pass
+  `buildFontkitMeasurer()` in Node for real glyph metrics.
+- `tolerancePx` — overflow at or below this many px (96 DPI) is ignored.
+  Default `1`; raise it if you only care about visibly broken slides.
+- `reportSoftWraps` — opt into `soft-wrap` issues. Off by default because
+  wrapping is normal for body text; turn it on when auditing titles or labels
+  meant to stay on one line.
+
+Accuracy: the bundled fonts are metric-compatible with the Office defaults, so
+verdicts for Calibri / Cambria / Arial / Times / Courier decks match real glyph
+widths; for any other font (custom brand fonts, Japanese fonts), register the
+real files via `buildFontkitMeasurer({ fonts })` — a registered font is used
+both for runs that name it and as a glyph fallback for CJK text in runs that
+resolve to a Latin face. Line-break positions can differ from PowerPoint by a
+few characters in edge cases (kinsoku, hyphenation), which is what the default
+1 px tolerance absorbs. Table cell text is not audited yet.
+
 ## Fidelity
 
 This is a high-fidelity preview, not a spec-complete PowerPoint renderer.

--- a/packages/preview/src/audit.ts
+++ b/packages/preview/src/audit.ts
@@ -1,0 +1,294 @@
+// Text-layout audit: measures every shape's laid-out text against its box and
+// reports where ink escapes (overflow) or paragraphs soft-wrap (段落ち).
+//
+// The measurement runs through the SAME pipeline the preview renders with —
+// `resolveTextBodyModel` (effective bodyPr / autofit / paragraph model) into
+// `layoutCore` (wrap + baseline placement) — so a reported overflow is exactly
+// what the rasterized preview would paint outside the box.
+//
+// Browser-safe like text-layout.ts: the measurer is injected. The default
+// heuristic measurer estimates widths per character (results are flagged
+// `approximate`); pass `buildFontkitMeasurer()` from
+// `@office-kit/pptx-preview/node` for glyph-accurate metrics.
+
+import {
+  getGroupChildren,
+  getPresentationTheme,
+  getShapeBoundsResolved,
+  getShapeKind,
+  getShapeName,
+  getShapePlaceholderType,
+  getShapeTextColumns,
+  getShapeTextDirection,
+  getSlides,
+  getSlideShapes,
+  type PresentationData,
+  type PresentationTheme,
+  type SlideShapeData,
+} from '@office-kit/pptx';
+import {
+  buildSvgTextInput,
+  EMU_PER_PX,
+  resolveTextBodyModel,
+  verticalLayoutOf,
+} from './render-slide.ts';
+import {
+  defaultMeasurer,
+  layoutCore,
+  SANS,
+  type ColumnLayout,
+  type FontSpec,
+  type TextMeasurer,
+} from './text-layout.ts';
+
+interface IssueBase {
+  /** 0-based deck position of the slide the shape sits on. */
+  readonly slideIndex: number;
+  readonly shapeName: string | null;
+  /** True when any run was measured by estimate rather than real glyph
+   *  metrics (heuristic measurer, or a font without the needed glyphs).
+   *  Treat borderline overflows as advisory when set. */
+  readonly approximate: boolean;
+}
+
+export type TextAuditIssue =
+  | (IssueBase & {
+      readonly kind: 'overflow-x' | 'overflow-y';
+      /** How far the text ink escapes the box, in px at 96 DPI. */
+      readonly overflowPx: number;
+    })
+  | (IssueBase & {
+      readonly kind: 'soft-wrap';
+      readonly paragraphIndex: number;
+      /** Lines beyond the paragraph's authored line count (1 + explicit
+       *  breaks) — i.e. how many times the text wrapped on its own. */
+      readonly extraLines: number;
+    });
+
+export interface AuditTextLayoutOptions {
+  /** Measurer for run widths / vertical metrics. Defaults to the heuristic
+   *  measurer (browser-safe, approximate); pass the fontkit measurer from
+   *  `@office-kit/pptx-preview/node` for real glyph metrics. */
+  readonly measureText?: TextMeasurer;
+  /** Overflow at or below this many px (96 DPI) is ignored. Default 1 —
+   *  measurement and PowerPoint disagree by sub-pixel amounts routinely. */
+  readonly tolerancePx?: number;
+  /** Also report paragraphs that wrap onto more lines than their explicit
+   *  breaks author (段落ち). Off by default: wrapping is normal for body
+   *  text, so this is opt-in for single-line-intent content like titles. */
+  readonly reportSoftWraps?: boolean;
+}
+
+const DEFAULT_TOLERANCE_PX = 1;
+
+const round2 = (n: number): number => Math.round(n * 100) / 100;
+
+// Depth-first over group trees. Children are audited in their own (child)
+// coordinate space, where box and text agree; a group's non-uniform scale
+// stretches both equally in the rendered output, so overflow verdicts hold.
+function* walkShapes(shapes: ReadonlyArray<SlideShapeData>): Generator<SlideShapeData> {
+  for (const shape of shapes) {
+    if (getShapeKind(shape) === 'group') {
+      yield* walkShapes(getGroupChildren(shape));
+    } else {
+      yield shape;
+    }
+  }
+}
+
+// The audit hands the measurer the AUTHORED font name (falling back to the
+// generic sans substitute), unlike the render path's `substituteFamily` —
+// a fontkit measurer with user-registered fonts resolves it first and only
+// then falls back to the same substitution map.
+const passthroughFamily = (family: string | null): string => family ?? SANS;
+
+const auditShape = (
+  pres: PresentationData,
+  theme: PresentationTheme | null,
+  shape: SlideShapeData,
+  slideIndex: number,
+  measure: TextMeasurer,
+  tolerancePx: number,
+  reportSoftWraps: boolean,
+  issues: TextAuditIssue[],
+): void => {
+  const kind = getShapeKind(shape);
+  if (kind !== 'shape' && kind !== 'graphicFrame') return;
+  const bounds = getShapeBoundsResolved(pres, shape);
+  if (!bounds) return;
+  const model = resolveTextBodyModel(
+    pres,
+    shape,
+    { x: bounds.x as number, y: bounds.y as number, w: bounds.w as number, h: bounds.h as number },
+    theme,
+    getShapePlaceholderType(shape),
+    measure,
+    '#000000', // colors don't affect metrics
+  );
+  if (model === null) return;
+
+  const vert = verticalLayoutOf(model.effectiveBody.vert ?? getShapeTextDirection(shape));
+  const cols = getShapeTextColumns(shape);
+  const columns: ColumnLayout | null =
+    vert === 'none' && cols && cols.count >= 2
+      ? {
+          count: cols.count,
+          gapPx: cols.gapEmu !== undefined ? cols.gapEmu / EMU_PER_PX : 12,
+        }
+      : null;
+  const rect = model.svgTextRect(vert);
+  if (rect.w <= 0 || rect.h <= 0) return;
+
+  // SVG semantics (see the render path's `svgScale`): only an authored
+  // autofit shrinks; the heuristic factor is foreignObject-only.
+  const autoFitScale = model.authoredAutofit ? model.autoFitScale : 1;
+  const input = buildSvgTextInput({
+    pres,
+    shape,
+    theme,
+    paraData: model.paraData,
+    numberLabels: model.numberLabels,
+    autoFitScale,
+    lineHeightScale: model.lineHeightScale,
+    defaultPt: model.defaultPt,
+    themeFace: model.themeFace,
+    defaultColor: '#000000',
+    anchor: model.anchor,
+    wrap: model.effectiveBody.wrap !== 'none',
+    innerX: rect.x,
+    innerY: rect.y,
+    innerW: rect.w,
+    innerH: rect.h,
+    measure,
+    vert,
+    columns,
+    resolveFamily: passthroughFamily,
+  });
+  const core = layoutCore(input, measure);
+
+  // Mirror layoutCore's frame: the ±90° rotations lay out into a frame with
+  // swapped extents re-centred on the box, so ink must be compared against
+  // that frame, not the box itself.
+  const rotated = vert === 'cw90' || vert === 'cw270';
+  const frame = rotated
+    ? {
+        x: input.boxXpx + input.boxWpx / 2 - input.boxHpx / 2,
+        y: input.boxYpx + input.boxHpx / 2 - input.boxWpx / 2,
+        w: input.boxHpx,
+        h: input.boxWpx,
+      }
+    : { x: input.boxXpx, y: input.boxYpx, w: input.boxWpx, h: input.boxHpx };
+
+  // Ink extents over every placed line. Empty lines (blank paragraphs, lines
+  // of spaces) paint nothing — they influence later lines' positions but are
+  // not themselves visible overflow.
+  let inkTop = Infinity;
+  let inkBottom = -Infinity;
+  let overflowX = 0;
+  let anyInk = false;
+  for (const p of core.placements) {
+    const toks = [...p.line.tokens];
+    while (toks.length > 0 && (toks[toks.length - 1]!.isSpace || toks[toks.length - 1]!.isBreak)) {
+      toks.pop();
+    }
+    if (!toks.some((t) => !t.isSpace && !t.isBreak)) continue;
+    anyInk = true;
+    let lineW = 0;
+    for (const t of toks) {
+      if (!t.isBreak) lineW += t.width;
+    }
+    const left =
+      p.line.textAnchor === 'middle'
+        ? p.line.anchorX - lineW / 2
+        : p.line.textAnchor === 'end'
+          ? p.line.anchorX - lineW
+          : p.line.anchorX;
+    const over = Math.max(frame.x - (left + p.dx), left + p.dx + lineW - (frame.x + frame.w));
+    if (over > overflowX) overflowX = over;
+    inkTop = Math.min(inkTop, p.baselineY - p.line.ascent);
+    inkBottom = Math.max(inkBottom, p.baselineY + p.line.descent);
+  }
+  if (!anyInk) return;
+
+  const approximate = detectApproximate(input.paragraphs, measure);
+  const slideRef = { slideIndex, shapeName: getShapeName(shape), approximate };
+
+  if (overflowX > tolerancePx) {
+    issues.push({ ...slideRef, kind: 'overflow-x', overflowPx: round2(overflowX) });
+  }
+  const overflowY = Math.max(frame.y - inkTop, inkBottom - (frame.y + frame.h));
+  if (overflowY > tolerancePx) {
+    issues.push({ ...slideRef, kind: 'overflow-y', overflowPx: round2(overflowY) });
+  }
+
+  // 段落ち — a paragraph occupying more lines than 1 + its explicit <a:br>
+  // count wrapped on its own. Meaningless for `upright` (one glyph per line
+  // by construction), so horizontal text only.
+  if (reportSoftWraps && vert === 'none') {
+    const lineCounts = new Map<number, number>();
+    for (const p of core.placements) {
+      lineCounts.set(p.line.paraIndex, (lineCounts.get(p.line.paraIndex) ?? 0) + 1);
+    }
+    input.paragraphs.forEach((para, pi) => {
+      const breaks = para.pieces.reduce((n, pc) => n + (pc.isBreak ? 1 : 0), 0);
+      const extraLines = (lineCounts.get(pi) ?? 0) - 1 - breaks;
+      if (extraLines > 0) {
+        issues.push({ ...slideRef, kind: 'soft-wrap', paragraphIndex: pi, extraLines });
+      }
+    });
+  }
+};
+
+// A shape's verdict is approximate when any of its runs was measured by
+// estimate: the heuristic measurer (no vertical metrics) or a fontkit
+// measurer that hit a missing glyph (`approximate` flag).
+const detectApproximate = (
+  paragraphs: ReturnType<typeof buildSvgTextInput>['paragraphs'],
+  measure: TextMeasurer,
+): boolean => {
+  const seen = new Set<string>();
+  for (const para of paragraphs) {
+    for (const piece of para.pieces) {
+      if (piece.isBreak || piece.text === '') continue;
+      const key = `${piece.family}|${piece.sizePx}|${piece.bold}|${piece.italic}|${piece.text}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const spec: FontSpec = {
+        family: piece.family,
+        sizePx: piece.sizePx,
+        bold: piece.bold,
+        italic: piece.italic,
+        letterSpacingPx: piece.letterSpacingPx,
+      };
+      const r = measure(piece.text, spec);
+      if (r.approximate === true || r.ascentPx === undefined) return true;
+    }
+  }
+  return false;
+};
+
+/**
+ * Measures every text body in the deck and reports text that escapes its box
+ * (`overflow-x` / `overflow-y`) and, opt-in, paragraphs that soft-wrap
+ * (`soft-wrap`, 段落ち).
+ *
+ * Table cell text is not audited (v1 covers shape text bodies, including
+ * placeholders and shapes inside groups).
+ */
+export const auditTextLayout = (
+  pres: PresentationData,
+  options: AuditTextLayoutOptions = {},
+): ReadonlyArray<TextAuditIssue> => {
+  const measure = options.measureText ?? defaultMeasurer;
+  const tolerancePx = options.tolerancePx ?? DEFAULT_TOLERANCE_PX;
+  const reportSoftWraps = options.reportSoftWraps ?? false;
+  const theme = getPresentationTheme(pres);
+  const issues: TextAuditIssue[] = [];
+  const slides = getSlides(pres);
+  for (let slideIndex = 0; slideIndex < slides.length; slideIndex++) {
+    for (const shape of walkShapes(getSlideShapes(slides[slideIndex]!))) {
+      auditShape(pres, theme, shape, slideIndex, measure, tolerancePx, reportSoftWraps, issues);
+    }
+  }
+  return issues;
+};

--- a/packages/preview/src/index.ts
+++ b/packages/preview/src/index.ts
@@ -12,6 +12,11 @@
 
 export { renderSlideSvg as renderSlideToSvg } from './render-slide.ts';
 
+// Text-layout audit — overflow (はみ出し) and soft-wrap (段落ち) detection,
+// measured with the same layout engine the preview renders with.
+export { auditTextLayout } from './audit.ts';
+export type { AuditTextLayoutOptions, TextAuditIssue } from './audit.ts';
+
 export type {
   RenderSlideOptions,
   TextLayoutMode,

--- a/packages/preview/src/measure.ts
+++ b/packages/preview/src/measure.ts
@@ -9,11 +9,15 @@ import { existsSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import {
   ARIAL,
+  AVG_GLYPH_W_RATIO,
+  isCjk,
   MONO,
   SANS,
   SERIF,
+  substituteFamily,
   TIMES,
   type FontSpec,
+  type MeasureResult,
   type TextMeasurer,
 } from './text-layout.ts';
 
@@ -46,14 +50,47 @@ const openFont = (path: string): fontkit.Font => {
   return font;
 };
 
-const styleSuffix = (spec: FontSpec): (typeof STYLES)[number] => {
+const styleSuffix = (spec: { bold: boolean; italic: boolean }): (typeof STYLES)[number] => {
   if (spec.bold && spec.italic) return 'BoldItalic';
   if (spec.bold) return 'Bold';
   if (spec.italic) return 'Italic';
   return 'Regular';
 };
 
-export const buildFontkitMeasurer = (): TextMeasurer => {
+/** A font the caller supplies for measurement, keyed by the AUTHORED family
+ *  name (`<a:latin typeface>` / `<a:ea typeface>` — e.g. "游ゴシック",
+ *  "Montserrat"), which routinely differs from the file's internal name. */
+export interface RegisteredFont {
+  readonly family: string;
+  /** Path to a ttf/otf file, or its bytes. */
+  readonly source: string | Uint8Array;
+  readonly bold?: boolean;
+  readonly italic?: boolean;
+}
+
+export interface FontkitMeasurerOptions {
+  /** Fonts the deck actually uses. A run whose family matches a registered
+   *  font measures with it; any registered font also serves as a fallback
+   *  for glyphs the resolved font lacks (the bundled faces are Latin-only,
+   *  so this is how CJK text gets real metrics). */
+  readonly fonts?: ReadonlyArray<RegisteredFont>;
+}
+
+const openFontSource = (source: string | Uint8Array): fontkit.Font => {
+  if (typeof source === 'string') return openFont(source);
+  const font = fontkit.create(Buffer.from(source));
+  if (!('layout' in font)) {
+    throw new Error('Expected a single font, got a collection');
+  }
+  return font;
+};
+
+// Per-character width estimate for glyphs no available font covers — the same
+// ratios as the heuristic measurer, so estimates and defaultMeasurer agree.
+const estimateCharWidth = (ch: string, sizePx: number): number =>
+  sizePx * (isCjk(ch.codePointAt(0) ?? 0) ? 1 : AVG_GLYPH_W_RATIO);
+
+export const buildFontkitMeasurer = (options: FontkitMeasurerOptions = {}): TextMeasurer => {
   const cache = new Map<string, fontkit.Font>();
   // Load + verify every face up front. The familyName assertion guarantees the
   // emit-side family === resvg match === the face we measure, which is the load-
@@ -73,9 +110,28 @@ export const buildFontkitMeasurer = (): TextMeasurer => {
     }
   }
 
+  // Registered fonts, keyed by lowercased authored family + style. No
+  // familyName assertion here: the registration key is the DECK's name for
+  // the font, which legitimately differs from the file's internal name.
+  const registered = new Map<string, fontkit.Font>();
+  const fallbackFonts: fontkit.Font[] = [];
+  for (const reg of options.fonts ?? []) {
+    const font = openFontSource(reg.source);
+    const style = styleSuffix({ bold: reg.bold ?? false, italic: reg.italic ?? false });
+    registered.set(`${reg.family.toLowerCase()}-${style}`, font);
+    fallbackFonts.push(font);
+  }
+
   const pick = (spec: FontSpec): fontkit.Font => {
-    const prefix = FAMILY_TO_PREFIX[spec.family] ?? 'Carlito';
     const style = styleSuffix(spec);
+    const regKey = spec.family.toLowerCase();
+    const reg = registered.get(`${regKey}-${style}`) ?? registered.get(`${regKey}-Regular`);
+    if (reg) return reg;
+    // The render path pre-substitutes families (spec.family is a bundled
+    // internal name); the audit path passes the authored name through, so
+    // resolve it with the same map before keying the bundled faces.
+    const prefix =
+      FAMILY_TO_PREFIX[spec.family] ?? FAMILY_TO_PREFIX[substituteFamily(spec.family)]!;
     return (
       cache.get(`${prefix}-${style}`) ??
       cache.get(`${prefix}-Regular`) ??
@@ -83,20 +139,56 @@ export const buildFontkitMeasurer = (): TextMeasurer => {
     );
   };
 
-  return (text, spec) => {
-    const font = pick(spec);
-    const scale = spec.sizePx / font.unitsPerEm;
-    const run = font.layout(text); // applies the font's kerning / GPOS
+  // Splits `text` into maximal segments coverable by one font: the resolved
+  // font first, then each registered font in registration order. Characters
+  // no font covers fall back to the per-character estimate (approximate).
+  const measureWithFallback = (
+    text: string,
+    spec: FontSpec,
+    primary: fontkit.Font,
+  ): MeasureResult => {
+    const chain = [primary, ...fallbackFonts.filter((f) => f !== primary)];
+    let widthPx = 0;
+    let approximate = false;
+    let metricsFont: fontkit.Font | null = null;
+    let segment = '';
+    let segmentFont: fontkit.Font | null = null;
+    const flush = (): void => {
+      if (segment === '' || segmentFont === null) return;
+      const scale = spec.sizePx / segmentFont.unitsPerEm;
+      widthPx += segmentFont.layout(segment).advanceWidth * scale;
+      metricsFont ??= segmentFont;
+      segment = '';
+    };
+    for (const ch of text) {
+      const cp = ch.codePointAt(0) ?? 0;
+      const font = chain.find((f) => f.hasGlyphForCodePoint(cp)) ?? null;
+      if (font !== segmentFont) {
+        flush();
+        segmentFont = font;
+      }
+      if (font === null) {
+        widthPx += estimateCharWidth(ch, spec.sizePx);
+        approximate = true;
+      } else {
+        segment += ch;
+      }
+    }
+    flush();
+    const vm = verticalMetrics(metricsFont ?? primary);
+    const vmScale = spec.sizePx / (metricsFont ?? primary).unitsPerEm;
     const glyphCount = [...text].length;
     const tracking = glyphCount > 1 ? spec.letterSpacingPx * (glyphCount - 1) : 0;
-    const vm = verticalMetrics(font);
     return {
-      widthPx: run.advanceWidth * scale + tracking,
-      ascentPx: vm.ascent * scale,
-      descentPx: vm.descent * scale,
-      lineGapPx: vm.lineGap * scale,
+      widthPx: widthPx + tracking,
+      ascentPx: vm.ascent * vmScale,
+      descentPx: vm.descent * vmScale,
+      lineGapPx: vm.lineGap * vmScale,
+      ...(approximate ? { approximate } : {}),
     };
   };
+
+  return (text, spec) => measureWithFallback(text, spec, pick(spec));
 };
 
 // Which vertical-metric set a renderer uses depends on the OS/2 fsSelection

--- a/packages/preview/src/node.ts
+++ b/packages/preview/src/node.ts
@@ -19,6 +19,7 @@ export * from './index.ts';
 
 // Advanced: pre-build / share a fontkit measurer, or locate the bundled fonts.
 export { buildFontkitMeasurer, FONT_FILES, FONT_DIR } from './measure.ts';
+export type { FontkitMeasurerOptions, RegisteredFont } from './measure.ts';
 
 /** Raw, un-encoded raster: RGBA bytes in row-major order. */
 export interface RgbaImage {

--- a/packages/preview/src/render-slide.ts
+++ b/packages/preview/src/render-slide.ts
@@ -175,7 +175,7 @@ const DEFAULT_SIZE = { width: 12_192_000, height: 6_858_000 };
 // Real browsers refuse to render text when CSS font-size grows into
 // the hundreds of thousands of pixels (which is what happens if you
 // keep EMU as the SVG user unit).
-const EMU_PER_PX = 9525;
+export const EMU_PER_PX = 9525;
 
 // CSS px per typographic point.
 const PX_PER_PT = 96 / 72;
@@ -2200,7 +2200,7 @@ const hasStrikeFmt = (fmt: TextFormat | null): boolean => {
   return s !== undefined && s !== false && s !== 'noStrike';
 };
 
-interface SvgTextArgs {
+export interface SvgTextArgs {
   readonly pres: PresentationData;
   readonly shape: SlideShapeData;
   readonly theme: PresentationTheme | null;
@@ -2220,6 +2220,13 @@ interface SvgTextArgs {
   readonly measure: TextMeasurer;
   readonly vert: VerticalLayout;
   readonly columns: ColumnLayout | null;
+  /** Maps an authored font name onto the family the measurer keys off.
+   *  The render paths leave this unset (= `substituteFamily`, whose output
+   *  must match the bundled TTFs' internal names for resvg). The audit path
+   *  passes the authored name through so a fontkit measurer with
+   *  user-registered fonts can resolve it before falling back to the
+   *  substitution map. */
+  readonly resolveFamily?: (family: string | null) => string;
 }
 
 const alignOf = (a: string): ParaInput['align'] =>
@@ -2239,7 +2246,9 @@ const alignOf = (a: string): ParaInput['align'] =>
 // agree for text that fits; they differ only past the box, where the deck is
 // already out of spec. Faithful multi-column upright wrapping in the SVG engine
 // is disproportionate to that edge case, so we accept the clip.
-const verticalLayoutOf = (vert: ReturnType<typeof getShapeTextDirection>): VerticalLayout => {
+export const verticalLayoutOf = (
+  vert: ReturnType<typeof getShapeTextDirection>,
+): VerticalLayout => {
   switch (vert) {
     case 'vert':
     case 'eaVert':
@@ -2256,7 +2265,7 @@ const verticalLayoutOf = (vert: ReturnType<typeof getShapeTextDirection>): Verti
 };
 
 // Build the px-native engine input from the resolved paraData (at a.autoFitScale).
-const buildSvgTextInput = (a: SvgTextArgs): TextBodyInput => {
+export const buildSvgTextInput = (a: SvgTextArgs): TextBodyInput => {
   const scale = a.autoFitScale;
   const paragraphs: ParaInput[] = a.paraData.map((para, pi): ParaInput => {
     const pieces: PieceInput[] = [];
@@ -2278,7 +2287,7 @@ const buildSvgTextInput = (a: SvgTextArgs): TextBodyInput => {
           underline: fmt?.underline ?? true,
         };
       }
-      const family = substituteFamily(fmt?.font ?? a.themeFace);
+      const family = (a.resolveFamily ?? substituteFamily)(fmt?.font ?? a.themeFace);
       const sizePx = run.sizePt * scale * PX_PER_PT;
       const fillHex =
         fmt?.color !== undefined && fmt.color !== null
@@ -2426,7 +2435,7 @@ const buildBullet = (a: SvgTextArgs, para: ParaData, pi: number): BulletInput | 
     : a.defaultColor;
   return {
     text: char,
-    family: substituteFamily(para.bulletDetail.font ?? DEFAULT_BULLET_FONT),
+    family: (a.resolveFamily ?? substituteFamily)(para.bulletDetail.font ?? DEFAULT_BULLET_FONT),
     sizePx,
     fillHex,
     ...(para.bulletImageHref ? { imageHref: para.bulletImageHref } : {}),
@@ -2462,21 +2471,52 @@ const presetTextRect = (
   }
 };
 
-const renderTextBody = (
+// The render-path-independent half of a shape's text body: the resolved
+// paragraph/run model, the effective bodyPr cascade, the inner text rect, and
+// the final autofit factor. Extracted from renderTextBody so the audit API
+// (`auditTextLayout`) measures with EXACTLY the pipeline the renderer draws
+// with — any drift between the two would make the audit lie about the preview.
+export interface TextBodyModel {
+  readonly paraData: readonly ParaData[];
+  readonly numberLabels: ReadonlyArray<string | null>;
+  readonly authoredAutofit: ReturnType<typeof getShapeTextAutoFitParams>;
+  /** Final autofit factor: the baked `fontScale`, the bare-normAutofit shrink
+   *  search result, or the foreignObject-only heuristic. SVG-semantics callers
+   *  (the fidelity path, the audit) must apply it only when `authoredAutofit`
+   *  is set — see the render path's `svgScale`. */
+  readonly autoFitScale: number;
+  readonly lineHeightScale: number;
+  readonly defaultPt: number;
+  readonly themeFace: string | null;
+  readonly effectiveDefaultFont: string;
+  readonly effectiveBody: ReturnType<typeof getShapeBodyPrEffective>;
+  readonly anchor: 'top' | 'center' | 'bottom';
+  /** Inner text rect in EMU (preset-geometry text rect + insets applied). */
+  readonly innerX: number;
+  readonly innerY: number;
+  readonly innerW: number;
+  readonly innerH: number;
+  readonly svgTextRect: (v: VerticalLayout) => { x: number; y: number; w: number; h: number };
+}
+
+// Returns null when the shape has no text body worth laying out (no
+// paragraphs, no run text, or a degenerate inner rect).
+export const resolveTextBodyModel = (
   pres: PresentationData,
   shape: SlideShapeData,
   bounds: { x: number; y: number; w: number; h: number },
   theme: PresentationTheme | null,
   phType: string | null,
-  ctx: LayoutCtx,
-): string => {
+  measure: TextMeasurer,
+  defaultColor: string,
+): TextBodyModel | null => {
   let paragraphCount: number;
   try {
     paragraphCount = getShapeParagraphCount(shape);
   } catch {
-    return '';
+    return null;
   }
-  if (paragraphCount === 0) return '';
+  if (paragraphCount === 0) return null;
 
   const defaultPt = placeholderDefaultPt(phType);
   // Theme font stack — `<a:fontScheme><a:majorFont>` is the title face,
@@ -2540,7 +2580,7 @@ const renderTextBody = (
     innerW = rectW;
     innerH = rectH;
   }
-  if (innerW <= 0 || innerH <= 0) return '';
+  if (innerW <= 0 || innerH <= 0) return null;
 
   // The rect the pure-SVG path lays text into for a given vertical layout.
   // Horizontal and `upright` (wordArtVert) text use the shared inner rect; the
@@ -2708,7 +2748,7 @@ const renderTextBody = (
       indent,
     });
   }
-  if (!hasAnyText) return '';
+  if (!hasAnyText) return null;
 
   // Prefer the *authored* autofit factor when PowerPoint already
   // computed one (`<a:normAutofit fontScale=…/>`). That's the same
@@ -2827,30 +2867,82 @@ const renderTextBody = (
       lineHeightScale,
       defaultPt,
       themeFace,
-      defaultColor: activeDeckTextColor,
+      defaultColor,
       anchor: anchor === 'center' || anchor === 'bottom' ? anchor : 'top',
       wrap: effectiveBody.wrap !== 'none',
       innerX: fitRect.x,
       innerY: fitRect.y,
       innerW: fitRect.w,
       innerH: fitRect.h,
-      measure: ctx.measure,
+      measure,
       vert: fitVert,
       columns: fitColumns,
     };
     let s = 1;
     while (s > AUTOFIT_FLOOR) {
       if (
-        measureTextBodyHeight(
-          buildSvgTextInput({ ...fitArgsBase, autoFitScale: s }),
-          ctx.measure,
-        ) <= fitBoxPx
+        measureTextBodyHeight(buildSvgTextInput({ ...fitArgsBase, autoFitScale: s }), measure) <=
+        fitBoxPx
       )
         break;
       s -= AUTOFIT_STEP;
     }
     autoFitScale = Math.max(AUTOFIT_FLOOR, s);
   }
+
+  return {
+    paraData,
+    numberLabels,
+    authoredAutofit,
+    autoFitScale,
+    lineHeightScale,
+    defaultPt,
+    themeFace,
+    effectiveDefaultFont,
+    effectiveBody,
+    anchor,
+    innerX,
+    innerY,
+    innerW,
+    innerH,
+    svgTextRect,
+  };
+};
+
+const renderTextBody = (
+  pres: PresentationData,
+  shape: SlideShapeData,
+  bounds: { x: number; y: number; w: number; h: number },
+  theme: PresentationTheme | null,
+  phType: string | null,
+  ctx: LayoutCtx,
+): string => {
+  const model = resolveTextBodyModel(
+    pres,
+    shape,
+    bounds,
+    theme,
+    phType,
+    ctx.measure,
+    activeDeckTextColor,
+  );
+  if (model === null) return '';
+  const {
+    paraData,
+    numberLabels,
+    authoredAutofit,
+    autoFitScale,
+    defaultPt,
+    themeFace,
+    effectiveDefaultFont,
+    effectiveBody,
+    anchor,
+    innerX,
+    innerY,
+    innerW,
+    innerH,
+    svgTextRect,
+  } = model;
 
   // Second pass — emit runs with scaled sizes.
   const paragraphs: string[] = [];

--- a/packages/preview/src/text-layout.ts
+++ b/packages/preview/src/text-layout.ts
@@ -33,6 +33,11 @@ export interface MeasureResult {
   readonly ascentPx?: number;
   readonly descentPx?: number;
   readonly lineGapPx?: number;
+  /** True when the width is an estimate rather than a glyph measurement —
+   *  the heuristic measurer always, the fontkit measurer when the resolved
+   *  font lacks a glyph and per-character ratios filled the gap. The audit
+   *  API surfaces this so borderline verdicts can be treated as advisory. */
+  readonly approximate?: boolean;
 }
 
 export type TextMeasurer = (text: string, spec: FontSpec) => MeasureResult;
@@ -78,17 +83,18 @@ export const substituteFamily = (family: string | null | undefined): string => {
 };
 
 // CJK detection — lifted from render-slide.ts so the heuristic measurer
-// matches today's autofit estimate exactly.
-const isCjk = (cp: number): boolean =>
+// matches today's autofit estimate exactly. Exported for the fontkit
+// measurer's missing-glyph fallback, which must estimate with the same ratios.
+export const isCjk = (cp: number): boolean =>
   (cp >= 0x3040 && cp <= 0x309f) ||
   (cp >= 0x30a0 && cp <= 0x30ff) ||
   (cp >= 0x4e00 && cp <= 0x9fff) ||
   (cp >= 0xac00 && cp <= 0xd7af);
 
 // Mean glyph width as a fraction of size for a typical sans-serif — the same
-// 0.55 PowerPoint's autofit estimator uses. Only used by the heuristic
-// measurer (no real font metrics available).
-const AVG_GLYPH_W_RATIO = 0.55;
+// 0.55 PowerPoint's autofit estimator uses. Used by the heuristic measurer
+// and by the fontkit measurer's missing-glyph fallback.
+export const AVG_GLYPH_W_RATIO = 0.55;
 
 export const defaultMeasurer: TextMeasurer = (text, spec) => {
   let w = 0;
@@ -201,7 +207,7 @@ export interface TextBodyInput {
 // ---------------------------------------------------------------------------
 // Layout internals.
 
-interface Token {
+export interface Token {
   readonly text: string;
   readonly piece: PieceInput;
   readonly isSpace: boolean;
@@ -209,8 +215,11 @@ interface Token {
   width: number;
 }
 
-interface Line {
+export interface Line {
   readonly tokens: Token[];
+  /** Index into TextBodyInput.paragraphs of the paragraph this line came
+   *  from — the audit API maps wrapped line counts back to paragraphs. */
+  readonly paraIndex: number;
   ascent: number;
   descent: number;
   lineGap: number;
@@ -233,7 +242,7 @@ interface Frame {
 
 // A laid-out line ready to emit: its baseline Y plus an X shift (non-zero only
 // for the second-and-later columns of a multi-column body).
-interface Placement {
+export interface Placement {
   readonly line: Line;
   readonly baselineY: number;
   readonly dx: number;
@@ -269,7 +278,7 @@ const fmt = (n: number): string => {
 
 // ---------------------------------------------------------------------------
 
-interface LayoutCore {
+export interface LayoutCore {
   readonly placements: Placement[];
   readonly requiredH: number; // laid-out content height in px (top-anchored space)
   readonly vert: VerticalLayout;
@@ -277,7 +286,9 @@ interface LayoutCore {
   readonly cy: number;
 }
 
-const layoutCore = (input: TextBodyInput, measure: TextMeasurer): LayoutCore => {
+// Exported (module-level, not part of the package's public surface) for the
+// audit API, which reads the raw placements instead of emitting SVG.
+export const layoutCore = (input: TextBodyInput, measure: TextMeasurer): LayoutCore => {
   const widthCache = new Map<string, number>();
   const metricCache = new Map<string, { a: number; d: number; g: number }>();
   const key = (text: string, s: FontSpec): string =>
@@ -318,7 +329,8 @@ const layoutCore = (input: TextBodyInput, measure: TextMeasurer): LayoutCore => 
     const lines: Line[] = [];
     let cursorY = 0;
 
-    for (const para of input.paragraphs) {
+    for (let paraIndex = 0; paraIndex < input.paragraphs.length; paraIndex++) {
+      const para = input.paragraphs[paraIndex]!;
       cursorY += para.spcBefPx;
       const wrapLeft = contentLeft + para.marLpx;
       const wrapRight = contentRight - para.marRpx;
@@ -391,6 +403,7 @@ const layoutCore = (input: TextBodyInput, measure: TextMeasurer): LayoutCore => 
           : (isFirst ? firstLeft : wrapLeft) + bulletLead;
         const line: Line = {
           tokens: toks,
+          paraIndex,
           ascent,
           descent,
           lineGap,

--- a/test/preview-audit-text.test.ts
+++ b/test/preview-audit-text.test.ts
@@ -1,0 +1,216 @@
+// auditTextLayout — text overflow (はみ出し) and soft-wrap (段落ち) detection.
+//
+// Decks are built in memory with the public authoring API and measured with
+// the bundled fontkit measurer (real glyph metrics), so the expectations are
+// deterministic. Import pattern follows test/preview-svg-text-modes.test.ts.
+
+import { readFile } from 'node:fs/promises';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  addSlide,
+  addSlideTextBox,
+  findSlideLayout,
+  loadPresentation,
+  inches,
+  setShapeTextAutoFit,
+  setShapeTextWrap,
+} from '../src/api/index.ts';
+import { auditTextLayout, type TextAuditIssue } from '../packages/preview/src/index.ts';
+import { buildFontkitMeasurer, FONT_DIR } from '../packages/preview/src/node.ts';
+
+const fixturePath = fileURLToPath(new URL('./fixtures/minimal/blank.pptx', import.meta.url));
+
+const blankSlide = async () => {
+  const pres = await loadPresentation(await readFile(fixturePath));
+  const layout = findSlideLayout(pres, 'Blank');
+  if (!layout) throw new Error('Blank layout not found');
+  return { pres, slide: addSlide(pres, { layout }) };
+};
+
+const measureText = buildFontkitMeasurer();
+
+const ofShape = (issues: ReadonlyArray<TextAuditIssue>, name: string): TextAuditIssue[] =>
+  issues.filter((i) => i.shapeName === name);
+
+// One long paragraph — wraps to many lines in a 2" column at the default 18pt.
+const LONG_PARAGRAPH = Array.from({ length: 30 }, (_, i) => `word${i + 1}`).join(' ');
+
+describe('auditTextLayout — overflow', () => {
+  it('reports nothing for text that fits its box', async () => {
+    const { pres, slide } = await blankSlide();
+    addSlideTextBox(slide, {
+      x: inches(1),
+      y: inches(1),
+      w: inches(4),
+      h: inches(1),
+      text: 'Fits fine',
+      name: 'fits',
+    });
+    expect(ofShape(auditTextLayout(pres, { measureText }), 'fits')).toEqual([]);
+  });
+
+  it('reports overflow-y when wrapped text is taller than the box', async () => {
+    const { pres, slide } = await blankSlide();
+    addSlideTextBox(slide, {
+      x: inches(1),
+      y: inches(1),
+      w: inches(2),
+      h: inches(0.5),
+      text: LONG_PARAGRAPH,
+      name: 'tall',
+    });
+    const issues = ofShape(auditTextLayout(pres, { measureText }), 'tall');
+    const oy = issues.find((i) => i.kind === 'overflow-y');
+    expect(oy).toBeDefined();
+    expect(oy!.kind === 'overflow-y' && oy!.overflowPx).toBeGreaterThan(1);
+    expect(oy!.approximate).toBe(false);
+  });
+
+  it('reports overflow-x for wrap="none" text wider than the box', async () => {
+    const { pres, slide } = await blankSlide();
+    const box = addSlideTextBox(slide, {
+      x: inches(1),
+      y: inches(1),
+      w: inches(1),
+      h: inches(1),
+      text: 'This single unwrapped line is far wider than one inch',
+      name: 'wide',
+    });
+    setShapeTextWrap(box, 'none');
+    const issues = ofShape(auditTextLayout(pres, { measureText }), 'wide');
+    expect(issues.some((i) => i.kind === 'overflow-x')).toBe(true);
+  });
+
+  it('honours normAutofit: the shrink-to-fit search suppresses the overflow', async () => {
+    const mk = async () => {
+      const { pres, slide } = await blankSlide();
+      const box = addSlideTextBox(slide, {
+        x: inches(1),
+        y: inches(1),
+        w: inches(3),
+        h: inches(0.6),
+        text: LONG_PARAGRAPH,
+        name: 'fit',
+      });
+      return { pres, box };
+    };
+    // Without autofit the box overflows …
+    const plain = await mk();
+    expect(
+      ofShape(auditTextLayout(plain.pres, { measureText }), 'fit').some(
+        (i) => i.kind === 'overflow-y',
+      ),
+    ).toBe(true);
+    // … with a bare <a:normAutofit/> the audit shrinks like the renderer does.
+    const fitted = await mk();
+    setShapeTextAutoFit(fitted.box, 'normal');
+    expect(
+      ofShape(auditTextLayout(fitted.pres, { measureText }), 'fit').some(
+        (i) => i.kind === 'overflow-y',
+      ),
+    ).toBe(false);
+  });
+
+  it('flags issues as approximate under the default heuristic measurer', async () => {
+    const { pres, slide } = await blankSlide();
+    addSlideTextBox(slide, {
+      x: inches(1),
+      y: inches(1),
+      w: inches(2),
+      h: inches(0.5),
+      text: LONG_PARAGRAPH,
+      name: 'heuristic',
+    });
+    const issues = ofShape(auditTextLayout(pres), 'heuristic');
+    expect(issues.length).toBeGreaterThan(0);
+    expect(issues.every((i) => i.approximate)).toBe(true);
+  });
+});
+
+describe('auditTextLayout — soft wraps (段落ち)', () => {
+  it('reports wrapped paragraphs only when opted in', async () => {
+    const { pres, slide } = await blankSlide();
+    addSlideTextBox(slide, {
+      x: inches(1),
+      y: inches(1),
+      w: inches(2),
+      h: inches(6), // tall enough that nothing overflows
+      text: LONG_PARAGRAPH,
+      name: 'wrapping',
+    });
+    expect(ofShape(auditTextLayout(pres, { measureText }), 'wrapping')).toEqual([]);
+    const issues = ofShape(
+      auditTextLayout(pres, { measureText, reportSoftWraps: true }),
+      'wrapping',
+    );
+    expect(issues).toHaveLength(1);
+    const wrap = issues[0]!;
+    expect(wrap.kind).toBe('soft-wrap');
+    if (wrap.kind === 'soft-wrap') {
+      expect(wrap.paragraphIndex).toBe(0);
+      expect(wrap.extraLines).toBeGreaterThan(0);
+    }
+  });
+
+  it('does not count authored line breaks as soft wraps', async () => {
+    const { pres, slide } = await blankSlide();
+    addSlideTextBox(slide, {
+      x: inches(1),
+      y: inches(1),
+      w: inches(4),
+      h: inches(3),
+      text: 'first\nsecond\nthird',
+      name: 'authored-breaks',
+    });
+    expect(
+      ofShape(auditTextLayout(pres, { measureText, reportSoftWraps: true }), 'authored-breaks'),
+    ).toEqual([]);
+  });
+});
+
+describe('buildFontkitMeasurer — registered fonts and glyph fallback', () => {
+  const spec = { family: 'Carlito', sizePx: 24, bold: false, italic: false, letterSpacingPx: 0 };
+
+  it('estimates CJK glyphs the bundled Latin fonts lack (1em, approximate)', () => {
+    const r = measureText('あいう', spec);
+    expect(r.approximate).toBe(true);
+    expect(r.widthPx).toBeCloseTo(3 * spec.sizePx, 5);
+    // Vertical metrics still come from a real font.
+    expect(r.ascentPx).toBeGreaterThan(0);
+  });
+
+  it('measures fully covered text with real glyphs (no approximate flag)', () => {
+    const r = measureText('Hello world', spec);
+    expect(r.approximate).toBeUndefined();
+    expect(r.widthPx).toBeGreaterThan(0);
+  });
+
+  it('resolves a registered font by its authored family name', () => {
+    const m = buildFontkitMeasurer({
+      fonts: [{ family: 'My Brand Serif', source: `${FONT_DIR}Caladea-Regular.ttf` }],
+    });
+    const branded = m('Measurement sample', { ...spec, family: 'My Brand Serif' });
+    const serif = m('Measurement sample', { ...spec, family: 'Caladea' });
+    const sans = m('Measurement sample', { ...spec, family: 'Carlito' });
+    expect(branded.widthPx).toBeCloseTo(serif.widthPx, 5);
+    expect(branded.widthPx).not.toBeCloseTo(sans.widthPx, 1);
+  });
+
+  it('accepts font bytes as the source', () => {
+    const bytes = new Uint8Array(readFileSync(`${FONT_DIR}Caladea-Regular.ttf`));
+    const m = buildFontkitMeasurer({ fonts: [{ family: 'From Bytes', source: bytes }] });
+    const fromBytes = m('Measurement sample', { ...spec, family: 'From Bytes' });
+    const serif = m('Measurement sample', { ...spec, family: 'Caladea' });
+    expect(fromBytes.widthPx).toBeCloseTo(serif.widthPx, 5);
+  });
+
+  it('substitutes authored Office names like the render path does', () => {
+    // The audit passes authored names through; unknown/Office names must land
+    // on the same bundled faces the emitter substitutes.
+    const arial = measureText('Measurement sample', { ...spec, family: 'Arial' });
+    const liberation = measureText('Measurement sample', { ...spec, family: 'Liberation Sans' });
+    expect(arial.widthPx).toBeCloseTo(liberation.widthPx, 5);
+  });
+});


### PR DESCRIPTION
<!-- pr-template:v1 -->

## Summary

Adds `auditTextLayout(pres, options)` to `@office-kit/pptx-preview`: it measures every shape's text body with the same layout engine the preview renders with and reports text whose ink escapes its box (`overflow-x` / `overflow-y`) plus, opt-in, paragraphs that soft-wrap beyond their authored line breaks (`soft-wrap`, 段落ち). `buildFontkitMeasurer` gains `{ fonts }` so the deck's real font files (especially Japanese fonts) can be registered by their authored family names for accurate widths.

## Motivation

The existing overlap helpers (`shapesOverlap`, `findOverlappingShapePairs`) compare `<a:xfrm>` bounding boxes only — they cannot detect text overflowing a text box, the most common way a generated deck is visibly broken. Design discussion happened in a Claude Code session with the maintainer: the audit reuses the preview package's fontkit measurement + `layoutCore` engine (SSIM-calibrated against LibreOffice ground truth) rather than adding a heavy native dependency like skia-canvas, and lives in `packages/preview` because that is where the layout engine and the OOXML→px normalization already exist.

## Changes

- New export `auditTextLayout(pres, { measureText?, tolerancePx?, reportSoftWraps? })` (browser-safe entry) returning a discriminated union of `overflow-x` / `overflow-y` / `soft-wrap` issues, each with `slideIndex`, `shapeName`, and an `approximate` flag for estimated widths. Honours the effective bodyPr cascade (insets, wrap, anchor, vertical text, columns) and `normAutofit` shrinking; covers placeholders, text boxes, autoshapes, and shapes inside groups. Table cells are documented as not audited yet.
- `buildFontkitMeasurer(options?)` (`/node` entry) now accepts `{ fonts: [{ family, source, bold?, italic? }] }` to register fonts by authored family name (path or bytes). Registered fonts also serve as glyph fallbacks; glyphs no font covers are estimated per character (CJK ≈ 1 em, Latin ≈ 0.55 em) and flag the result `approximate` instead of being measured against missing-glyph advances.
- `MeasureResult` gains an optional `approximate` field (additive).
- Internal: the render-path-independent half of `renderTextBody` is extracted as `resolveTextBodyModel` and shared by renderer and audit so the two cannot drift; `layoutCore` is module-exported and `Line` carries `paraIndex`. No render behavior change.
- Docs: README section with usage, issue-kind table, option reference, and accuracy notes. Changeset: `@office-kit/pptx-preview` minor.

## Testing

- New `test/preview-audit-text.test.ts` (12 tests): fits / overflow-y / overflow-x with `wrap="none"` / bare-`normAutofit` shrink suppressing the overflow / heuristic-measurer `approximate` flagging / soft-wrap opt-in and authored-`<a:br>` exclusion / registered fonts by path and bytes / CJK glyph estimation / Office-name substitution parity.
- Renderer regression: all existing preview + fidelity suites pass unchanged (109 tests), full suite 1299 passed.
- Run: `pnpm vitest run test/preview-audit-text.test.ts`

## Breaking changes

None. (`buildFontkitMeasurer`'s missing-glyph handling changes measured widths only for glyphs the bundled Latin fonts never covered — previously measured as missing-glyph advances, i.e. already wrong.)

## Checklist

- [x] I have read CLAUDE.md and followed the project's conventions.
- [x] I have added or updated tests for the change.
- [x] I have added or updated documentation where user-visible behavior changed.
- [x] If this is a breaking change, I have added a changeset / CHANGELOG entry and flagged it above.
- [x] I have re-read my own diff and removed dead code, debug prints, and stale comments.
- [x] If I used an LLM to draft this PR, I have verified each change myself, the PR represents real work that warrants a maintainer's review, and I am willing to defend each line in review.

<!-- pr-template:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139hgWtq2wqyuZUTAs7npqW