### PR TITLE
feat(preview): let renderSlideToImage load extra rasterizer fonts

### DIFF
--- a/.changeset/brave-fonts-raster.md
+++ b/.changeset/brave-fonts-raster.md
@@ -1,0 +1,13 @@
+---
+'@office-kit/pptx-preview': minor
+---
+
+feat: let `renderSlideToImage` / `renderSlideToRgba` load extra rasterizer fonts
+
+`RenderImageOptions` gains `fontFiles` (extra ttf / otf / ttc paths handed to
+resvg alongside the bundled Latin faces) and `loadSystemFonts` (opt-in OS font
+fallback, default `false` to keep output deterministic). The bundled set has
+no CJK coverage, so decks with Japanese / Chinese / Korean text previously
+rasterized as missing-glyph boxes with no way to fix it — now callers can
+supply a CJK face, pairing it with `buildFontkitMeasurer({ fonts })` so wrap
+math and painted glyphs use the same metrics.

--- a/packages/preview/src/node.ts
+++ b/packages/preview/src/node.ts
@@ -41,6 +41,22 @@ export interface RenderImageOptions {
    * result to control its lifetime, or a custom measurer to swap fonts.
    */
   readonly measureText?: TextMeasurer;
+  /**
+   * Extra font files (ttf / otf / ttc paths) loaded into the rasterizer in
+   * addition to the bundled Latin faces. The bundled set has no CJK
+   * coverage, so decks with Japanese / Chinese / Korean text render as
+   * missing-glyph boxes unless the caller supplies a face here (pair it with
+   * a {@link buildFontkitMeasurer} `fonts` registration so wrap math uses the
+   * same metrics).
+   */
+  readonly fontFiles?: ReadonlyArray<string>;
+  /**
+   * Also let the rasterizer discover OS-installed fonts as a fallback for
+   * families the bundled + `fontFiles` faces don't cover. Defaults to
+   * `false`: system fonts vary per machine, so the default keeps output
+   * deterministic.
+   */
+  readonly loadSystemFonts?: boolean;
 }
 
 const DEFAULT_WIDTH = 1280;
@@ -61,8 +77,8 @@ const rasterize = (pres: PresentationData, slide: SlideData, opts: RenderImageOp
   const resvg = new Resvg(svg, {
     fitTo: { mode: 'width', value: width },
     font: {
-      loadSystemFonts: false, // deterministic: only the bundled fonts
-      fontFiles: FONT_FILES,
+      loadSystemFonts: opts.loadSystemFonts ?? false, // default: deterministic bundled set
+      fontFiles: [...FONT_FILES, ...(opts.fontFiles ?? [])],
       defaultFontFamily: SANS,
       sansSerifFamily: SANS,
       serifFamily: SERIF,

--- a/test/preview-node-raster.test.ts
+++ b/test/preview-node-raster.test.ts
@@ -17,7 +17,7 @@ import {
   loadPresentation,
   setShapeFill,
 } from '../src/api/index.ts';
-import { renderSlideToImage, renderSlideToRgba } from '../packages/preview/src/node.ts';
+import { FONT_DIR, renderSlideToImage, renderSlideToRgba } from '../packages/preview/src/node.ts';
 
 const fixturePath = fileURLToPath(new URL('./fixtures/minimal/blank.pptx', import.meta.url));
 
@@ -113,5 +113,36 @@ describe('renderSlideToImage (Node)', () => {
     const fromImage = renderSlideToImage(pres, slide, opts);
     const { png: fromRgba } = renderSlideToRgba(pres, slide, opts);
     expect(Buffer.from(fromImage).toString('hex')).toBe(Buffer.from(fromRgba).toString('hex'));
+  });
+});
+
+describe('renderSlideToImage — rasterizer font options', () => {
+  it('accepts extra fontFiles without changing an all-Latin render', async () => {
+    // The strongest deterministic assertion available without shipping a CJK
+    // fixture font: an extra face that adds no new glyph coverage must not
+    // perturb the output, proving the option is plumbed through resvg rather
+    // than replacing the bundled set.
+    const { pres, slide } = await buildTestSlide();
+    const baseline = renderSlideToImage(pres, slide, { width: 320 });
+    const withExtra = renderSlideToImage(pres, slide, {
+      width: 320,
+      fontFiles: [`${FONT_DIR}Carlito-Regular.ttf`],
+    });
+    expect(Buffer.from(withExtra).toString('hex')).toBe(Buffer.from(baseline).toString('hex'));
+  });
+
+  it('tolerates a fontFiles path that does not exist (resvg skips it)', async () => {
+    const { pres, slide } = await buildTestSlide();
+    const png = renderSlideToImage(pres, slide, {
+      width: 320,
+      fontFiles: ['/nonexistent/no-such-font.ttf'],
+    });
+    expect(isPng(png)).toBe(true);
+  });
+
+  it('loadSystemFonts: true still produces a valid PNG', async () => {
+    const { pres, slide } = await buildTestSlide();
+    const png = renderSlideToImage(pres, slide, { width: 320, loadSystemFonts: true });
+    expect(isPng(png)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

`renderSlideToImage` / `renderSlideToRgba` hardcoded resvg's font set to the bundled Latin faces with `loadSystemFonts: false`. The bundled set has no CJK coverage, so decks with Japanese / Chinese / Korean text always rasterized as missing-glyph boxes (tofu) with no way to fix it from the caller side.

## Changes

`RenderImageOptions` gains:

- `fontFiles?: ReadonlyArray<string>` — extra ttf / otf / ttc paths handed to resvg alongside the bundled faces (pair with `buildFontkitMeasurer({ fonts })` so wrap math uses the same metrics).
- `loadSystemFonts?: boolean` — opt-in OS font fallback; defaults to `false` to keep output deterministic.

## Test plan

- A redundant extra face leaves an all-Latin render byte-identical (proves the option extends, not replaces, the bundled set).
- A nonexistent `fontFiles` path is skipped by resvg without throwing.
- `loadSystemFonts: true` still produces a valid PNG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kv96ssosHqX3orf1xCpQiq