### PR TITLE
fix(preview): render group children exactly once

### DIFF
--- a/.changeset/tidy-groups-render-once.md
+++ b/.changeset/tidy-groups-render-once.md
@@ -1,0 +1,15 @@
+---
+'@office-kit/pptx-preview': patch
+---
+
+fix: render group children exactly once
+
+`getSlideShapes` / `getSlideLayoutShapes` / `getSlideMasterShapes` flatten
+group descendants into their result, while `renderSlideToSvg` already recurses
+into groups and draws every child with the group transform applied. Rendering
+the flat list verbatim painted each group child a second time, untransformed —
+visibly offset whenever the group's `chOff` differs from its `off` (common in
+Google Slides exports, e.g. shape-built charts showing doubled axis labels).
+
+`auditTextLayout` had the same double-enumeration and reported each group
+child's issues twice; it now audits every shape exactly once.

--- a/packages/preview/src/audit.ts
+++ b/packages/preview/src/audit.ts
@@ -12,7 +12,6 @@
 // `@office-kit/pptx-preview/node` for glyph-accurate metrics.
 
 import {
-  getGroupChildren,
   getPresentationTheme,
   getShapeBoundsResolved,
   getShapeKind,
@@ -83,16 +82,15 @@ const DEFAULT_TOLERANCE_PX = 1;
 
 const round2 = (n: number): number => Math.round(n * 100) / 100;
 
-// Depth-first over group trees. Children are audited in their own (child)
-// coordinate space, where box and text agree; a group's non-uniform scale
-// stretches both equally in the rendered output, so overflow verdicts hold.
+// getSlideShapes already flattens group descendants into the list, so a
+// plain filter reaches every auditable shape exactly once — recursing into
+// groups on top of that would audit each child twice. Children are audited
+// in their own (child) coordinate space, where box and text agree; a group's
+// non-uniform scale stretches both equally in the rendered output, so
+// overflow verdicts hold.
 function* walkShapes(shapes: ReadonlyArray<SlideShapeData>): Generator<SlideShapeData> {
   for (const shape of shapes) {
-    if (getShapeKind(shape) === 'group') {
-      yield* walkShapes(getGroupChildren(shape));
-    } else {
-      yield shape;
-    }
+    if (getShapeKind(shape) !== 'group') yield shape;
   }
 }
 

--- a/packages/preview/src/render-slide.ts
+++ b/packages/preview/src/render-slide.ts
@@ -6382,6 +6382,47 @@ const buildEffectsFilter = (
 // ---------------------------------------------------------------------------
 // Slide composition.
 
+// getSlideShapes / getSlideLayoutShapes / getSlideMasterShapes flatten group
+// descendants into the returned list (document order: each group is followed
+// immediately by its descendants), while renderShape already recurses into
+// groups and draws every child with the group transform applied. Rendering
+// the flat list verbatim would therefore paint each group child a second
+// time, untransformed — visibly offset whenever the group's chOff differs
+// from its off. Walk the flat list and skip each group's descendants.
+//
+// The decoration readers (layout / master) additionally drop placeholder
+// shapes from their flat list, so placeholder descendants must not be
+// counted when skipping.
+const flattenedDescendantCount = (group: SlideShapeData, dropPlaceholders: boolean): number => {
+  let count = 0;
+  for (const child of getGroupChildren(group)) {
+    if (!dropPlaceholders || !isShapePlaceholder(child)) count += 1;
+    if (getShapeKind(child) === 'group') {
+      count += flattenedDescendantCount(child, dropPlaceholders);
+    }
+  }
+  return count;
+};
+
+const topLevelShapes = (
+  shapes: ReadonlyArray<SlideShapeData>,
+  opts: { dropPlaceholders: boolean },
+): SlideShapeData[] => {
+  const out: SlideShapeData[] = [];
+  let skip = 0;
+  for (const shape of shapes) {
+    if (skip > 0) {
+      skip -= 1;
+      continue;
+    }
+    out.push(shape);
+    if (getShapeKind(shape) === 'group') {
+      skip = flattenedDescendantCount(shape, opts.dropPlaceholders);
+    }
+  }
+  return out;
+};
+
 export const renderSlideSvg = (
   pres: PresentationData,
   slide: SlideData,
@@ -6487,8 +6528,12 @@ export const renderSlideSvg = (
   const layoutForBg = getSlideLayout(slide);
   if (layoutForBg) {
     try {
-      const masterShapes = getSlideMasterShapes(pres, layoutForBg);
-      const layoutShapes = getSlideLayoutShapes(pres, layoutForBg);
+      const masterShapes = topLevelShapes(getSlideMasterShapes(pres, layoutForBg), {
+        dropPlaceholders: true,
+      });
+      const layoutShapes = topLevelShapes(getSlideLayoutShapes(pres, layoutForBg), {
+        dropPlaceholders: true,
+      });
       layoutBgShapes = [...masterShapes, ...layoutShapes]
         .map((s) => renderShape(s, pres, theme, ctx))
         .join('');
@@ -6497,7 +6542,7 @@ export const renderSlideSvg = (
     }
   }
 
-  const shapesSvg = getSlideShapes(slide)
+  const shapesSvg = topLevelShapes(getSlideShapes(slide), { dropPlaceholders: false })
     .map((s) => renderShape(s, pres, theme, ctx))
     .join('');
 

--- a/test/preview-audit-text.test.ts
+++ b/test/preview-audit-text.test.ts
@@ -12,6 +12,7 @@ import {
   addSlide,
   addSlideTextBox,
   findSlideLayout,
+  groupShapes,
   loadPresentation,
   inches,
   setShapeTextAutoFit,
@@ -66,6 +67,29 @@ describe('auditTextLayout — overflow', () => {
     expect(oy).toBeDefined();
     expect(oy!.kind === 'overflow-y' && oy!.overflowPx).toBeGreaterThan(1);
     expect(oy!.approximate).toBe(false);
+  });
+
+  it('audits a group child exactly once (flattened list is not re-recursed)', async () => {
+    const { pres, slide } = await blankSlide();
+    const overflowing = addSlideTextBox(slide, {
+      x: inches(1),
+      y: inches(1),
+      w: inches(2),
+      h: inches(0.5),
+      text: LONG_PARAGRAPH,
+      name: 'grouped-tall',
+    });
+    const sibling = addSlideTextBox(slide, {
+      x: inches(4),
+      y: inches(1),
+      w: inches(4),
+      h: inches(1),
+      text: 'Fits fine',
+      name: 'grouped-fits',
+    });
+    groupShapes([overflowing, sibling]);
+    const issues = ofShape(auditTextLayout(pres, { measureText }), 'grouped-tall');
+    expect(issues.filter((i) => i.kind === 'overflow-y')).toHaveLength(1);
   });
 
   it('reports overflow-x for wrap="none" text wider than the box', async () => {

--- a/test/preview-render-svg.test.ts
+++ b/test/preview-render-svg.test.ts
@@ -19,6 +19,7 @@ import {
   findSlideLayout,
   findSlidePlaceholder,
   getSlides,
+  groupShapes,
   inches,
   loadPresentation,
   type PatternPreset,
@@ -657,6 +658,65 @@ describe('chart chrome fidelity', () => {
     // Data max 300 with a 50-step axis → top tick 350, ticks still every 50.
     expect(text).toContain('350');
     expect(text).toContain('50');
+  });
+});
+
+describe('grouped shapes', () => {
+  // getSlideShapes flattens group descendants into the top-level list while
+  // renderShape recurses into groups itself — before the top-level skip,
+  // every group child rendered twice (the second copy untransformed, so it
+  // sat at the group's internal coordinates).
+  it('renders each group child exactly once', async () => {
+    const { pres, slide } = await blankSlide();
+    const a = addSlideTextBox(slide, {
+      x: inches(1),
+      y: inches(1),
+      w: inches(2),
+      h: inches(1),
+      text: 'group-child-a',
+    });
+    const b = addSlideTextBox(slide, {
+      x: inches(3),
+      y: inches(2.5),
+      w: inches(2),
+      h: inches(1),
+      text: 'group-child-b',
+    });
+    groupShapes([a, b]);
+    const svg = renderSlideToSvg(pres, slide);
+    expect(svg.split('group-child-a').length - 1).toBe(1);
+    expect(svg.split('group-child-b').length - 1).toBe(1);
+  });
+
+  it('renders nested group descendants exactly once', async () => {
+    const { pres, slide } = await blankSlide();
+    const a = addSlideTextBox(slide, {
+      x: inches(1),
+      y: inches(1),
+      w: inches(2),
+      h: inches(1),
+      text: 'nested-child-a',
+    });
+    const b = addSlideTextBox(slide, {
+      x: inches(3),
+      y: inches(2.5),
+      w: inches(2),
+      h: inches(1),
+      text: 'nested-child-b',
+    });
+    const inner = groupShapes([a, b]);
+    const c = addSlideTextBox(slide, {
+      x: inches(6),
+      y: inches(1),
+      w: inches(2),
+      h: inches(1),
+      text: 'outer-child-c',
+    });
+    groupShapes([inner, c]);
+    const svg = renderSlideToSvg(pres, slide);
+    expect(svg.split('nested-child-a').length - 1).toBe(1);
+    expect(svg.split('nested-child-b').length - 1).toBe(1);
+    expect(svg.split('outer-child-c').length - 1).toBe(1);
   });
 });
 


### PR DESCRIPTION
## Summary

`getSlideShapes` / `getSlideLayoutShapes` / `getSlideMasterShapes` flatten group descendants into their result, while `renderSlideToSvg` already recurses into groups and draws every child with the group transform applied. Rendering the flat list verbatim painted each group child a second time, untransformed — visibly offset whenever the group's `chOff` differs from its `off` (common in Google Slides exports, e.g. shape-built charts showing doubled axis labels and a doubled axis line).

`auditTextLayout` had the same double-enumeration (flat list + its own group recursion) and reported each group child's issues twice.

## Changes

- `renderSlideSvg`: walk the flat list skipping each group's flattened descendants (placeholder-aware for the layout/master decoration readers, which drop placeholders from their flat list).
- `auditTextLayout`: audit the already-flattened list directly instead of re-recursing into groups.

## Test plan

- New regression tests: grouped and nested-grouped children render exactly once; a grouped overflowing shape is audited exactly once.
- Full suite green locally (the `property/schema-valid` 5s timeout also fails on clean `main` on this machine — pre-existing).

Verified against a real Google Slides-exported deck whose shape-built bar chart previously rendered every axis label twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kv96ssosHqX3orf1xCpQiq